### PR TITLE
zh: add debug section for backup restore, comment storageClassName by default

### DIFF
--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -14,7 +14,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-aws-s3-using-br/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## AWS 账号权限授予的三种方式
 

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -12,6 +12,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-aws-s3-using-br/']
 
 本文使用的备份方式基于 TiDB Operator v1.1 及以上版本的 Custom Resource Definition(CRD) 实现。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## AWS 账号权限授予的三种方式
 
 在 AWS 云环境中，不同的类型的 Kubernetes 集群提供了不同的权限授予方式。本文测试了以下三种权限授予方式:

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -12,10 +12,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-aws-s3-using-br/']
 
 本文使用的备份方式基于 TiDB Operator v1.1 及以上版本的 Custom Resource Definition(CRD) 实现。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## AWS 账号权限授予的三种方式
 
 在 AWS 云环境中，不同的类型的 Kubernetes 集群提供了不同的权限授予方式。本文测试了以下三种权限授予方式:
@@ -570,3 +566,7 @@ kubectl edit backup ${name} -n ${namespace}
 ```
 
 删除 `metadata.finalizers` 配置，即可正常删除 CR。
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -10,6 +10,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-gcs-using-br/']
 
 本文使用的备份方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## Ad-hoc 全量备份
 
 Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 对象来描述一次备份。TiDB Operator 根据这个 `Backup` 对象来完成具体的备份过程。如果备份过程中出现错误，程序不会自动重试，此时需要手动处理。

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -10,10 +10,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-gcs-using-br/']
 
 本文使用的备份方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## Ad-hoc 全量备份
 
 Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 对象来描述一次备份。TiDB Operator 根据这个 `Backup` 对象来完成具体的备份过程。如果备份过程中出现错误，程序不会自动重试，此时需要手动处理。
@@ -290,3 +286,7 @@ kubectl edit backup ${name} -n ${namespace}
 ```
 
 删除 `metadata.finalizers` 配置，即可正常删除 CR。
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -12,7 +12,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-gcs-using-br/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## Ad-hoc 全量备份
 

--- a/zh/backup-to-gcs.md
+++ b/zh/backup-to-gcs.md
@@ -10,10 +10,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-gcs/']
 
 本文使用的备份方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。基于 Helm Charts 的备份和恢复方式可参考[基于 Helm Charts 实现的 TiDB 集群备份与恢复](backup-and-restore-using-helm-charts.md)。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## Ad-hoc 全量备份
 
 Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 对象来描述一次备份。TiDB Operator 根据这个 `Backup` 对象来完成具体的备份过程。如果备份过程中出现错误，程序不会自动重试，此时需要手动处理。
@@ -302,3 +298,7 @@ kubectl edit backup ${name} -n ${namespace}
 ```
 
 删除 `metadata.finalizers` 配置，即可正常删除 CR。
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/backup-to-gcs.md
+++ b/zh/backup-to-gcs.md
@@ -10,6 +10,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-gcs/']
 
 本文使用的备份方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。基于 Helm Charts 的备份和恢复方式可参考[基于 Helm Charts 实现的 TiDB 集群备份与恢复](backup-and-restore-using-helm-charts.md)。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## Ad-hoc 全量备份
 
 Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 对象来描述一次备份。TiDB Operator 根据这个 `Backup` 对象来完成具体的备份过程。如果备份过程中出现错误，程序不会自动重试，此时需要手动处理。

--- a/zh/backup-to-gcs.md
+++ b/zh/backup-to-gcs.md
@@ -241,7 +241,7 @@ spec:
   #  - --rows=10000
   #  tableFilter:
   #  - "test.*"
-    storageClassName: local-storage
+    # storageClassName: local-storage
     storageSize: 10Gi
 ```
 

--- a/zh/backup-to-gcs.md
+++ b/zh/backup-to-gcs.md
@@ -12,7 +12,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-gcs/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## Ad-hoc 全量备份
 

--- a/zh/backup-to-s3.md
+++ b/zh/backup-to-s3.md
@@ -13,7 +13,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-s3/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## Ad-hoc 全量备份
 

