### PR TITLE
zh: add example to access dashboard via NodePort Service

### DIFF
--- a/zh/access-dashboard.md
+++ b/zh/access-dashboard.md
@@ -158,7 +158,7 @@ metadata:
   namespace: ${namespace}
 spec:
   ports:
-  - name: ${cluster_name}-dashboard
+  - name: dashboard
     port: 10262
     protocol: TCP
     targetPort: 10262
@@ -169,9 +169,9 @@ spec:
     app.kubernetes.io/name: tidb-cluster
 ```
 
-当 `Service` 部署完成后，可以通过 <https://{host}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `nodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
+当 `Service` 部署完成后，可以通过 <https://{nodeIP}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `nodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
 
-需注意在使用了反向代理访问 TiDB Dashboard 的部署环境中，如果 PD Pod 数量超过 1 台，需要在 PD 配置中设置 `internal-proxy = true` 以保证重定向正确。
+需要注意如果 PD Pod 数量超过 1 ，需要在 TidbCluster CR 中设置 `spec.pd.enableDashboardInternalProxy: true` 以保证正常访问 TiDB Dashboard。
 
 ## 更新 TiDB 集群
 

--- a/zh/access-dashboard.md
+++ b/zh/access-dashboard.md
@@ -144,6 +144,35 @@ type: kubernetes.io/tls
 
 当 Ingress 部署完成以后，你就可以通过 <https://{host}/dashboard> 访问 TiDB Dashboard。
 
+### 使用 NodePort Service
+
+由于 `Ingress` 必需使用域名访问，在某些场景下可能难以使用，此时可以通过添加一个 `NodePort` 类型的 `Service` 来访问和使用 `TiDB Dashboard`.
+
+以下是一个使用 `NodePort` 类型的 `Service` 访问 `TiDB Dashboard` 的 yaml 文件例子。运行 `kubectl apply -f` 命令，将以下 yaml 文件部署到 Kubernetes 集群中。
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: access-dashboard
+  namespace: ${namespace}
+spec:
+  ports:
+  - name: ${cluster_name}-dashboard
+    port: 10262
+    protocol: TCP
+    targetPort: 10262
+  type: NodePort
+  selector:
+    app.kubernetes.io/component: discovery
+    app.kubernetes.io/instance: ${cluster_name}
+    app.kubernetes.io/name: tidb-cluster
+```
+
+当 `Service` 部署完成后，可以通过 <https://{host}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `nodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
+
+需注意在使用了反向代理访问 TiDB Dashboard 的部署环境中，如果 PD Pod 数量超过 1 台，需要在 PD 配置中设置 `internal-proxy = true` 以保证重定向正确。
+
 ## 更新 TiDB 集群
 
 如果你是在一个已经运行的 TiDB 集群上进行更新来开启快捷访问 `Dashboard` 功能，以下两项配置都需要更新:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
For those don't have available domain configured, an option to access Dashboard would be using `Service` with `NodePort` type. This PR adds an example for it.

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
