### PR TITLE
en: set TLS config between drainer and downstream

### DIFF
--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -139,7 +139,7 @@ TiDB Binlog is disabled in the TiDB cluster by default. To create a TiDB cluster
     >
     > If you update the affinity configuration of the TiDB components, it will cause rolling updates of the TiDB components in the cluster.
 
-## Deploy drainer
+## Deploy Drainer
 
 To deploy multiple drainers using the `tidb-drainer` Helm chart for a TiDB cluster, take the following steps:
 
@@ -192,7 +192,7 @@ To deploy multiple drainers using the `tidb-drainer` Helm chart for a TiDB clust
 
     For complete configuration details, refer to [TiDB Binlog Drainer Configurations in Kubernetes](configure-tidb-binlog-drainer.md).
 
-4. Deploy the drainer:
+4. Deploy Drainer:
 
     {{< copyable "shell-regular" >}}
 
@@ -208,4 +208,57 @@ To deploy multiple drainers using the `tidb-drainer` Helm chart for a TiDB clust
 
 ## Enable TLS
 
+### Enable TLS between TiDB components
+
 If you want to enable TLS for the TiDB cluster and TiDB Binlog, refer to [Enable TLS between Components](enable-tls-between-components.md).
+
+After you create a secret and start a TiDB cluster with Pump, edit the `values.yaml` file to set `tlsCluster.enabled` to `true`, and configure the corresponding `certAllowedCN`:
+
+```yaml
+...
+tlsCluster:
+  enabled: true
+  # certAllowedCN:
+  #  - TiDB
+...
+```
+
+### Enable TLS between Drainer and the downstream database
+
+If you set the downstream database of `tidb-drainer` to `mysql/tidb`, and if you want to enable TLS between Drainer and the downstream database, take the following steps.
+
+1. Create a secret that contains the TLS information of the downstream database.
+
+    ```bash
+    kubectl create secret generic ${downstream_database_secret_name} --namespace=${namespace} --from-file=tls.crt=client.pem --from-file=tls.key=client-key.pem --from-file=ca.crt=ca.pem
+    ```
+
+    `tidb-drainer` saves the checkpoint in the downstream database by default, so you only need to configure `tlsSyncer.tlsClientSecretName` and the corresponding `cerAllowedCN`:
+
+    ```yaml
+    tlsSyncer:
+      tlsClientSecretName: ${downstream_database_secret_name}
+      # certAllowedCN:
+      #  - TiDB
+    ```
+
+2. To save the checkpoint of `tidb-drainer` to **other databases that have enabled TLS**, create a secret that contains the TLS information of the checkpoint database:
+
+    ```bash
+    kubectl create secret generic ${checkpoint_tidb_client_secret} --namespace=${namespace} --from-file=tls.crt=client.pem --from-file=tls.key=client-key.pem --from-file=ca.crt=ca.pem
+    ```
+
+    Edit the `values.yaml` file to set `tlsSyncer.checkpoint.tlsClientSecretName` to `${checkpoint_tidb_client_secret}`, and configure the corresponding `certAllowedCN`:
+
+    ```yaml
+    ...
+    tlsSyncer: {}
+      tlsClientSecretName: ${downstream_database_secret_name}
+      # certAllowedCN:
+      #  - TiDB
+      checkpoint:
+        tlsClientSecretName: ${checkpoint_tidb_client_secret}
+        # certAllowedCN:
+        #  - TiDB
+    ...
+    ```

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -212,7 +212,7 @@ To deploy multiple drainers using the `tidb-drainer` Helm chart for a TiDB clust
 
 If you want to enable TLS for the TiDB cluster and TiDB Binlog, refer to [Enable TLS between Components](enable-tls-between-components.md).
 
-After you create a secret and start a TiDB cluster with Pump, edit the `values.yaml` file to set `tlsCluster.enabled` to `true`, and configure the corresponding `certAllowedCN`:
+After you have created a secret and started a TiDB cluster with Pump, edit the `values.yaml` file to set the `tlsCluster.enabled` value to `true`, and configure the corresponding `certAllowedCN`:
 
 ```yaml
 ...
@@ -248,7 +248,7 @@ If you set the downstream database of `tidb-drainer` to `mysql/tidb`, and if you
     kubectl create secret generic ${checkpoint_tidb_client_secret} --namespace=${namespace} --from-file=tls.crt=client.pem --from-file=tls.key=client-key.pem --from-file=ca.crt=ca.pem
     ```
 
-    Edit the `values.yaml` file to set `tlsSyncer.checkpoint.tlsClientSecretName` to `${checkpoint_tidb_client_secret}`, and configure the corresponding `certAllowedCN`:
+    Edit the `values.yaml` file to set the `tlsSyncer.checkpoint.tlsClientSecretName` value to `${checkpoint_tidb_client_secret}`, and configure the corresponding `certAllowedCN`:
 
     ```yaml
     ...


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

Document how to set tls config between drainer and upstream database.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->https://github.com/pingcap/docs-tidb-operator/pull/589
- Other reference link(s): <!--Give links here-->