--- a/zh/backup-to-s3.md
+++ b/zh/backup-to-s3.md
@@ -11,10 +11,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-s3/']
 
 本文使用的备份方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。基于 Helm Charts 实现的备份和恢复方式可参考[基于 Helm Charts 实现的 TiDB 集群备份与恢复](backup-and-restore-using-helm-charts.md)。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## Ad-hoc 全量备份
 
 Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 对象来描述一次备份。TiDB Operator 根据这个 `Backup` 对象来完成具体的备份过程。如果备份过程中出现错误，程序不会自动重试，此时需要手动处理。
@@ -578,3 +574,7 @@ kubectl edit backup ${name} -n ${namespace}
 ```
 
 删除 `metadata.finalizers` 配置，即可正常删除 CR。
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/backup-to-s3.md
+++ b/zh/backup-to-s3.md
@@ -82,7 +82,7 @@ Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 
     #  - --rows=10000
     #  tableFilter:
     #  - "test.*"
-      storageClassName: local-storage
+      # storageClassName: local-storage
       storageSize: 10Gi
     ```
 
@@ -121,7 +121,7 @@ Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 
     #  - --rows=10000
     #  tableFilter:
     #  - "test.*"
-      storageClassName: local-storage
+      # storageClassName: local-storage
       storageSize: 10Gi
     ```
 
@@ -165,7 +165,7 @@ Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 
     #  - --rows=10000
     #  tableFilter:
     #  - "test.*"
-      storageClassName: local-storage
+      # storageClassName: local-storage
       storageSize: 10Gi
     ```
 
@@ -208,7 +208,7 @@ Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 
     #  - --rows=10000
     #  tableFilter:
     #  - "test.*"
-      storageClassName: local-storage
+      # storageClassName: local-storage
       storageSize: 10Gi
     ```
 
@@ -379,7 +379,7 @@ Amazon S3 支持以下几种 `storageClass` 类型：
       #  - --rows=10000
       #  tableFilter:
       #  - "test.*"
-        storageClassName: local-storage
+        # storageClassName: local-storage
         storageSize: 10Gi
     ```
 
@@ -423,7 +423,7 @@ Amazon S3 支持以下几种 `storageClass` 类型：
       #  - --rows=10000
       #  tableFilter:
       #  - "test.*"
-        storageClassName: local-storage
+        # storageClassName: local-storage
         storageSize: 10Gi
     ```
 
@@ -471,7 +471,7 @@ Amazon S3 支持以下几种 `storageClass` 类型：
       #  - --rows=10000
       #  tableFilter:
       #  - "test.*"
-        storageClassName: local-storage
+        # storageClassName: local-storage
         storageSize: 10Gi
     ```
 
@@ -518,7 +518,7 @@ Amazon S3 支持以下几种 `storageClass` 类型：
       #  - --rows=10000
       #  tableFilter:
       #  - "test.*"
-        storageClassName: local-storage
+        # storageClassName: local-storage
         storageSize: 10Gi
 
 定时全量备份创建完成后，可以通过以下命令查看定时全量备份的状态：

--- a/zh/backup-to-s3.md
+++ b/zh/backup-to-s3.md
@@ -11,6 +11,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/backup-to-s3/']
 
 本文使用的备份方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。基于 Helm Charts 实现的备份和恢复方式可参考[基于 Helm Charts 实现的 TiDB 集群备份与恢复](backup-and-restore-using-helm-charts.md)。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## Ad-hoc 全量备份
 
 Ad-hoc 全量备份通过创建一个自定义的 `Backup` custom resource (CR) 对象来描述一次备份。TiDB Operator 根据这个 `Backup` 对象来完成具体的备份过程。如果备份过程中出现错误，程序不会自动重试，此时需要手动处理。

--- a/zh/deploy-failures.md
+++ b/zh/deploy-failures.md
@@ -66,7 +66,7 @@ kubectl describe po -n ${namespace} ${pod_name}
 
 2. 将 `storageClassName` 修改为集群中可用的 StorageClass 名字。
 
-3. 运行 `kubectl apply -f tidb-cluster.yaml` 进行集群更新或者运行 `kubectl apply -f backup.yaml` 更新备份/恢复任务。
+3. 运行 `kubectl apply -f tidb-cluster.yaml` 进行集群更新，或运行 `kubectl apply -f backup.yaml` 更新备份/恢复任务。
 
 4. 将 Statefulset 删除，并且将对应的 PVC 也都删除。
 

