### PR TITLE
en: add enterprise image in deployment/upgrade docs

### DIFF
--- a/en/configure-a-tidb-cluster.md
+++ b/en/configure-a-tidb-cluster.md
@@ -127,6 +127,22 @@ If you want to enable TiCDC in the cluster, you can add TiCDC spec to the `TiDBC
       replicas: 3
 ```
 
+#### Deploy the enterprise version
+
+To deploy the enterprise version of TiDB/PD/TiKV/TiFlash/TiCDC, edit the `db.yaml` file to set `spec.<tidb/pd/tikv/tiflash/ticdc>.baseImage` to the enterprise image (`pingcap/<tidb/pd/tikv/tiflash/ticdc>-enterprise`).
+
+For example:
+
+```yaml
+spec:
+  ...
+  pd:
+    baseImage: pingcap/pd-enterprise
+  ...
+  tikv:
+    baseImage: pingcap/tikv-enterprise
+```
+
 ### Configure TiDB components
 
 This section introduces how to configure the parameters of TiDB/TiKV/PD/TiFlash/TiCDC.

--- a/en/deploy-on-alibaba-cloud.md
+++ b/en/deploy-on-alibaba-cloud.md
@@ -219,6 +219,20 @@ All the instances except ACK mandatory workers are deployed across availability 
 
         Modify `replicas` according to your needs.
 
+    To deploy the enterprise version of TiDB/PD/TiKV/TiFlash/TiCDC, edit the `db.yaml` file to set `spec.<tidb/pd/tikv/tiflash/ticdc>.baseImage` to the enterprise image (`pingcap/<tidb/pd/tikv/tiflash/ticdc>-enterprise`).
+
+    For example:
+
+    ```yaml
+    spec:
+      ...
+      pd:
+        baseImage: pingcap/pd-enterprise
+      ...
+      tikv:
+        baseImage: pingcap/tikv-enterprise
+    ```
+
     > **Note:**
     >
     > * Replace all the `TIDB_CLUSTER_NAME` in the `db.yaml` and `db-monitor.yaml` files with `tidb_cluster_name` configured in the deployment of ACK.

--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -228,7 +228,7 @@ You can use the `terraform output` command to get the output again.
         ```yaml
         spec:
           ...
-          tiflash:
+          ticdc:
             baseImage: pingcap/ticdc
             nodeSelector:
               dedicated: CLUSTER_NAME-cdc
@@ -241,6 +241,20 @@ You can use the `terraform output` command to get the output again.
         ```
 
         Modify `replicas` according to your needs.
+
+    To deploy the enterprise version of TiDB/PD/TiKV/TiFlash/TiCDC, edit the `db.yaml` file to set `spec.<tidb/pd/tikv/tiflash/ticdc>.baseImage` to the enterprise image (`pingcap/<tidb/pd/tikv/tiflash/ticdc>-enterprise`).
+
+    For example:
+
+    ```yaml
+    spec:
+      ...
+      pd:
+        baseImage: pingcap/pd-enterprise
+      ...
+      tikv:
+        baseImage: pingcap/tikv-enterprise
+    ```
 
     > **Note:**
     >

