### PR TITLE
en: fix commonName of all certificate

### DIFF
--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -466,7 +466,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
       namespace: <namespace>
     spec:
       secretName: <cluster-name>-ca-secret
-      commonName: "TiDB CA"
+      commonName: "TiDB"
       isCA: true
       issuerRef:
         name: <cluster-name>-selfsigned-ca-issuer
@@ -516,7 +516,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
           renewBefore: 360h # 15d
           organization:
           - PingCAP
-          commonName: "PD"
+          commonName: "TiDB"
           usages:
             - server auth
             - client auth
@@ -575,7 +575,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
           renewBefore: 360h # 15d
           organization:
           - PingCAP
-          commonName: "TiKV"
+          commonName: "TiDB"
           usages:
             - server auth
             - client auth
@@ -697,7 +697,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
           renewBefore: 360h # 15d
           organization:
           - PingCAP
-          commonName: "Pump"
+          commonName: "TiDB"
           usages:
             - server auth
             - client auth
@@ -761,7 +761,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
           renewBefore: 360h # 15d
           organization:
           - PingCAP
-          commonName: "Drainer"
+          commonName: "TiDB"
           usages:
             - server auth
             - client auth
@@ -792,7 +792,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
           renewBefore: 360h # 15d
           organization:
           - PingCAP
-          commonName: "Drainer"
+          commonName: "TiDB"
           usages:
             - server auth
             - client auth
@@ -836,7 +836,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
         renewBefore: 360h # 15d
         organization:
         - PingCAP
-        commonName: "TiDB Components TLS Client"
+        commonName: "TiDB"
         usages:
         - client auth
         issuerRef:
@@ -873,7 +873,7 @@ When you deploy a TiDB cluster, you can enable TLS between TiDB components, and 
 
 > **Note:**
 >
-> Currently, you can set only one value for the `cert-allowed-cn` configuration item of PD.
+> Currently, you can set only one value for the `cert-allowed-cn` configuration item of PD. Therefore, the `commonName` of all `Certificate` object must be the same value.
 
 In this step, you need to perform the following operations:
 

--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -873,7 +873,7 @@ When you deploy a TiDB cluster, you can enable TLS between TiDB components, and 
 
 > **Note:**
 >
-> Currently, you can set only one value for the `cert-allowed-cn` configuration item of PD. Therefore, the `commonName` of all `Certificate` object must be the same value.
+> Currently, you can set only one value for the `cert-allowed-cn` configuration item of PD. Therefore, the `commonName` of all `Certificate` object must be the same.
 
 In this step, you need to perform the following operations:
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->
The `commonName` in all `certificate` objects should be the same.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->https://github.com/pingcap/docs-tidb-operator/pull/167
- Other reference link(s): <!--Give links here-->