--- a/zh/deploy-failures.md
+++ b/zh/deploy-failures.md
@@ -16,15 +16,27 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-failures/']
 
 ```shell
 kubectl get tidbclusters -n ${namespace}
+kubectl describe tidbclusters -n ${namespace} ${cluster_name}
 kubectl get statefulsets -n ${namespace}
 kubectl describe statefulsets -n ${namespace} ${cluster_name}-pd
+```
+
+创建备份恢复任务后，如果 Pod 没有创建，则可以通过以下方式进行诊断：
+
+{{< copyable "shell-regular" >}}
+
+```shell
+kubectl get backups -n ${namespace}
+kubectl describe backups -n ${namespace} ${backup_name}
+kubectl describe backupschedules  -n ${namespace} ${backupschedule_name}
+kubectl describe restores -n ${namespace} ${restore_name}
 ```
 
 ## Pod 处于 Pending 状态
 
 Pod 处于 Pending 状态，通常都是资源不满足导致的，比如：
 
-* 使用持久化存储的 PD、TiKV、Monitor Pod 使用的 PVC 的 StorageClass 不存在或 PV 不足
+* 使用持久化存储的 PD、TiKV、Monitor、Backup、Restore Pod 使用的 PVC 的 StorageClass 不存在或 PV 不足
 * Kubernetes 集群中没有节点能满足 Pod 申请的 CPU 或内存
 * PD 或者 TiKV Replicas 数量和集群内节点数量不满足 tidb-scheduler 高可用调度策略
 
@@ -54,7 +66,7 @@ kubectl describe po -n ${namespace} ${pod_name}
 
 2. 将 `storageClassName` 修改为集群中可用的 StorageClass 名字。
 
-3. 运行 `kubectl apply -f tidb-cluster.yaml` 进行集群更新。
+3. 运行 `kubectl apply -f tidb-cluster.yaml` 进行集群更新或者运行 `kubectl apply -f backup.yaml` 更新备份/恢复任务。
 
 4. 将 Statefulset 删除，并且将对应的 PVC 也都删除。
 

--- a/zh/deploy-failures.md
+++ b/zh/deploy-failures.md
@@ -27,8 +27,10 @@ kubectl describe statefulsets -n ${namespace} ${cluster_name}-pd
 
 ```shell
 kubectl get backups -n ${namespace}
+kubectl get jobs -n ${namespace}
 kubectl describe backups -n ${namespace} ${backup_name}
-kubectl describe backupschedules  -n ${namespace} ${backupschedule_name}
+kubectl describe backupschedules -n ${namespace} ${backupschedule_name}
+kubectl describe jobs -n ${namespace} ${backupjob_name}
 kubectl describe restores -n ${namespace} ${restore_name}
 ```
 
@@ -36,7 +38,7 @@ kubectl describe restores -n ${namespace} ${restore_name}
 
 Pod 处于 Pending 状态，通常都是资源不满足导致的，比如：
 
-* 使用持久化存储的 PD、TiKV、Monitor、Backup、Restore Pod 使用的 PVC 的 StorageClass 不存在或 PV 不足
+* 使用持久化存储的 PD、TiKV、TiFlash、Pump、Monitor、Backup、Restore Pod 使用的 PVC 的 StorageClass 不存在或 PV 不足
 * Kubernetes 集群中没有节点能满足 Pod 申请的 CPU 或内存
 * PD 或者 TiKV Replicas 数量和集群内节点数量不满足 tidb-scheduler 高可用调度策略
 
@@ -66,7 +68,11 @@ kubectl describe po -n ${namespace} ${pod_name}
 
 2. 将 `storageClassName` 修改为集群中可用的 StorageClass 名字。
 
-3. 运行 `kubectl apply -f tidb-cluster.yaml` 进行集群更新，或运行 `kubectl apply -f backup.yaml` 更新备份/恢复任务。
+3. 使用下述方式更新配置文件：
+
+   * 如果是启动 tidbcluster 集群，运行 `kubectl apply -f tidb-cluster.yaml` 进行集群更新。
+   * 如果是运行 backup/restore 的备份/恢复任务，首先需要运行 `kubectl delete -f backup.yaml` 删掉老的备份/恢复任务，
+     再运行 `kubectl apply -f backup.yaml` 重新创建新的备份/恢复任务。
 
 4. 将 Statefulset 删除，并且将对应的 PVC 也都删除。
 

--- a/zh/restore-from-aws-s3-using-br.md
+++ b/zh/restore-from-aws-s3-using-br.md
@@ -14,7 +14,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-aws-s3-using-br/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## AWS 账号的三种权限授予方式
 

