### PR TITLE
aliases: change "stable" to "v3.0" in aliases

### DIFF
--- a/en/access-tidb.md
+++ b/en/access-tidb.md
@@ -2,7 +2,7 @@
 title: Access the TiDB Cluster in Kubernetes
 summary: Learn how to access the TiDB cluster in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/access-tidb/','/docs/v3.1/tidb-in-kubernetes/deploy/access-tidb/','/docs/stable/tidb-in-kubernetes/deploy/access-tidb/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/access-tidb/','/docs/v3.1/tidb-in-kubernetes/deploy/access-tidb/','/docs/v3.0/tidb-in-kubernetes/deploy/access-tidb/']
 ---
 
 # Access the TiDB Cluster in Kubernetes

--- a/en/backup-and-restore-using-helm-charts.md
+++ b/en/backup-and-restore-using-helm-charts.md
@@ -2,7 +2,7 @@
 title: Backup and Restore
 summary: Learn how to back up and restore the data of TiDB cluster in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/backup-and-restore/','/docs/v3.1/tidb-in-kubernetes/maintain/backup-and-restore/','/docs/stable/tidb-in-kubernetes/maintain/backup-and-restore/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/backup-and-restore/','/docs/v3.1/tidb-in-kubernetes/maintain/backup-and-restore/','/docs/v3.0/tidb-in-kubernetes/maintain/backup-and-restore/']
 ---
 
 # Backup and Restore

--- a/en/benchmark-sysbench.md
+++ b/en/benchmark-sysbench.md
@@ -2,7 +2,7 @@
 title: TiDB in Kubernetes Sysbench Performance Test
 summary: Learn the Sysbench performance test of TiDB in Kubernetes.
 category: benchmark
-aliases: ['/docs/dev/benchmark/sysbench-in-k8s/','/docs/v3.1/benchmark/sysbench-in-k8s/','/docs/stable/benchmark/sysbench-in-k8s/']
+aliases: ['/docs/dev/benchmark/sysbench-in-k8s/','/docs/v3.1/benchmark/sysbench-in-k8s/','/docs/v3.0/benchmark/sysbench-in-k8s/']
 ---
 
 # TiDB in Kubernetes Sysbench Performance Test

--- a/en/collect-tidb-logs.md
+++ b/en/collect-tidb-logs.md
@@ -2,7 +2,7 @@
 title: Collect TiDB Logs in Kubernetes
 summary: Learn how to collect TiDB logs in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/log-collecting/','/docs/v3.1/tidb-in-kubernetes/maintain/log-collecting/','/docs/stable/tidb-in-kubernetes/maintain/log-collecting/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/log-collecting/','/docs/v3.1/tidb-in-kubernetes/maintain/log-collecting/','/docs/v3.0/tidb-in-kubernetes/maintain/log-collecting/']
 ---
 
 # Collect TiDB Logs in Kubernetes

--- a/en/configure-a-tidb-cluster.md
+++ b/en/configure-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: TiDB Cluster Configurations in Kubernetes
 summary: Learn the configurations of a TiDB cluster in Kubernetes.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs/stable/tidb-in-kubernetes/reference/configuration/tidb-cluster/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs/v3.0/tidb-in-kubernetes/reference/configuration/tidb-cluster/']
 ---
 
 # TiDB Cluster Configurations in Kubernetes

--- a/en/configure-backup.md
+++ b/en/configure-backup.md
@@ -2,7 +2,7 @@
 title: The Backup Configuration of TiDB in Kubernetetes
 summary: Learn the backup configurations of TiDB in Kubernetetes.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/backup/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/backup/','/docs/stable/tidb-in-kubernetes/reference/configuration/backup/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/backup/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/backup/','/docs/v3.0/tidb-in-kubernetes/reference/configuration/backup/']
 ---
 
 # The Backup Configuration of TiDB in Kubernetetes

--- a/en/configure-storage-class.md
+++ b/en/configure-storage-class.md
@@ -2,7 +2,7 @@
 title: Persistent Storage Class Configuration in Kubernetes
 summary: Learn how to configure local PVs and network PVs.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/local-pv/','/docs/dev/tidb-in-kubernetes/reference/configuration/storage-class/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/storage-class/','/docs/stable/tidb-in-kubernetes/reference/configuration/storage-class/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/local-pv/','/docs/dev/tidb-in-kubernetes/reference/configuration/storage-class/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/storage-class/','/docs/v3.0/tidb-in-kubernetes/reference/configuration/storage-class/']
 ---
 
 # Persistent Storage Class Configuration in Kubernetes

--- a/en/configure-tidb-binlog-drainer.md
+++ b/en/configure-tidb-binlog-drainer.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog Drainer Configurations in Kubernetes
 summary: Learn the configurations of a TiDB Binlog Drainer in Kubernetes.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs/stable/tidb-in-kubernetes/reference/configuration/tidb-drainer/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs/v3.1/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs/v3.0/tidb-in-kubernetes/reference/configuration/tidb-drainer/']
 ---
 
 # TiDB Binlog Drainer Configurations in Kubernetes

--- a/en/deploy-on-alibaba-cloud.md
+++ b/en/deploy-on-alibaba-cloud.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB on Alibaba Cloud Kubernetes
 summary: Learn how to deploy a TiDB cluster on Alibaba Cloud Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs/v3.1/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs/stable/tidb-in-kubernetes/deploy/alibaba-cloud/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs/v3.1/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs/v3.0/tidb-in-kubernetes/deploy/alibaba-cloud/']
 ---
 
 # Deploy TiDB on Alibaba Cloud Kubernetes

--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB on AWS EKS
 summary: Learn how to deploy a TiDB cluster on AWS EKS.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/aws-eks/','/docs/v3.1/tidb-in-kubernetes/deploy/aws-eks/','/docs/stable/tidb-in-kubernetes/deploy/aws-eks/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/aws-eks/','/docs/v3.1/tidb-in-kubernetes/deploy/aws-eks/','/docs/v3.0/tidb-in-kubernetes/deploy/aws-eks/']
 ---
 
 # Deploy TiDB on AWS EKS

--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB on GCP GKE
 summary: Learn how to deploy a TiDB cluster on GCP GKE.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/gcp-gke/','/docs/v3.1/tidb-in-kubernetes/deploy/gcp-gke/','/docs/stable/tidb-in-kubernetes/deploy/gcp-gke/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/gcp-gke/','/docs/v3.1/tidb-in-kubernetes/deploy/gcp-gke/','/docs/v3.0/tidb-in-kubernetes/deploy/gcp-gke/']
 ---
 
 # Deploy TiDB on GCP GKE

--- a/en/deploy-on-general-kubernetes.md
+++ b/en/deploy-on-general-kubernetes.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB on General Kubernetes
 summary: Learn how to deploy a TiDB cluster on general Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/general-kubernetes/','/docs/v3.1/tidb-in-kubernetes/deploy/general-kubernetes/','/docs/stable/tidb-in-kubernetes/deploy/general-kubernetes/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/general-kubernetes/','/docs/v3.1/tidb-in-kubernetes/deploy/general-kubernetes/','/docs/v3.0/tidb-in-kubernetes/deploy/general-kubernetes/']
 ---
 
 # Deploy TiDB on General Kubernetes

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -2,7 +2,7 @@
 title: Maintain TiDB Binlog
 summary: Learn how to maintain TiDB Binlog of a TiDB cluster in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/tidb-binlog/','/docs/v3.1/tidb-in-kubernetes/maintain/tidb-binlog/','/docs/stable/tidb-in-kubernetes/maintain/tidb-binlog/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/tidb-binlog/','/docs/v3.1/tidb-in-kubernetes/maintain/tidb-binlog/','/docs/v3.0/tidb-in-kubernetes/maintain/tidb-binlog/']
 ---
 
 # Maintain TiDB Binlog

--- a/en/deploy-tidb-from-kubernetes-gke.md
+++ b/en/deploy-tidb-from-kubernetes-gke.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB on Google Cloud
 summary: Learn how to quickly deploy a TiDB cluster on Google Cloud using Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs/stable/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/']
+aliases: ['/docs/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/']
 ---
 
 # Deploy TiDB on Google Cloud

--- a/en/deploy-tidb-from-kubernetes-kind.md
+++ b/en/deploy-tidb-from-kubernetes-kind.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB in Kubernetes Using kind
 summary: Learn how to deploy a TiDB cluster in Kubernetes using kind.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy-tidb-from-kubernetes-dind/','/docs/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs/stable/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy-tidb-from-kubernetes-dind/','/docs/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/']
 
 ---
 

--- a/en/deploy-tidb-from-kubernetes-minikube.md
+++ b/en/deploy-tidb-from-kubernetes-minikube.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB in the Minikube Cluster
 summary: Learn how to deploy TiDB in the minikube cluster.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs/stable/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/']
+aliases: ['/docs/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/']
 ---
 
 # Deploy TiDB in the Minikube Cluster

