### PR TITLE
Added "path" and "other" to S3StorageProvider API reference

### DIFF
--- a/en/api-references.md
+++ b/en/api-references.md
@@ -7115,6 +7115,17 @@ string
 </tr>
 <tr>
 <td>
+<code>path</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Full path to file in S3, in the format s3://bucket/prefix/backup-date-time.tgz</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bucket</code></br>
 <em>
 string
@@ -7177,7 +7188,7 @@ string
 </em>
 </td>
 <td>
-<p>Prefix for the keys.</p>
+<p>Prefix (subdirectory) for the backup file.</p>
 </td>
 </tr>
 <tr>
@@ -7189,6 +7200,17 @@ string
 </td>
 <td>
 <p>SSE Sever-Side Encryption.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>options</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>rclone options for backup and restore with mydumper and Lightning.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

The "path" and "options" elements were missing from the documentation for the S3StorageProvider API. This resolves that.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
