### PR TITLE
zh, en: update dns names list in tls certificate

### DIFF
--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -126,7 +126,10 @@ This section describe how to issue certificates for the TiDB cluster using two m
           "${cluster_name}-tidb.${namespace}.svc",
           "*.${cluster_name}-tidb",
           "*.${cluster_name}-tidb.${namespace}",
-          "*.${cluster_name}-tidb.${namespace}.svc"
+          "*.${cluster_name}-tidb.${namespace}.svc",
+          "*.${cluster_name}-tidb-peer",
+          "*.${cluster_name}-tidb-peer.${namespace}",
+          "*.${cluster_name}-tidb-peer.${namespace}.svc"
         ],
     ...
     ```
@@ -281,6 +284,9 @@ You can generate multiple sets of client-side certificates. At least one set of 
         - "*.${cluster_name}-tidb"
         - "*.${cluster_name}-tidb.${namespace}"
         - "*.${cluster_name}-tidb.${namespace}.svc"
+        - "*.${cluster_name}-tidb-peer"
+        - "*.${cluster_name}-tidb-peer.${namespace}"
+        - "*.${cluster_name}-tidb-peer.${namespace}.svc"
       ipAddresses:
         - 127.0.0.1
         - ::1
@@ -301,6 +307,9 @@ You can generate multiple sets of client-side certificates. At least one set of 
         - `*.${cluster_name}-tidb`
         - `*.${cluster_name}-tidb.${namespace}`
         - `*.${cluster_name}-tidb.${namespace}.svc`
+        - `*.${cluster_name}-tidb-peer`
+        - `*.${cluster_name}-tidb-peer.${namespace}`
+        - `*.${cluster_name}-tidb-peer.${namespace}.svc`
     - Add the following 2 IPs in `ipAddresses`. You can also add other IPs according to your needs:
         - `127.0.0.1`
         - `::1`

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -120,7 +120,10 @@ category: how-to
           "${cluster_name}-tidb.${namespace}.svc",
           "*.${cluster_name}-tidb",
           "*.${cluster_name}-tidb.${namespace}",
-          "*.${cluster_name}-tidb.${namespace}.svc"
+          "*.${cluster_name}-tidb.${namespace}.svc",
+          "*.${cluster_name}-tidb-peer",
+          "*.${cluster_name}-tidb-peer.${namespace}",
+          "*.${cluster_name}-tidb-peer.${namespace}.svc"
         ],
     ...
     ```
@@ -275,6 +278,9 @@ category: how-to
         - "*.${cluster_name}-tidb"
         - "*.${cluster_name}-tidb.${namespace}"
         - "*.${cluster_name}-tidb.${namespace}.svc"
+        - "*.${cluster_name}-tidb-peer"
+        - "*.${cluster_name}-tidb-peer.${namespace}"
+        - "*.${cluster_name}-tidb-peer.${namespace}.svc"
       ipAddresses:
         - 127.0.0.1
         - ::1
@@ -295,6 +301,9 @@ category: how-to
       - `*.${cluster_name}-tidb`
       - `*.${cluster_name}-tidb.${namespace}`
       - `*.${cluster_name}-tidb.${namespace}.svc`
+      - `*.${cluster_name}-tidb-peer`
+      - `*.${cluster_name}-tidb-peer.${namespace}`
+      - `*.${cluster_name}-tidb-peer.${namespace}.svc`
     - `ipAddresses` 需要填写这两个 IP ，根据需要可以填写其他 IP：
       - `127.0.0.1`
       - `::1`


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
We need to add the following DNS names to certificate, otherwise dashboard will not work if TLS is enabled.
```
 - "*.${cluster_name}-tidb-peer"
 - "*.${cluster_name}-tidb-peer.${namespace}"
 - "*.${cluster_name}-tidb-peer.${namespace}.svc"
```
<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