--- a/en/deploy-tidb-operator.md
+++ b/en/deploy-tidb-operator.md
@@ -2,7 +2,7 @@
 title: Deploy TiDB Operator in Kubernetes
 summary: Learn how to deploy TiDB Operator in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/tidb-operator/','/docs/v3.1/tidb-in-kubernetes/deploy/tidb-operator/','/docs/stable/tidb-in-kubernetes/deploy/tidb-operator/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/tidb-operator/','/docs/v3.1/tidb-in-kubernetes/deploy/tidb-operator/','/docs/v3.0/tidb-in-kubernetes/deploy/tidb-operator/']
 ---
 
 # Deploy TiDB Operator in Kubernetes

--- a/en/destroy-a-tidb-cluster.md
+++ b/en/destroy-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Destroy TiDB Clusters in Kubernetes
 summary: Learn how to delete TiDB Cluster in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs/v3.1/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs/stable/tidb-in-kubernetes/maintain/destroy-tidb-cluster/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs/v3.1/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs/v3.0/tidb-in-kubernetes/maintain/destroy-tidb-cluster/']
 ---
 
 # Destroy TiDB Clusters in Kubernetes

--- a/en/faq.md
+++ b/en/faq.md
@@ -2,7 +2,7 @@
 title: TiDB FAQs in Kubernetes
 summary: Learn about TiDB FAQs in Kubernetes.
 category: FAQ
-aliases: ['/docs/dev/tidb-in-kubernetes/faq/','/docs/v3.1/tidb-in-kubernetes/faq/','/docs/stable/tidb-in-kubernetes/faq/']
+aliases: ['/docs/dev/tidb-in-kubernetes/faq/','/docs/v3.1/tidb-in-kubernetes/faq/','/docs/v3.0/tidb-in-kubernetes/faq/']
 ---
 
 # TiDB FAQs in Kubernetes

--- a/en/initialize-a-cluster.md
+++ b/en/initialize-a-cluster.md
@@ -2,7 +2,7 @@
 title: Initialize a TiDB Cluster in Kubernetes
 summary: Learn how to initialize a TiDB cluster in K8s.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/initialize-cluster/','/docs/v3.1/tidb-in-kubernetes/initialize-cluster/','/docs/stable/tidb-in-kubernetes/initialize-cluster/']
+aliases: ['/docs/dev/tidb-in-kubernetes/initialize-cluster/','/docs/v3.1/tidb-in-kubernetes/initialize-cluster/','/docs/v3.0/tidb-in-kubernetes/initialize-cluster/']
 ---
 
 # Initialize a TiDB Cluster in Kubernetes

--- a/en/maintain-a-kubernetes-node.md
+++ b/en/maintain-a-kubernetes-node.md
@@ -2,7 +2,7 @@
 title: Maintain Kubernetes Nodes that Hold the TiDB Cluster
 summary: Learn how to maintain Kubernetes nodes that hold the TiDB cluster.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/kubernetes-node/','/docs/v3.1/tidb-in-kubernetes/maintain/kubernetes-node/','/docs/stable/tidb-in-kubernetes/maintain/kubernetes-node/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/kubernetes-node/','/docs/v3.1/tidb-in-kubernetes/maintain/kubernetes-node/','/docs/v3.0/tidb-in-kubernetes/maintain/kubernetes-node/']
 ---
 
 # Maintain Kubernetes Nodes that Hold the TiDB Cluster

--- a/en/monitor-a-tidb-cluster.md
+++ b/en/monitor-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Monitor a TiDB Cluster in Kubernetes
 summary: Learn how to monitor a TiDB cluster in kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs/v3.1/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs/stable/tidb-in-kubernetes/monitor/tidb-in-kubernetes/']
+aliases: ['/docs/dev/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs/v3.1/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs/v3.0/tidb-in-kubernetes/monitor/tidb-in-kubernetes/']
 ---
 
 # Monitor a TiDB Cluster in Kubernetes

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -2,7 +2,7 @@
 title: Prerequisites for TiDB in Kubernetes
 summary: Learn the prerequisites for TiDB in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/deploy/prerequisites/','/docs/v3.1/tidb-in-kubernetes/deploy/prerequisites/','/docs/stable/tidb-in-kubernetes/deploy/prerequisites/']
+aliases: ['/docs/dev/tidb-in-kubernetes/deploy/prerequisites/','/docs/v3.1/tidb-in-kubernetes/deploy/prerequisites/','/docs/v3.0/tidb-in-kubernetes/deploy/prerequisites/']
 ---
 
 # Prerequisites for TiDB in Kubernetes

--- a/en/restart-a-tidb-cluster.md
+++ b/en/restart-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Restart a TiDB Cluster in Kubernetes
 summary: Learn how to restart a TiDB cluster in the Kubernetes cluster.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/restart/','/docs/v3.1/tidb-in-kubernetes/maintain/restart/','/docs/stable/tidb-in-kubernetes/maintain/restart/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/restart/','/docs/v3.1/tidb-in-kubernetes/maintain/restart/','/docs/v3.0/tidb-in-kubernetes/maintain/restart/']
 ---
 
 # Restart a TiDB Cluster in Kubernetes

--- a/en/restore-data-using-tidb-lightning.md
+++ b/en/restore-data-using-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: Restore Data into TiDB in Kubernetes
 summary: Learn how to quickly restore data into a TiDB cluster in Kubernetes with TiDB Lightning.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/lightning/','/docs/v3.1/tidb-in-kubernetes/maintain/lightning/','/docs/stable/tidb-in-kubernetes/maintain/lightning/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/lightning/','/docs/v3.1/tidb-in-kubernetes/maintain/lightning/','/docs/v3.0/tidb-in-kubernetes/maintain/lightning/']
 ---
 
 # Restore Data into TiDB in Kubernetes

--- a/en/scale-a-tidb-cluster.md
+++ b/en/scale-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 Title: Scale TiDB in Kubernetes
 summary: Learn how to horizontally and vertically scale up and down a TiDB cluster in Kubernetes.
 Category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/scale-in-kubernetes/','/docs/v3.1/tidb-in-kubernetes/scale-in-kubernetes/','/docs/stable/tidb-in-kubernetes/scale-in-kubernetes/']
+aliases: ['/docs/dev/tidb-in-kubernetes/scale-in-kubernetes/','/docs/v3.1/tidb-in-kubernetes/scale-in-kubernetes/','/docs/v3.0/tidb-in-kubernetes/scale-in-kubernetes/']
 ---
 
 # Scale TiDB in Kubernetes

--- a/en/tidb-operator-overview.md
+++ b/en/tidb-operator-overview.md
@@ -2,7 +2,7 @@
 title: Overview of TiDB Operator
 summary: Learn the overview of TiDB Operator.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/tidb-operator-overview/','/docs/v3.1/tidb-in-kubernetes/tidb-operator-overview/','/docs/stable/tidb-in-kubernetes/tidb-operator-overview/']
+aliases: ['/docs/dev/tidb-in-kubernetes/tidb-operator-overview/','/docs/v3.1/tidb-in-kubernetes/tidb-operator-overview/','/docs/v3.0/tidb-in-kubernetes/tidb-operator-overview/']
 ---
 
 # TiDB Operator Overview

--- a/en/tidb-scheduler.md
+++ b/en/tidb-scheduler.md
@@ -2,7 +2,7 @@
 title: TiDB Scheduler
 summary: Learn what is TiDB Scheduler and how it works.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs/v3.1/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs/stable/tidb-in-kubernetes/reference/components/tidb-scheduler/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs/v3.1/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs/v3.0/tidb-in-kubernetes/reference/components/tidb-scheduler/']
 ---
 
 # TiDB Scheduler

--- a/en/tidb-toolkit.md
+++ b/en/tidb-toolkit.md
@@ -2,7 +2,7 @@
 title: Tools in Kubernetes
 summary: Learn about operation tools for TiDB in Kubernetes.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs/v3.1/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs/stable/tidb-in-kubernetes/reference/tools/in-kubernetes/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs/v3.1/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs/v3.0/tidb-in-kubernetes/reference/tools/in-kubernetes/']
 ---
 
 # Tools in Kubernetes

--- a/en/tidb-toolkit.md
+++ b/en/tidb-toolkit.md
@@ -11,7 +11,7 @@ Operations on TiDB in Kubernetes require some open source tools. In the meantime
 
 ## Use PD Control in Kubernetes
 