--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -180,6 +180,20 @@ This section describes how to deploy a TiDB cluster.
 
     To complete the CR file configuration, refer to [TiDB Operator API documentation](https://github.com/pingcap/tidb-operator/blob/master/docs/api-references/docs.md) and [Configure Cluster using TidbCluster](configure-a-tidb-cluster.md).
 
+    To deploy the enterprise version of TiDB/PD/TiKV, edit the `db.yaml` file to set `spec.<tidb/pd/tikv>.baseImage` to the enterprise image (`pingcap/<tidb/pd/tikv>-enterprise`).
+
+    For example:
+
+    ```yaml
+    spec:
+      ...
+      pd:
+        baseImage: pingcap/pd-enterprise
+      ...
+      tikv:
+        baseImage: pingcap/tikv-enterprise
+    ```
+
     > **Note:**
     >
     > * Make sure the number of PD nodes, TiKV nodes, or TiDB nodes is the same as the value of the `replicas` field in `db.yaml`. Note that in the Regional cluster, the number of nodes to actually create is `pd_count` * `3`, `tikv_count` * `3`, or `tidb_count` * `3`.

--- a/en/deploy-ticdc.md
+++ b/en/deploy-ticdc.md
@@ -38,6 +38,16 @@ To deploy TiCDC when deploying the TiDB cluster, refer to [Deploy TiDB in Genera
         replicas: 3
     ```
 
+    To deploy the enterprise version of TiCDC, edit the `db.yaml` file to set `spec.ticdc.baseImage` to the enterprise image (`pingcap/ticdc-enterprise`).
+
+    For example:
+
+    ```yaml
+    spec:
+     ticdc:
+       baseImage: pingcap/ticdc-enterprise
+    ```
+
 3. After the deployment, enter a TiCDC Pod by running `kubectl exec`:
 
     {{< copyable "shell-regular" >}}

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -42,8 +42,18 @@ TiDB Binlog is disabled in the TiDB cluster by default. To create a TiDB cluster
 
     Edit `version`, `replicas`, `storageClassName`, and `requests.storage` according to your cluster.
 
+    To deploy the enterprise version of Pump, edit the YAML file above to set `spec.pump.baseImage` to the enterprise image (`pingcap/tidb-binlog-enterprise`).
+
+    For example:
+
+    ```yaml
+    spec:
+      pump:
+        baseImage: pingcap/tidb-binlog-enterprise
+    ```
+
 2. Set affinity and anti-affinity for TiDB and Pump.
-    
+
     If you enable TiDB Binlog in the production environment, it is recommended to set affinity and anti-affinity for TiDB and the Pump component; if you enable TiDB Binlog in a test environment on the internal network, you can skip this step.
 
     By default, the affinity of TiDB and Pump is set to `{}`. Currently, each TiDB instance does not have a corresponding Pump instance by default. When TiDB Binlog is enabled, if Pump and TiDB are separately deployed and network isolation occurs, and `ignore-error` is enabled in TiDB components, TiDB loses binlogs.
@@ -170,6 +180,7 @@ To deploy multiple drainers using the `tidb-drainer` Helm chart for a TiDB clust
     ```yaml
     clusterName: example-tidb
     clusterVersion: v3.0.0
+    baseImage:pingcap/tidb-binlog
     storageClassName: local-storage
     storage: 10Gi
     config: |
@@ -191,6 +202,17 @@ To deploy multiple drainers using the `tidb-drainer` Helm chart for a TiDB clust
     The `clusterName` and `clusterVersion` must match the desired source TiDB cluster.
 
     For complete configuration details, refer to [TiDB Binlog Drainer Configurations in Kubernetes](configure-tidb-binlog-drainer.md).
+
+    To deploy the enterprise version of Drainer, edit the YAML file above to set `baseImage` to the enterprise image (`pingcap/tidb-binlog-enterprise`).
+
+    For example:
+
+    ```yaml
+    ...
+    clusterVersion: v4.0.2
+    baseImage: pingcap/tidb-binlog-enterprise
+    ...
+    ```
 
 4. Deploy Drainer:
 

--- a/en/deploy-tiflash.md
+++ b/en/deploy-tiflash.md
@@ -41,6 +41,16 @@ spec:
       storageClassName: local-storage
 ```
 
+To deploy the enterprise version of TiFlash, edit the `dm.yaml` file above to set `spec.tiflash.baseImage` to the enterprise image (`pingcap/tiflash-enterprise`).
+
+For example:
+
+```yaml
+spec:
+  tiflash:
+    baseImage: pingcap/tiflash-enterprise
+```
+
 TiFlash supports mounting multiple Persistent Volumes (PVs). If you want to configure multiple PVs for TiFlash, configure multiple `resources` in `tiflash.storageClaims`, each `resources` with a separate `storage request` and `storageClassName`. For example:
 
 ```yaml

--- a/en/upgrade-a-tidb-cluster.md
+++ b/en/upgrade-a-tidb-cluster.md
@@ -21,6 +21,12 @@ If the TiDB cluster is deployed directly using TidbCluster CR, or deployed using
 
     Usually, components in a cluster are in the same version. You can upgrade the TiDB cluster simply by modifying `spec.version`. If you need to use different versions for different components, configure `spec.<pd/tidb/tikv/pump/tiflash/ticdc>.version`.
 
+    > **Note:**
+    >
+    > If you want to upgrade to the enterprise version, edit the `db.yaml` file to set `spec.<tidb/pd/tikv/tiflash/ticdc/pump>.baseImage` to the enterprise image (`pingcap/<tidb/pd/tikv/tiflash/ticdc/tidb-binlog>-enterprise`).
+    >
+    > For example, change `spec.pd.baseImage` from `pingcap/pd` to `pingcap/pd-enterprise`.
+
     The `version` field has following formats:
 
     - `spec.version`: the format is `imageTag`, such as `v3.1.0`
@@ -77,6 +83,12 @@ If you continue to manage your cluster using Helm, refer to the following steps 
 
 1. Change the `image` of PD, TiKV and TiDB to different image versions in the `values.yaml` file.
 
+    > **Note:**
+    >
+    > If you want to upgrade to the enterprise version, set the value of `<tidb/pd/tikv>.image` to the enterprise image.
+    >
+    > For example, change `pd.image` from `pingcap/pd:v4.0.0` to `pingcap/pd-enterprise:v4.0.0`.
+
 2. Run the `helm upgrade` command:
 
     {{< copyable "shell-regular" >}}
@@ -92,6 +104,8 @@ If you continue to manage your cluster using Helm, refer to the following steps 
     ```shell
     watch kubectl -n ${namespace} get pod -o wide
     ```
+
+    After all the Pods finish rebuilding and become `Running`, the upgrade is completed.
 
 ### Force an upgrade of TiDB cluster using Helm
 


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->
Add enterprise image in deployment/upgrade docs.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->https://github.com/pingcap/docs-tidb-operator/pull/529
- Other reference link(s): <!--Give links here-->
