### PR TITLE
chore: remove copyable snippet code when generate PDF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run:
           name: "Lint"
           command: |
-            markdownlint .
+            markdownlint $(git diff-tree --name-only --no-commit-id -r upstream/master..HEAD -- '*.md' '*.yml' '*.yaml')
 
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,21 @@
 version: 2
 
 jobs:
+  lint:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+    working_directory: ~/pingcap/docs-tidb-operator
+    steps:
+      - checkout
+      - run:
+          name: "Install markdownlint"
+          command: |
+            sudo npm install -g markdownlint-cli@0.17.0
+      - run:
+          name: "Lint"
+          command: |
+            markdownlint .
+
   build:
     docker:
       - image: andelf/doc-build:0.1.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,6 @@
 version: 2
 
 jobs:
-  lint:
-    docker:
-      - image: circleci/ruby:2.4.1-node
-    working_directory: ~/pingcap/docs-tidb-operator
-    steps:
-      - checkout
-      - run:
-          name: "Install markdownlint"
-          command: |
-            sudo npm install -g markdownlint-cli@0.17.0
-      - run:
-          name: "Lint"
-          command: |
-            markdownlint .
-
   build:
     docker:
       - image: andelf/doc-build:0.1.9

--- a/scripts/merge_by_toc.py
+++ b/scripts/merge_by_toc.py
@@ -23,6 +23,8 @@ image_link_pattern = re.compile(r'!\[(.*?)\]\((.*?)\)')
 level_pattern = re.compile(r'(\s*[\-\+]+)\s')
 # match all headings
 heading_patthern = re.compile(r'(^#+|\n#+)\s')
+# match copyable snippet code
+copyable_snippet_pattern = re.compile(r'{{< copyable .* >}}')
 
 entry_file = lang + "TOC.md"
 
@@ -126,14 +128,10 @@ def replace_heading_func(diff_level=0):
 
     return replace_heading
 
-def replace_img_link(match):
-    full = match.group(0)
-    link_name = match.group(1)
-    link = match.group(2)
+# remove copyable snippet code
+def remove_copyable(match):
+    return ''
 
-    if link.endswith('.png'):
-        fname = os.path.basename(link)
-        return '![%s](./media/%s)' % (link_name, fname)
 
 # stage 3, concat files
 for type_, level, name in followups:
@@ -146,7 +144,7 @@ for type_, level, name in followups:
             with open(lang + name) as fp:
                 chapter = fp.read()
                 chapter = replace_link_wrap(chapter, name)
-                # chapter = image_link_pattern.sub(replace_img_link, chapter)
+                chapter = copyable_snippet_pattern.sub(remove_copyable, chapter)
 
                 # fix heading level
                 diff_level = level - heading_patthern.findall(chapter)[0].count('#')


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
Remove `copyable `code snippet when generate PDF.
<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [x] v1.0 (TiDB Operator 1.0 versions)

<!--**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-1.1** and **needs-cherry-pick-1.0**.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