-[PD Control](https://pingcap.com/docs/stable/reference/tools/pd-control) is the command-line tool for PD (Placement Driver). To use PD Control to operate on TiDB clusters in Kubernetes, firstly you need to establish the connection from local to the PD service using `kubectl port-forward`:
+[PD Control](https://pingcap.com/docs/v3.0/reference/tools/pd-control) is the command-line tool for PD (Placement Driver). To use PD Control to operate on TiDB clusters in Kubernetes, firstly you need to establish the connection from local to the PD service using `kubectl port-forward`:
 
 {{< copyable "shell-regular" >}}
 
@@ -45,7 +45,7 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
 
 ## Use TiKV Control in Kubernetes
 
-[TiKV Control](https://pingcap.com/docs/stable/reference/tools/tikv-control) is the command-line tool for TiKV. When using TiKV Control for TiDB clusters in Kubernetes, be aware that each operation mode involves different steps, as described below:
+[TiKV Control](https://pingcap.com/docs/v3.0/reference/tools/tikv-control) is the command-line tool for TiKV. When using TiKV Control for TiDB clusters in Kubernetes, be aware that each operation mode involves different steps, as described below:
 
 * **Remote Mode**: In this mode, `tikv-ctl` accesses the TiKV service or the PD service through network. Firstly you need to establish the connection from local to the PD service and the target TiKV node using `kubectl port-forward`:
 
@@ -115,7 +115,7 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
 
 ## Use TiDB Control in Kubernetes
 
-[TiDB Control](https://pingcap.com/docs/stable/reference/tools/tidb-control) is the command-line tool for TiDB. To use TiDB Control in Kubernetes, you need to access the TiDB node and the PD service from local. It is suggested you turn on the connection from local to the TiDB node and the PD service using `kubectl port-forward`:
+[TiDB Control](https://pingcap.com/docs/v3.0/reference/tools/tidb-control) is the command-line tool for TiDB. To use TiDB Control in Kubernetes, you need to access the TiDB node and the PD service from local. It is suggested you turn on the connection from local to the TiDB node and the PD service using `kubectl port-forward`:
 
 {{< copyable "shell-regular" >}}
 

--- a/en/troubleshoot.md
+++ b/en/troubleshoot.md
@@ -196,7 +196,7 @@ If the log fails to help diagnose the problem, you can add the `-p` parameter to
 kubectl -n <namespace> logs -p <pod-name>
 ```
 
-After checking the error messages in the log, you can refer to [Cannot start `tidb-server`](https://pingcap.com/docs/stable/how-to/troubleshoot/cluster-setup#cannot-start-tidb-server), [Cannot start `tikv-server`](https://pingcap.com/docs/stable/how-to/troubleshoot/cluster-setup#cannot-start-tikv-server), and [Cannot start `pd-server`](https://pingcap.com/docs/stable/how-to/troubleshoot/cluster-setup#cannot-start-pd-server) for further troubleshooting.
+After checking the error messages in the log, you can refer to [Cannot start `tidb-server`](https://pingcap.com/docs/v3.0/how-to/troubleshoot/cluster-setup#cannot-start-tidb-server), [Cannot start `tikv-server`](https://pingcap.com/docs/v3.0/how-to/troubleshoot/cluster-setup#cannot-start-tikv-server), and [Cannot start `pd-server`](https://pingcap.com/docs/v3.0/how-to/troubleshoot/cluster-setup#cannot-start-pd-server) for further troubleshooting.
 
 When the "cluster id mismatch" message appears in the TiKV Pod log, it means that the TiKV Pod might have used old data from other or previous TiKV Pod. If the data on the local disk remain uncleared when you configure local storage in the cluster, or the data is not recycled by the local volume provisioner due to a forced deletion of PV, an error might occur.
 

--- a/en/troubleshoot.md
+++ b/en/troubleshoot.md
@@ -2,7 +2,7 @@
 title: Troubleshoot TiDB in Kubernetes
 summary: Learn how to diagnose and resolve issues when you use TiDB in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/troubleshoot/','/docs/v3.1/tidb-in-kubernetes/troubleshoot/','/docs/stable/tidb-in-kubernetes/troubleshoot/']
+aliases: ['/docs/dev/tidb-in-kubernetes/troubleshoot/','/docs/v3.1/tidb-in-kubernetes/troubleshoot/','/docs/v3.0/tidb-in-kubernetes/troubleshoot/']
 ---
 
 # Troubleshoot TiDB in Kubernetes

--- a/en/upgrade-a-tidb-cluster.md
+++ b/en/upgrade-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Perform a Rolling Update to a TiDB Cluster in Kubernetes
 summary: Learn how to perform a rolling update to a TiDB cluster in Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs/v3.1/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs/stable/tidb-in-kubernetes/upgrade/tidb-cluster/']
+aliases: ['/docs/dev/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs/v3.1/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs/v3.0/tidb-in-kubernetes/upgrade/tidb-cluster/']
 ---
 
 # Perform a Rolling Update to a TiDB Cluster in Kubernetes

--- a/en/upgrade-tidb-operator.md
+++ b/en/upgrade-tidb-operator.md
@@ -2,7 +2,7 @@
 title: Upgrade TiDB Operator and Kubernetes
 summary: Learn how to upgrade TiDB Operator and Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/upgrade/tidb-operator/','/docs/v3.1/tidb-in-kubernetes/upgrade/tidb-operator/','/docs/stable/tidb-in-kubernetes/upgrade/tidb-operator/']
+aliases: ['/docs/dev/tidb-in-kubernetes/upgrade/tidb-operator/','/docs/v3.1/tidb-in-kubernetes/upgrade/tidb-operator/','/docs/v3.0/tidb-in-kubernetes/upgrade/tidb-operator/']
 ---
 
 # Upgrade TiDB Operator and Kubernetes

--- a/en/use-auto-failover.md
+++ b/en/use-auto-failover.md
@@ -2,7 +2,7 @@
 title: Automatic Failover
 summary: Learn the automatic failover policies of TiDB cluster components on Kubernetes.
 category: how-to
-aliases: ['/docs/dev/tidb-in-kubernetes/maintain/auto-failover/','/docs/v3.1/tidb-in-kubernetes/maintain/auto-failover/','/docs/stable/tidb-in-kubernetes/maintain/auto-failover/']
+aliases: ['/docs/dev/tidb-in-kubernetes/maintain/auto-failover/','/docs/v3.1/tidb-in-kubernetes/maintain/auto-failover/','/docs/v3.0/tidb-in-kubernetes/maintain/auto-failover/']
 ---
 
 # Automatic Failover

--- a/en/use-auto-failover.md
+++ b/en/use-auto-failover.md
@@ -47,7 +47,7 @@ Assume that there are 3 nodes in a PD cluster. If a PD node is down for over 5 m
 
 ### Failover with TiKV
 
-When a TiKV node fails, its status turns to `Disconnected`. After 30 minutes (configurable by modifying [`max-store-down-time`](https://pingcap.com/docs/stable/reference/configuration/pd-server/configuration-file#max-store-down-time) in PD's [configuration file](https://github.com/pingcap/pd/blob/master/conf/config.toml)), it turns to `Down`. After waiting for 5 minutes (configurable by modifying `tikvFailoverPeriod`), TiDB Operator creates a new TiKV node if this TiKV node is still down. If the failed TiKV node gets back online, TiDB Operator does not automatically delete the newly created node, and you need to manually drop it and restore the original number of nodes. To do this, you can delete the TiKV node from the `status.tikv.failureStores` field of the `TidbCluster` object:
+When a TiKV node fails, its status turns to `Disconnected`. After 30 minutes (configurable by modifying [`max-store-down-time`](https://pingcap.com/docs/v3.0/reference/configuration/pd-server/configuration-file#max-store-down-time) in PD's [configuration file](https://github.com/pingcap/pd/blob/master/conf/config.toml)), it turns to `Down`. After waiting for 5 minutes (configurable by modifying `tikvFailoverPeriod`), TiDB Operator creates a new TiKV node if this TiKV node is still down. If the failed TiKV node gets back online, TiDB Operator does not automatically delete the newly created node, and you need to manually drop it and restore the original number of nodes. To do this, you can delete the TiKV node from the `status.tikv.failureStores` field of the `TidbCluster` object:
 
 {{< copyable "shell-regular" >}}
 

--- a/en/use-tkctl.md
+++ b/en/use-tkctl.md
@@ -2,7 +2,7 @@
 title: TiDB Kubernetes Control User Guide
 summary: Learn how to use the tkctl (TiDB Kubernetes Control) tool.
 category: reference
-aliases: ['/docs/dev/tidb-in-kubernetes/reference/tools/tkctl/','/docs/v3.1/tidb-in-kubernetes/reference/tools/tkctl/','/docs/stable/tidb-in-kubernetes/reference/tools/tkctl/']
+aliases: ['/docs/dev/tidb-in-kubernetes/reference/tools/tkctl/','/docs/v3.1/tidb-in-kubernetes/reference/tools/tkctl/','/docs/v3.0/tidb-in-kubernetes/reference/tools/tkctl/']
 ---
 
 # TiDB Kubernetes Control User Guide

--- a/zh/access-tidb.md
+++ b/zh/access-tidb.md
@@ -2,7 +2,7 @@
 title: 访问 Kubernetes 上的 TiDB 集群
 summary: 介绍如何访问 Kubernetes 上的 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/access-tidb/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/access-tidb/','/docs-cn/stable/tidb-in-kubernetes/deploy/access-tidb/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/access-tidb/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/access-tidb/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/access-tidb/']
 ---
 
 # 访问 Kubernetes 上的 TiDB 集群

--- a/zh/backup-and-restore-using-helm-charts.md
+++ b/zh/backup-and-restore-using-helm-charts.md
@@ -2,7 +2,7 @@
 title: 基于 Helm Charts 实现的 TiDB 集群备份恢复
 summary: 介绍如何基于 Helm Charts 实现 TiDB 集群的备份与恢复。
 category: how-to
-aliases: ['/docs-cn/dev/maintain/backup-and-store/','/docs-cn/dev/tidb-in-kubernetes/maintain/backup-and-restore/charts/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/backup-and-restore/charts/','/docs-cn/stable/tidb-in-kubernetes/maintain/backup-and-restore/charts/']
+aliases: ['/docs-cn/dev/maintain/backup-and-store/','/docs-cn/dev/tidb-in-kubernetes/maintain/backup-and-restore/charts/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/backup-and-restore/charts/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/backup-and-restore/charts/']
 ---
 
 # 基于 Helm Charts 实现的 TiDB 集群备份与恢复

--- a/zh/backup-and-restore-using-helm-charts.md
+++ b/zh/backup-and-restore-using-helm-charts.md
@@ -11,8 +11,8 @@ aliases: ['/docs-cn/dev/maintain/backup-and-store/','/docs-cn/dev/tidb-in-kubern
 
 Kubernetes 上的 TiDB 集群支持两种备份策略：
 
-* [全量备份](#全量备份)（定时执行或 Ad-hoc）：使用 [`mydumper`](https://pingcap.com/docs-cn/stable/reference/tools/mydumper) 获取集群的逻辑备份；
-* [增量备份](#增量备份)：使用 [`TiDB Binlog`](https://pingcap.com/docs-cn/stable/reference/tidb-binlog/overview) 将 TiDB 集群的数据实时复制到其它数据库中或实时获得增量数据备份；
+* [全量备份](#全量备份)（定时执行或 Ad-hoc）：使用 [`mydumper`](https://pingcap.com/docs-cn/v3.0/reference/tools/mydumper) 获取集群的逻辑备份；
+* [增量备份](#增量备份)：使用 [`TiDB Binlog`](https://pingcap.com/docs-cn/v3.0/reference/tidb-binlog/overview) 将 TiDB 集群的数据实时复制到其它数据库中或实时获得增量数据备份；
 
 目前，Kubernetes 上的 TiDB 集群只对 `mydumper` 获取的全量备份数据提供自动化的数据恢复操作。恢复 `TiDB-Binlog` 获取的增量数据需要手动进行。
 
@@ -124,7 +124,7 @@ kubectl get pvc -n <namespace> -l app.kubernetes.io/component=backup,pingcap.com
 
 ## 增量备份
 
-增量备份使用 [TiDB Binlog](https://pingcap.com/docs-cn/stable/reference/tidb-binlog/overview) 工具从 TiDB 集群收集 Binlog，并提供实时备份和向其它数据库的实时同步能力。
+增量备份使用 [TiDB Binlog](https://pingcap.com/docs-cn/v3.0/reference/tidb-binlog/overview) 工具从 TiDB 集群收集 Binlog，并提供实时备份和向其它数据库的实时同步能力。
 
 有关 Kubernetes 上运维 TiDB Binlog 的详细指南，可参阅 [TiDB Binlog](deploy-tidb-binlog.md)。
 

--- a/zh/benchmark-sysbench.md
+++ b/zh/benchmark-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB in Kubernetes Sysbench 性能测试
 category: benchmark
-aliases: ['/docs-cn/dev/benchmark/sysbench-in-k8s/','/docs-cn/v3.1/benchmark/sysbench-in-k8s/','/docs-cn/stable/benchmark/sysbench-in-k8s/']
+aliases: ['/docs-cn/dev/benchmark/sysbench-in-k8s/','/docs-cn/v3.1/benchmark/sysbench-in-k8s/','/docs-cn/v3.0/benchmark/sysbench-in-k8s/']
 ---
 
 # TiDB in Kubernetes Sysbench 性能测试

--- a/zh/collect-tidb-logs.md
+++ b/zh/collect-tidb-logs.md
@@ -2,7 +2,7 @@
 title: 日志收集
 summary: 介绍收集 TiDB 及相关组件日志的方法。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/log-collecting/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/log-collecting/','/docs-cn/stable/tidb-in-kubernetes/maintain/log-collecting/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/log-collecting/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/log-collecting/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/log-collecting/']
 ---
 
 # 日志收集

--- a/zh/configure-a-tidb-cluster.md
+++ b/zh/configure-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群配置
 summary: 介绍 Kubernetes 上 TiDB 集群的配置。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs-cn/stable/tidb-in-kubernetes/reference/configuration/tidb-cluster/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/tidb-cluster/','/docs-cn/v3.0/tidb-in-kubernetes/reference/configuration/tidb-cluster/']
 ---
 
 # Kubernetes 上的 TiDB 集群配置

--- a/zh/configure-a-tidb-cluster.md
+++ b/zh/configure-a-tidb-cluster.md
@@ -34,7 +34,7 @@ TiDB Operator 使用 Helm 部署和管理 TiDB 集群。通过 Helm 获取的配
 | `discovery.resources.requests.cpu` | PD 服务发现组件的 CPU 资源请求 | `80m` |
 | `discovery.resources.requests.memory` | PD 服务发现组件的内存资源请求 | `50Mi` |
 | `enableConfigMapRollout` | 是否开启 TiDB 集群自动滚动更新。如果启用，则 TiDB 集群的 ConfigMap 变更时，TiDB 集群自动更新对应组件。该配置只在 tidb-operator v1.0 及以上版本才支持 | `false` |
-| `pd.config` | 配置文件格式的 PD 的配置，请参考 [`pd/conf/config.toml`](https://github.com/pingcap/pd/blob/master/conf/config.toml) 查看默认 PD 配置文件（选择对应 PD 版本的 tag），可以参考 [PD 配置文件描述](https://pingcap.com/docs-cn/stable/reference/configuration/pd-server/configuration-file)查看配置参数的具体介绍（请选择对应的文档版本），这里只需要**按照配置文件中的格式修改配置** | TiDB Operator 版本 <= v1.0.0-beta.3，默认值为：<br>`nil`<br>TiDB Operator 版本 > v1.0.0-beta.3，默认值为：<br>`[log]`<br>`level = "info"`<br>`[replication]`<br>`location-labels = ["region", "zone", "rack", "host"]`<br>配置示例：<br>&nbsp;&nbsp;`config:` \|<br>&nbsp;&nbsp;&nbsp;&nbsp;`[log]`<br>&nbsp;&nbsp;&nbsp;&nbsp;`level = "info"`<br>&nbsp;&nbsp;&nbsp;&nbsp;`[replication]`<br>&nbsp;&nbsp;&nbsp;&nbsp;`location-labels = ["region", "zone", "rack", "host"]` |
+| `pd.config` | 配置文件格式的 PD 的配置，请参考 [`pd/conf/config.toml`](https://github.com/pingcap/pd/blob/master/conf/config.toml) 查看默认 PD 配置文件（选择对应 PD 版本的 tag），可以参考 [PD 配置文件描述](https://pingcap.com/docs-cn/v3.0/reference/configuration/pd-server/configuration-file)查看配置参数的具体介绍（请选择对应的文档版本），这里只需要**按照配置文件中的格式修改配置** | TiDB Operator 版本 <= v1.0.0-beta.3，默认值为：<br>`nil`<br>TiDB Operator 版本 > v1.0.0-beta.3，默认值为：<br>`[log]`<br>`level = "info"`<br>`[replication]`<br>`location-labels = ["region", "zone", "rack", "host"]`<br>配置示例：<br>&nbsp;&nbsp;`config:` \|<br>&nbsp;&nbsp;&nbsp;&nbsp;`[log]`<br>&nbsp;&nbsp;&nbsp;&nbsp;`level = "info"`<br>&nbsp;&nbsp;&nbsp;&nbsp;`[replication]`<br>&nbsp;&nbsp;&nbsp;&nbsp;`location-labels = ["region", "zone", "rack", "host"]` |
 | `pd.replicas` | PD 的 Pod 数 | `3` |
 | `pd.image` | PD 镜像 | `pingcap/pd:v3.0.0-rc.1` |
 | `pd.imagePullPolicy` | PD 镜像的拉取策略 | `IfNotPresent` |
@@ -52,7 +52,7 @@ TiDB Operator 使用 Helm 部署和管理 TiDB 集群。通过 Helm 获取的配
 | `pd.nodeSelector` | `pd.nodeSelector` 确保 PD Pods 只调度到以该键值对作为标签的节点，详情参考：[nodeselector](https://kubernetes.io/docs/concepts/configuration/assign-Pod-node/#nodeselector) | `{}` |
 | `pd.tolerations` | `pd.tolerations` 应用于 PD Pods，允许 PD Pods 调度到含有指定 taints 的节点上，详情参考：[taint-and-toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration) | `{}` |
 | `pd.annotations` | 为 PD Pods 添加特定的 `annotations` | `{}` |
-| `tikv.config` | 配置文件格式的 TiKV 的配置，请参考 [`tikv/etc/config-template.toml`](https://github.com/tikv/tikv/blob/master/etc/config-template.toml) 查看默认 TiKV 配置文件（选择对应 TiKV 版本的 tag），可以参考 [TiKV 配置文件描述](https://pingcap.com/docs-cn/stable/reference/configuration/tikv-server/configuration-file/)查看配置参数的具体介绍（请选择对应的文档版本），这里只需要**按照配置文件中的格式修改配置**<br/><br/>以下两个配置项需要显式配置：<br/><br/>`[storage.block-cache]`<br/>&nbsp;&nbsp;`shared = true`<br/>&nbsp;&nbsp;`capacity = "1GB"`<br/>推荐设置：`capacity` 设置为 `tikv.resources.limits.memory` 的 50%<br/><br/>`[readpool.coprocessor]`<br/>&nbsp;&nbsp;`high-concurrency = 8`<br/>&nbsp;&nbsp;`normal-concurrency = 8`<br/>&nbsp;&nbsp;`low-concurrency = 8`<br/>推荐设置：设置为 `tikv.resources.limits.cpu` 的 80%| TiDB Operator 版本 <= v1.0.0-beta.3，默认值为：<br>`nil`<br>TiDB Operator 版本 > v1.0.0-beta.3，默认值为：<br>`log-level = "info"`<br>配置示例：<br>&nbsp;&nbsp;`config:` \|<br>&nbsp;&nbsp;&nbsp;&nbsp;`log-level = "info"` |
+| `tikv.config` | 配置文件格式的 TiKV 的配置，请参考 [`tikv/etc/config-template.toml`](https://github.com/tikv/tikv/blob/master/etc/config-template.toml) 查看默认 TiKV 配置文件（选择对应 TiKV 版本的 tag），可以参考 [TiKV 配置文件描述](https://pingcap.com/docs-cn/v3.0/reference/configuration/tikv-server/configuration-file/)查看配置参数的具体介绍（请选择对应的文档版本），这里只需要**按照配置文件中的格式修改配置**<br/><br/>以下两个配置项需要显式配置：<br/><br/>`[storage.block-cache]`<br/>&nbsp;&nbsp;`shared = true`<br/>&nbsp;&nbsp;`capacity = "1GB"`<br/>推荐设置：`capacity` 设置为 `tikv.resources.limits.memory` 的 50%<br/><br/>`[readpool.coprocessor]`<br/>&nbsp;&nbsp;`high-concurrency = 8`<br/>&nbsp;&nbsp;`normal-concurrency = 8`<br/>&nbsp;&nbsp;`low-concurrency = 8`<br/>推荐设置：设置为 `tikv.resources.limits.cpu` 的 80%| TiDB Operator 版本 <= v1.0.0-beta.3，默认值为：<br>`nil`<br>TiDB Operator 版本 > v1.0.0-beta.3，默认值为：<br>`log-level = "info"`<br>配置示例：<br>&nbsp;&nbsp;`config:` \|<br>&nbsp;&nbsp;&nbsp;&nbsp;`log-level = "info"` |
 | `tikv.replicas` | TiKV 的 Pod 数 | `3` |
 | `tikv.image` | TiKV 的镜像 | `pingcap/tikv:v3.0.0-rc.1` |
 | `tikv.imagePullPolicy` | TiKV 镜像的拉取策略 | `IfNotPresent` |
@@ -75,7 +75,7 @@ TiDB Operator 使用 Helm 部署和管理 TiDB 集群。通过 Helm 获取的配
 | `tikv.readpoolStorageConcurrency` | TiKV 存储的高优先级/普通优先级/低优先级操作的线程池大小<br>如果 TiDB Operator 版本 > v1.0.0-beta.3，请通过 `tikv.config` 配置：<br>`[readpool.storage]`<br>`high-concurrency = 4`<br>`normal-concurrency = 4`<br>`low-concurrency = 4` | `4` |
 | `tikv.readpoolCoprocessorConcurrency` | 一般如果 `tikv.resources.limits.cpu` > 8，则 `tikv.readpoolCoprocessorConcurrency` 设置为`tikv.resources.limits.cpu` * 0.8<br>如果 TiDB Operator 版本 > v1.0.0-beta.3，请通过 `tikv.config` 配置：<br>`[readpool.coprocessor]`<br>`high-concurrency = 8`<br>`normal-concurrency = 8`<br>`low-concurrency = 8` | `8` |
 | `tikv.storageSchedulerWorkerPoolSize` | TiKV 调度程序的工作池大小，应在重写情况下增加，同时应小于总 CPU 核心<br>如果 TiDB Operator 版本 > v1.0.0-beta.3，请通过 `tikv.config` 配置：<br>`[storage]`<br>`scheduler-worker-pool-size = 4` | `4` |
-| `tidb.config` | 配置文件格式的 TiDB 的配置，请参考[配置文件](https://github.com/pingcap/tidb/blob/master/config/config.toml.example)查看默认 TiDB 配置文件（选择对应 TiDB 版本的 tag），可以参考 [TiDB 配置文件描述](https://pingcap.com/docs-cn/stable/reference/configuration/tidb-server/configuration-file)查看配置参数的具体介绍（请选择对应的文档版本）。这里只需要**按照配置文件中的格式修改配置**。<br/><br/>以下配置项需要显式配置：<br/><br/>`[performance]`<br/>&nbsp;&nbsp;`max-procs = 0`<br/>推荐设置：`max-procs` 设置为 `tidb.resources.limits.cpu` 对应的核心数 | TiDB Operator 版本 <= v1.0.0-beta.3，默认值为：<br>`nil`<br>TiDB Operator 版本 > v1.0.0-beta.3，默认值为：<br>`[log]`<br>`level = "info"`<br>配置示例：<br>&nbsp;&nbsp;`config:` \|<br>&nbsp;&nbsp;&nbsp;&nbsp;`[log]`<br>&nbsp;&nbsp;&nbsp;&nbsp;`level = "info"` |
+| `tidb.config` | 配置文件格式的 TiDB 的配置，请参考[配置文件](https://github.com/pingcap/tidb/blob/master/config/config.toml.example)查看默认 TiDB 配置文件（选择对应 TiDB 版本的 tag），可以参考 [TiDB 配置文件描述](https://pingcap.com/docs-cn/v3.0/reference/configuration/tidb-server/configuration-file)查看配置参数的具体介绍（请选择对应的文档版本）。这里只需要**按照配置文件中的格式修改配置**。<br/><br/>以下配置项需要显式配置：<br/><br/>`[performance]`<br/>&nbsp;&nbsp;`max-procs = 0`<br/>推荐设置：`max-procs` 设置为 `tidb.resources.limits.cpu` 对应的核心数 | TiDB Operator 版本 <= v1.0.0-beta.3，默认值为：<br>`nil`<br>TiDB Operator 版本 > v1.0.0-beta.3，默认值为：<br>`[log]`<br>`level = "info"`<br>配置示例：<br>&nbsp;&nbsp;`config:` \|<br>&nbsp;&nbsp;&nbsp;&nbsp;`[log]`<br>&nbsp;&nbsp;&nbsp;&nbsp;`level = "info"` |
 | `tidb.replicas` | TiDB 的 Pod 数 | `2` |
 | `tidb.image` | TiDB 的镜像 | `pingcap/tidb:v3.0.0-rc.1` |
 | `tidb.imagePullPolicy` | TiDB 镜像的拉取策略 | `IfNotPresent` |
@@ -119,7 +119,7 @@ TiDB Operator 使用 Helm 部署和管理 TiDB 集群。通过 Helm 获取的配
 
 ## 资源配置说明
 
-部署前需要根据实际情况和需求，为 TiDB 集群各个组件配置资源，其中 PD、TiKV、TiDB 是 TiDB 集群的核心服务组件，在生产环境下它们的资源配置还需要按组件要求指定，具体参考：[资源配置推荐](https://pingcap.com/docs-cn/stable/how-to/deploy/hardware-recommendations)。
+部署前需要根据实际情况和需求，为 TiDB 集群各个组件配置资源，其中 PD、TiKV、TiDB 是 TiDB 集群的核心服务组件，在生产环境下它们的资源配置还需要按组件要求指定，具体参考：[资源配置推荐](https://pingcap.com/docs-cn/v3.0/how-to/deploy/hardware-recommendations)。
 
 为了保证 TiDB 集群的组件在 Kubernetes 中合理的调度和稳定的运行，建议为其设置 Guaranteed 级别的 QoS，通过在配置资源时让 limits 等于 requests 来实现, 具体参考：[配置 QoS](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/)。
 
@@ -187,7 +187,7 @@ affinity:
 
 ### 数据的容灾
 
-在开始数据容灾配置前，首先请阅读[集群拓扑信息配置](https://pingcap.com/docs-cn/stable/how-to/deploy/geographic-redundancy/location-awareness)。该文档描述了 TiDB 集群数据容灾的实现原理。
+在开始数据容灾配置前，首先请阅读[集群拓扑信息配置](https://pingcap.com/docs-cn/v3.0/how-to/deploy/geographic-redundancy/location-awareness)。该文档描述了 TiDB 集群数据容灾的实现原理。
 
 在 Kubernetes 上支持数据容灾的功能，需要如下操作：
 

--- a/zh/configure-backup.md
+++ b/zh/configure-backup.md
@@ -60,7 +60,7 @@ aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/backup/','/do
 
 + 恢复参数
 + 默认："-t 16"
-+ 为恢复数据时使用的 [Loader](https://pingcap.com/docs-cn/stable/reference/tools/loader) 指定额外的运行参数
++ 为恢复数据时使用的 [Loader](https://pingcap.com/docs-cn/v3.0/reference/tools/loader) 指定额外的运行参数
 
 ## `gcp.bucket`
 

--- a/zh/configure-backup.md
+++ b/zh/configure-backup.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群备份配置
 summary: 介绍 Kubernetes 上 TiDB 集群备份 tidb-backup 的配置参数。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/backup/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/backup/','/docs-cn/stable/tidb-in-kubernetes/reference/configuration/backup/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/backup/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/backup/','/docs-cn/v3.0/tidb-in-kubernetes/reference/configuration/backup/']
 ---
 
 # Kubernetes 上的 TiDB 集群备份配置

--- a/zh/configure-storage-class.md
+++ b/zh/configure-storage-class.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的持久化存储类型配置
 summary: 介绍 Kubernetes 上的数据持久化存储类型配置。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/local-pv/','/docs-cn/dev/tidb-in-kubernetes/reference/configuration/storage-class/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/storage-class/','/docs-cn/stable/tidb-in-kubernetes/reference/configuration/storage-class/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/local-pv/','/docs-cn/dev/tidb-in-kubernetes/reference/configuration/storage-class/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/storage-class/','/docs-cn/v3.0/tidb-in-kubernetes/reference/configuration/storage-class/']
 ---
 
 # Kubernetes 上的持久化存储类型配置

--- a/zh/configure-tidb-binlog-drainer.md
+++ b/zh/configure-tidb-binlog-drainer.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB Binlog Drainer 配置
 summary: 了解 Kubernetes 上的 TiDB Binlog Drainer 配置参数。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs-cn/stable/tidb-in-kubernetes/reference/configuration/tidb-drainer/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs-cn/v3.1/tidb-in-kubernetes/reference/configuration/tidb-drainer/','/docs-cn/v3.0/tidb-in-kubernetes/reference/configuration/tidb-drainer/']
 ---
 
 # Kubernetes 上的 TiDB Binlog Drainer 配置

--- a/zh/deploy-on-alibaba-cloud.md
+++ b/zh/deploy-on-alibaba-cloud.md
@@ -2,7 +2,7 @@
 title: 在阿里云上部署 TiDB 集群
 summary: 介绍如何在阿里云上部署 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs-cn/stable/tidb-in-kubernetes/deploy/alibaba-cloud/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/alibaba-cloud/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/alibaba-cloud/']
 ---
 
 # 在阿里云上部署 TiDB 集群

--- a/zh/deploy-on-aws-eks.md
+++ b/zh/deploy-on-aws-eks.md
@@ -2,7 +2,7 @@
 title: 在 AWS EKS 上部署 TiDB 
 summary: 介绍如何在 AWS EKS (Elastic Kubernetes Service) 上部署 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/aws-eks/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/aws-eks/','/docs-cn/stable/tidb-in-kubernetes/deploy/aws-eks/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/aws-eks/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/aws-eks/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/aws-eks/']
 ---
 
 # 在 AWS EKS 上部署 TiDB 集群

--- a/zh/deploy-on-gcp-gke.md
+++ b/zh/deploy-on-gcp-gke.md
@@ -2,7 +2,7 @@
 title: 在 GCP GKE 上部署 TiDB 集群
 summary: 了解如何在 GCP GKE 上部署 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/gcp-gke/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/gcp-gke/','/docs-cn/stable/tidb-in-kubernetes/deploy/gcp-gke/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/gcp-gke/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/gcp-gke/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/gcp-gke/']
 ---
 
 # 在 GCP GKE 上部署 TiDB 集群

--- a/zh/deploy-on-general-kubernetes.md
+++ b/zh/deploy-on-general-kubernetes.md
@@ -2,7 +2,7 @@
 title: 在标准 Kubernetes 上部署 TiDB 集群
 summary: 介绍如何在标准 Kubernetes 集群上通过 TiDB Operator 部署 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/general-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/general-kubernetes/','/docs-cn/stable/tidb-in-kubernetes/deploy/general-kubernetes/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/general-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/general-kubernetes/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/general-kubernetes/']
 ---
 
 # 在标准 Kubernetes 上部署 TiDB 集群

--- a/zh/deploy-tidb-binlog.md
+++ b/zh/deploy-tidb-binlog.md
@@ -7,7 +7,7 @@ aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/tidb-binlog/','/docs-cn/v3.1
 
 # TiDB Binlog 运维
 
-本文档介绍如何在 Kubernetes 上运维 TiDB 集群的 [TiDB Binlog](https://pingcap.com/docs-cn/stable/reference/tidb-binlog/overview)。
+本文档介绍如何在 Kubernetes 上运维 TiDB 集群的 [TiDB Binlog](https://pingcap.com/docs-cn/v3.0/reference/tidb-binlog/overview)。
 
 ## 运维准备
 

--- a/zh/deploy-tidb-binlog.md
+++ b/zh/deploy-tidb-binlog.md
@@ -2,7 +2,7 @@
 title: TiDB Binlog 运维
 summary: 了解如何在 Kubernetes 上运维 TiDB 集群的 TiDB Binlog。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/tidb-binlog/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/tidb-binlog/','/docs-cn/stable/tidb-in-kubernetes/maintain/tidb-binlog/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/tidb-binlog/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/tidb-binlog/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/tidb-binlog/']
 ---
 
 # TiDB Binlog 运维

--- a/zh/deploy-tidb-from-kubernetes-gke.md
+++ b/zh/deploy-tidb-from-kubernetes-gke.md
@@ -2,7 +2,7 @@
 title: 在 GCP 上通过 Kubernetes 部署 TiDB 集群
 summary: 在 GCP 上通过 Kubernetes 部署 TiDB 集群教程。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs-cn/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs-cn/stable/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs-cn/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/','/docs-cn/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-gke/']
 ---
 
 # 在 GCP 上通过 Kubernetes 部署 TiDB 集群

--- a/zh/deploy-tidb-from-kubernetes-kind.md
+++ b/zh/deploy-tidb-from-kubernetes-kind.md
@@ -2,7 +2,7 @@
 title: 使用 kind 在 Kubernetes 上部署 TiDB 集群
 summary: 介绍如何使用 kind 在 Kubernetes 上部署 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/get-started/deploy-tidb-from-kubernetes-dind/','/docs-cn/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs-cn/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs-cn/stable/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/']
+aliases: ['/docs-cn/dev/get-started/deploy-tidb-from-kubernetes-dind/','/docs-cn/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs-cn/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/','/docs-cn/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-kind/']
 ---
 
 # 使用 kind 在 Kubernetes 上部署 TiDB 集群

--- a/zh/deploy-tidb-from-kubernetes-minikube.md
+++ b/zh/deploy-tidb-from-kubernetes-minikube.md
@@ -2,7 +2,7 @@
 title: 在 Minikube 集群上部署 TiDB 集群
 summary: 介绍如何在 Minikube 集群上部署 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs-cn/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs-cn/stable/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs-cn/v3.1/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/','/docs-cn/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube/']
 ---
 
 # 在 Minikube 集群上部署 TiDB 集群

--- a/zh/deploy-tidb-operator.md
+++ b/zh/deploy-tidb-operator.md
@@ -2,7 +2,7 @@
 title: 在 Kubernetes 上部署 TiDB Operator
 summary: 了解如何在 Kubernetes 上部署 TiDB Operator。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/tidb-operator/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/tidb-operator/','/docs-cn/stable/tidb-in-kubernetes/deploy/tidb-operator/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/tidb-operator/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/tidb-operator/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/tidb-operator/']
 ---
 
 # 在 Kubernetes 上部署 TiDB Operator

--- a/zh/destroy-a-tidb-cluster.md
+++ b/zh/destroy-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: 销毁 Kubernetes 上的 TiDB 集群
 summary: 介绍如何销毁 Kubernetes 集群上的 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs-cn/stable/tidb-in-kubernetes/maintain/destroy-tidb-cluster/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/destroy-tidb-cluster/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/destroy-tidb-cluster/']
 ---
 
 # 销毁 Kubernetes 上的 TiDB 集群

--- a/zh/faq.md
+++ b/zh/faq.md
@@ -22,7 +22,7 @@ aliases: ['/docs-cn/dev/tidb-in-kubernetes/faq/','/docs-cn/v3.1/tidb-in-kubernet
     如果 TiDB 集群已经在运行，需要做如下修改：
 
     * 在 TiDB 集群的 `values.yaml` 文件中，修改 `timezone` 配置，例如：`timezone: Asia/Shanghai`，然后升级 TiDB 集群。
-    * 参考[时区支持](https://pingcap.com/docs-cn/stable/how-to/configure/time-zone)，修改 TiDB 服务时区配置。
+    * 参考[时区支持](https://pingcap.com/docs-cn/v3.0/how-to/configure/time-zone)，修改 TiDB 服务时区配置。
 
 ## TiDB 相关组件可以配置 HPA 或 VPA 么？
 
@@ -49,7 +49,7 @@ TiDB 集群目前还不支持 HPA（Horizontal Pod Autoscaling，自动水平扩
 
 TiDB Operator 尚不支持自动编排 TiSpark。
 
-假如要为 TiDB in Kubernetes 添加 TiSpark 组件，你需要在**同一个** Kubernetes 集群中自行维护 Spark，确保 Spark 能够访问到 PD 和 TiKV 实例的 IP 与端口，并为 Spark 安装 TiSpark 插件，TiSpark 插件的安装方式可以参考 [TiSpark](https://pingcap.com/docs-cn/stable/reference/tispark/#已有-Spark-集群的部署方式)。
+假如要为 TiDB in Kubernetes 添加 TiSpark 组件，你需要在**同一个** Kubernetes 集群中自行维护 Spark，确保 Spark 能够访问到 PD 和 TiKV 实例的 IP 与端口，并为 Spark 安装 TiSpark 插件，TiSpark 插件的安装方式可以参考 [TiSpark](https://pingcap.com/docs-cn/v3.0/reference/tispark/#已有-Spark-集群的部署方式)。
 
 在 Kubernetes 上维护 Spark 可以参考 Spark 的官方文档：[Spark on Kubernetes](http://spark.apache.org/docs/latest/running-on-kubernetes.html)。
 

--- a/zh/faq.md
+++ b/zh/faq.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群常见问题
 summary: 介绍 Kubernetes 上的 TiDB 集群常见问题以及解决方案。
 category: FAQ
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/faq/','/docs-cn/v3.1/tidb-in-kubernetes/faq/','/docs-cn/stable/tidb-in-kubernetes/faq/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/faq/','/docs-cn/v3.1/tidb-in-kubernetes/faq/','/docs-cn/v3.0/tidb-in-kubernetes/faq/']
 ---
 
 # Kubernetes 上的 TiDB 集群常见问题

--- a/zh/initialize-a-cluster.md
+++ b/zh/initialize-a-cluster.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的集群初始化配置
 summary: 介绍如何初始化配置 Kubernetes 上的 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/initialize-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/initialize-cluster/','/docs-cn/stable/tidb-in-kubernetes/initialize-cluster/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/initialize-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/initialize-cluster/','/docs-cn/v3.0/tidb-in-kubernetes/initialize-cluster/']
 ---
 
 # Kubernetes 上的集群初始化配置

--- a/zh/maintain-a-kubernetes-node.md
+++ b/zh/maintain-a-kubernetes-node.md
@@ -2,7 +2,7 @@
 title: 维护 TiDB 集群所在的 Kubernetes 节点
 summary: 介绍如何维护 TiDB 集群所在的 Kubernetes 节点。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/kubernetes-node/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/kubernetes-node/','/docs-cn/stable/tidb-in-kubernetes/maintain/kubernetes-node/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/kubernetes-node/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/kubernetes-node/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/kubernetes-node/']
 ---
 
 # 维护 TiDB 集群所在的 Kubernetes 节点

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -15,7 +15,7 @@ TiDB 通过 Prometheus 和 Grafana 监控 TiDB 集群。在通过 TiDB Operator 
 
 监控数据默认没有持久化，如果由于某些原因监控容器重启，已有的监控数据会丢失。可以在 `values.yaml` 中设置 `monitor.persistent` 为 `true` 来持久化监控数据。开启此选项时应将 `storageClass` 设置为一个当前集群中已有的存储，并且此存储应当支持将数据持久化，否则仍然会存在数据丢失的风险。
 
-在 [TiDB 集群监控](https://pingcap.com/docs-cn/stable/how-to/monitor/monitor-a-cluster/)中有一些监控系统配置的细节可供参考。
+在 [TiDB 集群监控](https://pingcap.com/docs-cn/v3.0/how-to/monitor/monitor-a-cluster/)中有一些监控系统配置的细节可供参考。
 
 ### 查看监控面板
 

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群监控
 summary: 介绍如何在 Kubernetes 上部署 TiDB 集群监控。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs-cn/stable/tidb-in-kubernetes/monitor/tidb-in-kubernetes/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/monitor/tidb-in-kubernetes/','/docs-cn/v3.0/tidb-in-kubernetes/monitor/tidb-in-kubernetes/']
 ---
 
 # Kubernetes 上的 TiDB 集群监控

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -114,7 +114,7 @@ cat /proc/irq/<ir_num>/smp_affinity_list
 
 ## 硬件和部署要求
 
-与使用 binary 方式部署 TiDB 集群一致，要求选用 Intel x86-64 架构的 64 位通用硬件服务器，使用万兆网卡。关于 TiDB 集群在物理机上的具体部署需求，参考 [TiDB 软件和硬件环境建议配置](https://pingcap.com/docs-cn/stable/how-to/deploy/hardware-recommendations)。
+与使用 binary 方式部署 TiDB 集群一致，要求选用 Intel x86-64 架构的 64 位通用硬件服务器，使用万兆网卡。关于 TiDB 集群在物理机上的具体部署需求，参考 [TiDB 软件和硬件环境建议配置](https://pingcap.com/docs-cn/v3.0/how-to/deploy/hardware-recommendations)。
 
 对于服务器 disk、memory、CPU 的选择要根据对集群的容量规划以及部署拓扑来定。线上 Kubernetes 集群部署为了保证高可用，一般需要部署三个 master 节点、三个 etcd 节点以及若干个 worker 节点。同时，为了充分利用机器资源，master 节点一般也充当 worker 节点（也就是 master 节点上也可以调度负载）。通过 kubelet 设置[预留资源](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/)来保证机器上的系统进程以及 Kubernetes 的核心进程在工作负载很高的情况下仍然有足够的资源来运行，从而保证整个系统的稳定。
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群环境需求
 summary: 介绍在 Kubernetes 上部署 TiDB 集群的软硬件环境需求。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/prerequisites/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/prerequisites/','/docs-cn/stable/tidb-in-kubernetes/deploy/prerequisites/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/deploy/prerequisites/','/docs-cn/v3.1/tidb-in-kubernetes/deploy/prerequisites/','/docs-cn/v3.0/tidb-in-kubernetes/deploy/prerequisites/']
 ---
 
 # Kubernetes 上的 TiDB 集群环境需求

--- a/zh/restart-a-tidb-cluster.md
+++ b/zh/restart-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: 重启 Kubernetes 上的 TiDB 集群
 summary: 了解如何重启 Kubernetes 集群上的 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/restart/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/restart/','/docs-cn/stable/tidb-in-kubernetes/maintain/restart/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/restart/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/restart/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/restart/']
 ---
 
 # 重启 Kubernetes 上的 TiDB 集群

--- a/zh/restore-data-using-tidb-lightning.md
+++ b/zh/restore-data-using-tidb-lightning.md
@@ -127,7 +127,7 @@ tikv-importer 可以在一个现有的 TiDB 集群上启用，或者在新建 Ti
 
 4. 运行 `cat /proc/1/cmdline`，获得启动脚本。
 
-5. 参考[故障排除指南](https://pingcap.com/docs-cn/stable/how-to/troubleshoot/tidb-lightning/#tidb-lightning-troubleshooting)，对 lightning 进行诊断。
+5. 参考[故障排除指南](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/tidb-lightning/#tidb-lightning-troubleshooting)，对 lightning 进行诊断。
 
 ## 销毁 TiDB Lightning
 

--- a/zh/restore-data-using-tidb-lightning.md
+++ b/zh/restore-data-using-tidb-lightning.md
@@ -2,7 +2,7 @@
 title: 恢复 Kubernetes 上的 TiDB 集群数据
 summary: 使用 TiDB Lightning 快速恢复 Kubernetes 上的 TiDB 集群数据。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/backup-and-restore/lightning/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/backup-and-restore/lightning/','/docs-cn/stable/tidb-in-kubernetes/maintain/backup-and-restore/lightning/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/backup-and-restore/lightning/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/backup-and-restore/lightning/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/backup-and-restore/lightning/']
 ---
 
 # 恢复 Kubernetes 上的 TiDB 集群数据

--- a/zh/scale-a-tidb-cluster.md
+++ b/zh/scale-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群扩缩容
 summary: 介绍如何在 Kubernetes 中对 TiDB 集群扩缩容。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/scale-in-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/scale-in-kubernetes/','/docs-cn/stable/tidb-in-kubernetes/scale-in-kubernetes/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/scale-in-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/scale-in-kubernetes/','/docs-cn/v3.0/tidb-in-kubernetes/scale-in-kubernetes/']
 ---
 
 # Kubernetes 上的 TiDB 集群扩缩容

--- a/zh/tidb-operator-overview.md
+++ b/zh/tidb-operator-overview.md
@@ -2,7 +2,7 @@
 title: TiDB Operator 简介
 summary: 介绍 TiDB Operator 的整体架构及使用方式。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/tidb-operator-overview/','/docs-cn/v3.1/tidb-in-kubernetes/tidb-operator-overview/','/docs-cn/stable/tidb-in-kubernetes/tidb-operator-overview/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/tidb-operator-overview/','/docs-cn/v3.1/tidb-in-kubernetes/tidb-operator-overview/','/docs-cn/v3.0/tidb-in-kubernetes/tidb-operator-overview/']
 ---
 
 # TiDB Operator 简介

--- a/zh/tidb-scheduler.md
+++ b/zh/tidb-scheduler.md
@@ -2,7 +2,7 @@
 title: TiDB Scheduler 扩展调度器
 summary: 了解 TiDB Scheduler 扩展调度器及其工作原理。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs-cn/v3.1/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs-cn/stable/tidb-in-kubernetes/reference/components/tidb-scheduler/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs-cn/v3.1/tidb-in-kubernetes/reference/components/tidb-scheduler/','/docs-cn/v3.0/tidb-in-kubernetes/reference/components/tidb-scheduler/']
 ---
 
 # TiDB Scheduler 扩展调度器

--- a/zh/tidb-toolkit.md
+++ b/zh/tidb-toolkit.md
@@ -11,7 +11,7 @@ Kubernetes 上的 TiDB 运维管理需要使用一些开源工具。同时，在
 
 ## 在 Kubernetes 上使用 PD Control
 
-[PD Control](https://pingcap.com/docs-cn/stable/reference/tools/pd-control) 是 PD 的命令行工具，在使用 PD Control 操作 Kubernetes 上的 TiDB 集群时，需要先使用 `kubectl port-forward` 打开本地到 PD 服务的连接：
+[PD Control](https://pingcap.com/docs-cn/v3.0/reference/tools/pd-control) 是 PD 的命令行工具，在使用 PD Control 操作 Kubernetes 上的 TiDB 集群时，需要先使用 `kubectl port-forward` 打开本地到 PD 服务的连接：
 
 {{< copyable "shell-regular" >}}
 
@@ -45,7 +45,7 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
 
 ## 在 Kubernetes 上使用 TiKV Control
 
-[TiKV Control](https://pingcap.com/docs-cn/stable/reference/tools/tikv-control) 是 TiKV 的命令行工具。在使用 TiKV Control 操作 Kubernetes 上的 TiDB 集群时，针对 TiKV Control 的不同操作模式，有不同的操作步骤。
+[TiKV Control](https://pingcap.com/docs-cn/v3.0/reference/tools/tikv-control) 是 TiKV 的命令行工具。在使用 TiKV Control 操作 Kubernetes 上的 TiDB 集群时，针对 TiKV Control 的不同操作模式，有不同的操作步骤。
 
 * **远程模式**：此模式下 `tikv-ctl` 命令需要通过网络访问 TiKV 服务或 PD 服务，因此需要先使用 `kubectl port-forward` 打开本地到 PD 服务以及目标 TiKV 节点的连接：
 
@@ -113,7 +113,7 @@ pd-ctl -u 127.0.0.1:<local-port> -d config show
 
 ## 在 Kubernetes 上使用 TiDB Control
 
-[TiDB Control](https://pingcap.com/docs-cn/stable/reference/tools/tidb-control) 是 TiDB 的命令行工具，使用 TiDB Control 时，需要从本地访问 TiDB 节点和 PD 服务，因此建议使用 `kubectl port-forward` 打开到集群中 TiDB 节点和 PD 服务的连接：
+[TiDB Control](https://pingcap.com/docs-cn/v3.0/reference/tools/tidb-control) 是 TiDB 的命令行工具，使用 TiDB Control 时，需要从本地访问 TiDB 节点和 PD 服务，因此建议使用 `kubectl port-forward` 打开到集群中 TiDB 节点和 PD 服务的连接：
 
 {{< copyable "shell-regular" >}}
 

--- a/zh/tidb-toolkit.md
+++ b/zh/tidb-toolkit.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 工具指南
 summary: 详细介绍 Kubernetes 上的 TiDB 相关的工具及其使用方法。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs-cn/stable/tidb-in-kubernetes/reference/tools/in-kubernetes/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs-cn/v3.1/tidb-in-kubernetes/reference/tools/in-kubernetes/','/docs-cn/v3.0/tidb-in-kubernetes/reference/tools/in-kubernetes/']
 ---
 
 # Kubernetes 上的 TiDB 工具指南

--- a/zh/troubleshoot.md
+++ b/zh/troubleshoot.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群故障诊断
 summary: 介绍 Kubernetes 上 TiDB 集群的常见故障以及诊断解决方案。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/troubleshoot/','/docs-cn/v3.1/tidb-in-kubernetes/troubleshoot/','/docs-cn/stable/tidb-in-kubernetes/troubleshoot/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/troubleshoot/','/docs-cn/v3.1/tidb-in-kubernetes/troubleshoot/','/docs-cn/v3.0/tidb-in-kubernetes/troubleshoot/']
 ---
 
 # Kubernetes 上的 TiDB 集群故障诊断

--- a/zh/troubleshoot.md
+++ b/zh/troubleshoot.md
@@ -190,7 +190,7 @@ kubectl -n <namespace> logs -f <pod-name>
 kubectl -n <namespace> logs -p <pod-name>
 ```
 
-确认日志中的错误信息后，可以根据 [tidb-server 启动报错](https://pingcap.com/docs-cn/stable/how-to/troubleshoot/cluster-setup/#tidb-server-启动报错)，[tikv-server 启动报错](https://pingcap.com/docs-cn/stable/how-to/troubleshoot/cluster-setup/#tikv-server-启动报错)，[pd-server 启动报错](https://pingcap.com/docs-cn/stable/how-to/troubleshoot/cluster-setup/#pd-server-启动报错)中的指引信息进行进一步排查解决。
+确认日志中的错误信息后，可以根据 [tidb-server 启动报错](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/cluster-setup/#tidb-server-启动报错)，[tikv-server 启动报错](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/cluster-setup/#tikv-server-启动报错)，[pd-server 启动报错](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/cluster-setup/#pd-server-启动报错)中的指引信息进行进一步排查解决。
 
 若是 TiKV Pod 日志中出现 "cluster id mismatch" 信息，则 TiKV Pod 使用的数据可能是其他或之前的 TiKV Pod 的旧数据。在集群配置本地存储时未清除机器上本地磁盘上的数据，或者强制删除了 PV 导致数据并没有被 local volume provisioner 程序回收，可能导致 PV 遗留旧数据，导致错误。
 

--- a/zh/upgrade-a-tidb-cluster.md
+++ b/zh/upgrade-a-tidb-cluster.md
@@ -2,7 +2,7 @@
 title: 滚动升级 Kubernetes 上的 TiDB 集群
 summary: 介绍如何滚动升级 Kubernetes 上的 TiDB 集群。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs-cn/stable/tidb-in-kubernetes/upgrade/tidb-cluster/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs-cn/v3.1/tidb-in-kubernetes/upgrade/tidb-cluster/','/docs-cn/v3.0/tidb-in-kubernetes/upgrade/tidb-cluster/']
 ---
 
 # 滚动升级 Kubernetes 上的 TiDB 集群

--- a/zh/upgrade-tidb-operator.md
+++ b/zh/upgrade-tidb-operator.md
@@ -2,7 +2,7 @@
 title: 升级 TiDB Operator
 summary: 介绍如何升级 TiDB Operator。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/upgrade/tidb-operator/','/docs-cn/v3.1/tidb-in-kubernetes/upgrade/tidb-operator/','/docs-cn/stable/tidb-in-kubernetes/upgrade/tidb-operator/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/upgrade/tidb-operator/','/docs-cn/v3.1/tidb-in-kubernetes/upgrade/tidb-operator/','/docs-cn/v3.0/tidb-in-kubernetes/upgrade/tidb-operator/']
 ---
 
 # 升级 TiDB Operator

--- a/zh/use-auto-failover.md
+++ b/zh/use-auto-failover.md
@@ -2,7 +2,7 @@
 title: Kubernetes 上的 TiDB 集群故障自动转移
 summary: 介绍 Kubernetes 上的 TiDB 集群故障自动转移的功能。
 category: how-to
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/auto-failover/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/auto-failover/','/docs-cn/stable/tidb-in-kubernetes/maintain/auto-failover/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/maintain/auto-failover/','/docs-cn/v3.1/tidb-in-kubernetes/maintain/auto-failover/','/docs-cn/v3.0/tidb-in-kubernetes/maintain/auto-failover/']
 ---
 
 # Kubernetes 上的 TiDB 集群故障自动转移

--- a/zh/use-tkctl.md
+++ b/zh/use-tkctl.md
@@ -2,7 +2,7 @@
 title: tkctl 使用指南
 summary: 介绍如何使用 tkctl 命令行工具来运维集群和诊断集群问题。
 category: reference
-aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/tools/tkctl/','/docs-cn/v3.1/tidb-in-kubernetes/reference/tools/tkctl/','/docs-cn/stable/tidb-in-kubernetes/reference/tools/tkctl/']
+aliases: ['/docs-cn/dev/tidb-in-kubernetes/reference/tools/tkctl/','/docs-cn/v3.1/tidb-in-kubernetes/reference/tools/tkctl/','/docs-cn/v3.0/tidb-in-kubernetes/reference/tools/tkctl/']
 ---
 
 # tkctl 使用指南


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

change "stable" to "v3.0" in aliases
<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] master (the latest development version)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [x] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here--> https://github.com/pingcap/docs-tidb-operator/pull/148
