### PR TITLE
zh, en: add prompt information

### DIFF
--- a/en/configure-storage-class.md
+++ b/en/configure-storage-class.md
@@ -71,7 +71,7 @@ Kubernetes currently supports statically allocated local storage. To create a lo
 
 1. Pre-allocate local storage in cluster nodes. See the [operation guide](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/docs/operations.md) provided by Kubernetes.
 
-2. Deploy `local-volume-provisioner`.
+2. Deploy `local-volume-provisioner`. Here, for example we inherited the `/mnt/disk` example in `local-volume-provisioner`.
 
       {{< copyable "shell-regular" >}}
 

--- a/zh/configure-storage-class.md
+++ b/zh/configure-storage-class.md
@@ -71,7 +71,7 @@ Kubernetes 当前支持静态分配的本地存储。可使用 [local-static-pro
 
 1. 参考 Kubernetes 提供的[操作文档](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/docs/operations.md)，在集群节点中预分配本地存储。
 
-2. 部署 `local-volume-provisioner` 程序。
+2. 部署 `local-volume-provisioner` 程序。这里我们沿用了 `local-static-provisioner` 中 `/mnt/disk` 的例子。
 
     {{< copyable "shell-regular" >}}
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

add a hint info on local-volume-provisioner yaml. Since I spent some time to figure it out.
对 local-volume-provisoner yaml添加了一点提示信息。因为我自己使用的时候花了一点时间。

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] master (the latest development version)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [X] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
[Line19 in this yaml](https://raw.githubusercontent.com/pingcap/tidb-operator/master/manifests/local-dind/local-volume-provisioner.yaml)
[source example](https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/blob/master/docs/operations.md)