--- a/zh/restore-from-aws-s3-using-br.md
+++ b/zh/restore-from-aws-s3-using-br.md
@@ -12,10 +12,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-aws-s3-using-br/']
 
 以下示例将 Amazon S3 的存储（指定路径）上的备份数据恢复到 AWS Kubernetes 环境中的 TiDB 集群。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## AWS 账号的三种权限授予方式
 
 参考[使用 BR 工具备份 AWS 上的 TiDB 集群](backup-to-aws-s3-using-br.md#aws-账号权限授予的三种方式)
@@ -284,3 +280,7 @@ kubectl get rt -n test2 -o wide
     ```shell
     kubectl create secret generic ${secret_name} --namespace=${namespace} --from-file=tls.crt=${cert_path} --from-file=tls.key=${key_path} --from-file=ca.crt=${ca_path}
     ```  
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/restore-from-aws-s3-using-br.md
+++ b/zh/restore-from-aws-s3-using-br.md
@@ -12,6 +12,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-aws-s3-using-br/']
 
 以下示例将 Amazon S3 的存储（指定路径）上的备份数据恢复到 AWS Kubernetes 环境中的 TiDB 集群。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## AWS 账号的三种权限授予方式
 
 参考[使用 BR 工具备份 AWS 上的 TiDB 集群](backup-to-aws-s3-using-br.md#aws-账号权限授予的三种方式)

--- a/zh/restore-from-gcs-using-br.md
+++ b/zh/restore-from-gcs-using-br.md
@@ -12,6 +12,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs-using-br/']
 
 以下示例将存储在 GCS 上指定路径的集群备份数据恢复到 TiDB 集群。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## 环境准备
 
 1. 下载文件 [`backup-rbac.yaml`](https://github.com/pingcap/tidb-operator/blob/master/manifests/backup/backup-rbac.yaml)，并执行以下命令在 `test2` 这个 namespace 中创建恢复所需的 RBAC 相关资源：

--- a/zh/restore-from-gcs-using-br.md
+++ b/zh/restore-from-gcs-using-br.md
@@ -14,7 +14,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs-using-br/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## 环境准备
 

--- a/zh/restore-from-gcs-using-br.md
+++ b/zh/restore-from-gcs-using-br.md
@@ -12,10 +12,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs-using-br/']
 
 以下示例将存储在 GCS 上指定路径的集群备份数据恢复到 TiDB 集群。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## 环境准备
 
 1. 下载文件 [`backup-rbac.yaml`](https://github.com/pingcap/tidb-operator/blob/master/manifests/backup/backup-rbac.yaml)，并执行以下命令在 `test2` 这个 namespace 中创建恢复所需的 RBAC 相关资源：
@@ -113,3 +109,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs-using-br/']
     ```shell
     kubectl create secret generic ${secret_name} --namespace=${namespace} --from-file=tls.crt=${cert_path} --from-file=tls.key=${key_path} --from-file=ca.crt=${ca_path}
     ```  
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/restore-from-gcs.md
+++ b/zh/restore-from-gcs.md
@@ -63,7 +63,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs/']
         projectId: ${project_id}
         secretName: gcs-secret
         path: gcs://${backup_path}
-      storageClassName: local-storage
+      # storageClassName: local-storage
       storageSize: 1Gi
     ```
 

--- a/zh/restore-from-gcs.md
+++ b/zh/restore-from-gcs.md
@@ -14,7 +14,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## 环境准备
 

--- a/zh/restore-from-gcs.md
+++ b/zh/restore-from-gcs.md
@@ -12,6 +12,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs/']
 
 以下示例将存储在 [Google Cloud Storage (GCS)](https://cloud.google.com/storage/docs/) 上指定路径上的集群备份数据恢复到 TiDB 集群。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## 环境准备
 
 1. 下载文件 [`backup-rbac.yaml`](https://github.com/pingcap/tidb-operator/blob/master/manifests/backup/backup-rbac.yaml)，并执行以下命令在 `test2` 这个 namespace 中创建恢复所需的 RBAC 相关资源：

--- a/zh/restore-from-gcs.md
+++ b/zh/restore-from-gcs.md
@@ -12,10 +12,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs/']
 
 以下示例将存储在 [Google Cloud Storage (GCS)](https://cloud.google.com/storage/docs/) 上指定路径上的集群备份数据恢复到 TiDB 集群。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## 环境准备
 
 1. 下载文件 [`backup-rbac.yaml`](https://github.com/pingcap/tidb-operator/blob/master/manifests/backup/backup-rbac.yaml)，并执行以下命令在 `test2` 这个 namespace 中创建恢复所需的 RBAC 相关资源：
@@ -90,3 +86,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-gcs/']
 > **注意：**
 >
 > TiDB Operator 会创建一个 PVC，用于数据恢复，备份数据会先从远端存储下载到 PV，然后再进行恢复。如果恢复完成后想要删掉这个 PVC，可以参考[删除资源](cheat-sheet.md#删除资源)先把恢复 Pod 删掉，然后再把 PVC 删掉。
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。

--- a/zh/restore-from-s3.md
+++ b/zh/restore-from-s3.md
@@ -10,6 +10,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
 
 本文使用的恢复方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。基于 Helm Charts 实现的备份和恢复方式可参考[基于 Helm Charts 实现的 TiDB 集群备份恢复](backup-and-restore-using-helm-charts.md)。
 
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+
 ## AWS 账号的三种权限授予方式
 
 如果使用 Amazon S3 来备份恢复集群，可以使用三种权限授予方式授予权限，参考[使用 BR 工具备份 AWS 上的 TiDB 集群](backup-to-aws-s3-using-br.md#aws-账号权限授予的三种方式)，使用 Ceph 作为后端存储测试备份恢复时，是通过 AccessKey 和 SecretKey 模式授权。

--- a/zh/restore-from-s3.md
+++ b/zh/restore-from-s3.md
@@ -70,7 +70,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
             endpoint: ${endpoint}
             secretName: s3-secret
             path: s3://${backup_path}
-          storageClassName: local-storage
+          # storageClassName: local-storage
           storageSize: 1Gi
         ```
 
@@ -103,7 +103,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
             region: ${region}
             secretName: s3-secret
             path: s3://${backup_path}
-          storageClassName: local-storage
+          # storageClassName: local-storage
           storageSize: 1Gi
         ```
 
@@ -137,7 +137,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
               provider: aws
               region: ${region}
               path: s3://${backup_path}
-            storageClassName: local-storage
+            # storageClassName: local-storage
             storageSize: 1Gi
         ```
 
@@ -170,7 +170,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
               provider: aws
               region: ${region}
               path: s3://${backup_path}
-            storageClassName: local-storage
+            # storageClassName: local-storage
             storageSize: 1Gi
         ```
 

--- a/zh/restore-from-s3.md
+++ b/zh/restore-from-s3.md
@@ -12,7 +12,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
 
 ## 故障诊断
 
-在使用过程中如果遇到问题，可以参考[故障诊断](#deploy-failures.md)。
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
 
 ## AWS 账号的三种权限授予方式
 

--- a/zh/restore-from-s3.md
+++ b/zh/restore-from-s3.md
@@ -10,10 +10,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
 
 本文使用的恢复方式基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。基于 Helm Charts 实现的备份和恢复方式可参考[基于 Helm Charts 实现的 TiDB 集群备份恢复](backup-and-restore-using-helm-charts.md)。
 
-## 故障诊断
-
-在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。
-
 ## AWS 账号的三种权限授予方式
 
 如果使用 Amazon S3 来备份恢复集群，可以使用三种权限授予方式授予权限，参考[使用 BR 工具备份 AWS 上的 TiDB 集群](backup-to-aws-s3-using-br.md#aws-账号权限授予的三种方式)，使用 Ceph 作为后端存储测试备份恢复时，是通过 AccessKey 和 SecretKey 模式授权。
@@ -197,3 +193,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-s3/']
 > **注意：**
 >
 > TiDB Operator 会创建一个 PVC，用于数据恢复，备份数据会先从远端存储下载到 PV，然后再进行恢复。如果恢复完成后想要删掉这个 PVC，可以参考[删除资源](cheat-sheet.md#删除资源)先把恢复 Pod 删掉，然后再把 PVC 删掉。
+
+## 故障诊断
+
+在使用过程中如果遇到问题，可以参考[故障诊断](deploy-failures.md)。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
Add debug section for backup restore part. Comment `storageClassName` in backup & restore to avoid mistake.

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
