### PR TITLE
en: Add an example to access dashboard via NodePort Service

### DIFF
--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -158,7 +158,7 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 ### Use NodePort Service
 
-Because you must access `ingress` via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use TiDB Dashboard, you can add the `Service` of `NodePort` type.
+Because `ingress` must be accessed via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use TiDB Dashboard, you can add the `Service` of `NodePort` type.
 
 The following is an example of using the `Service` of `NodePort` type to access the `.yaml` file of TiDB Dashboard. To deploy the following `.yaml` file into the Kubernetes cluster, you can run the `kubectl apply -f` command:
 
@@ -181,7 +181,7 @@ spec:
     app.kubernetes.io/name: tidb-cluster
 ```
 
-After deploying the `Service`, you can access TiDB Dashboard via <https://{nodeIP}:{nodePort}/dashboard>, where Kubernetes randomly assigns the `NodePort` by default. You can also specify an available port in the `.yaml` file.
+After deploying the `Service`, you can access TiDB Dashboard via <https://{nodeIP}:{nodePort}/dashboard>. By default, `nodePort` is randomly assigned by Kubernetes. You can also specify an available port in the `.yaml` file.
 
 Note that if the number of `PD Pod` exceeds `1`, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
 

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -156,6 +156,35 @@ type: kubernetes.io/tls
 
 After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashboard.
 
+### Use NodePort Service
+
+You must access `ingress` via the domain name, but it might be difficult to use the domain name in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
+
+The following is an example of using the `Service` of `NodePort` type to access the yaml file of `TiDB Dashboard`. Run the `kubectl apply -f` command to deploy the following yaml file to the Kubernetes cluster.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: access-dashboard
+  namespace: ${namespace}
+spec:
+  ports:
+  - name: dashboard
+    port: 10262
+    protocol: TCP
+    targetPort: 10262
+  type: NodePort
+  selector:
+    app.kubernetes.io/component: discovery
+    app.kubernetes.io/instance: ${cluster_name}
+    app.kubernetes.io/name: tidb-cluster
+```
+
+After deploying the `Service`, you can access `TiDB Dashboard` via <https://{nodeIP}:{nodePort}/dashboard>, where Kubernetes randomly assigns the `nodePort` by default. You can also specify an available port in the yaml file.
+
+Note that if the number of `PD Pod` exceeds `1`, you need to set `spec.pd.enableDashboardInternalProxy: true` in `TidbCluster` CR to ensure normal access to TiDB Dashboard.
+
 ## Update the TiDB cluster
 
 To enable quick access to TiDB Dashboard by updating an existing TiDB cluster, update the following two configurations:

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -160,7 +160,7 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 Because `ingress` can only be accessed with a domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use TiDB Dashboard, you can add a `Service` of `NodePort` type.
 
-The following is an example `.yaml` using the `Service` of `NodePort` type to access the TiDB Dashboard. To deploy the following `.yaml` file into the Kubernetes cluster, you can run the `kubectl apply -f` command:
+The following is an `.yaml` example using the `Service` of `NodePort` type to access the TiDB Dashboard. To deploy the following `.yaml` file into the Kubernetes cluster, you can run the `kubectl apply -f` command:
 
 ```yaml
 apiVersion: v1
@@ -183,7 +183,7 @@ spec:
 
 After deploying the `Service`, you can access TiDB Dashboard via <https://{nodeIP}:{nodePort}/dashboard>. By default, `nodePort` is randomly assigned by Kubernetes. You can also specify an available port in the `.yaml` file.
 
-Note that if there is more than 1 PD `Pod`s in the cluster, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
+Note that if there is more than one PD `Pod` in the cluster, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
 
 ## Update the TiDB cluster
 

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -158,9 +158,9 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 ### Use NodePort Service
 
-Because `ingress` must be accessed via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use TiDB Dashboard, you can add the `Service` of `NodePort` type.
+Because `ingress` can only be accessed with a domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use TiDB Dashboard, you can add a `Service` of `NodePort` type.
 
-The following is an example of using the `Service` of `NodePort` type to access the `.yaml` file of TiDB Dashboard. To deploy the following `.yaml` file into the Kubernetes cluster, you can run the `kubectl apply -f` command:
+The following is an example `.yaml` using the `Service` of `NodePort` type to access the TiDB Dashboard. To deploy the following `.yaml` file into the Kubernetes cluster, you can run the `kubectl apply -f` command:
 
 ```yaml
 apiVersion: v1
@@ -183,7 +183,7 @@ spec:
 
 After deploying the `Service`, you can access TiDB Dashboard via <https://{nodeIP}:{nodePort}/dashboard>. By default, `nodePort` is randomly assigned by Kubernetes. You can also specify an available port in the `.yaml` file.
 
-Note that if the number of `PD Pod` exceeds `1`, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
+Note that if there is more than 1 PD `Pod`s in the cluster, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
 
 ## Update the TiDB cluster
 

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -160,7 +160,7 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 Because you must access `ingress` via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
 
-The following is an example of using the `Service` of `NodePort` type to access the yaml file of `TiDB Dashboard`. To deploy the following yaml file to the Kubernetes cluster, you can run the `kubectl apply -f` command:
+The following is an example of using the `Service` of `NodePort` type to access the `.yaml` file of `TiDB Dashboard`. To deploy the following `.yaml` file to the Kubernetes cluster, you can run the `kubectl apply -f` command:
 
 ```yaml
 apiVersion: v1
@@ -181,9 +181,9 @@ spec:
     app.kubernetes.io/name: tidb-cluster
 ```
 
-After deploying the `Service`, you can access `TiDB Dashboard` via <https://{nodeIP}:{nodePort}/dashboard>, where Kubernetes randomly assigns the `nodePort` by default. You can also specify an available port in the yaml file.
+After deploying the `Service`, you can access `TiDB Dashboard` via <https://{nodeIP}:{nodePort}/dashboard>, where Kubernetes randomly assigns the `NodePort` by default. You can also specify an available port in the `.yaml` file.
 
-Note that if the number of `PD Pod` exceeds `1`, you need to set `spec.pd.enableDashboardInternalProxy: true` in `TidbCluster` CR to ensure normal access to TiDB Dashboard.
+Note that if the number of `PD Pod` exceeds `1`, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
 
 ## Update the TiDB cluster
 

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -158,7 +158,7 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 ### Use NodePort Service
 
-You must access `ingress` via the domain name, but it might be difficult to use the domain name in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
+Because you must access `ingress` via the domain name, and it might be difficult to use `ingress` in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
 
 The following is an example of using the `Service` of `NodePort` type to access the yaml file of `TiDB Dashboard`. Run the `kubectl apply -f` command to deploy the following yaml file to the Kubernetes cluster.
 

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -158,9 +158,9 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 ### Use NodePort Service
 
-Because you must access `ingress` via the domain name, and it might be difficult to use `ingress` in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
+Because you must access `ingress` via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
 
-The following is an example of using the `Service` of `NodePort` type to access the yaml file of `TiDB Dashboard`. Run the `kubectl apply -f` command to deploy the following yaml file to the Kubernetes cluster.
+The following is an example of using the `Service` of `NodePort` type to access the yaml file of `TiDB Dashboard`. To deploy the following yaml file to the Kubernetes cluster, you can run the `kubectl apply -f` command:
 
 ```yaml
 apiVersion: v1

--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -158,9 +158,9 @@ After Ingress is deployed, visit <https://{host}/dashboard> to access TiDB Dashb
 
 ### Use NodePort Service
 
-Because you must access `ingress` via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use `TiDB Dashboard`, you can add the `Service` of `NodePort` type.
+Because you must access `ingress` via the domain name, it might be difficult to use `ingress` in some scenarios. In this case, to access and use TiDB Dashboard, you can add the `Service` of `NodePort` type.
 
-The following is an example of using the `Service` of `NodePort` type to access the `.yaml` file of `TiDB Dashboard`. To deploy the following `.yaml` file to the Kubernetes cluster, you can run the `kubectl apply -f` command:
+The following is an example of using the `Service` of `NodePort` type to access the `.yaml` file of TiDB Dashboard. To deploy the following `.yaml` file into the Kubernetes cluster, you can run the `kubectl apply -f` command:
 
 ```yaml
 apiVersion: v1
@@ -181,7 +181,7 @@ spec:
     app.kubernetes.io/name: tidb-cluster
 ```
 
-After deploying the `Service`, you can access `TiDB Dashboard` via <https://{nodeIP}:{nodePort}/dashboard>, where Kubernetes randomly assigns the `NodePort` by default. You can also specify an available port in the `.yaml` file.
+After deploying the `Service`, you can access TiDB Dashboard via <https://{nodeIP}:{nodePort}/dashboard>, where Kubernetes randomly assigns the `NodePort` by default. You can also specify an available port in the `.yaml` file.
 
 Note that if the number of `PD Pod` exceeds `1`, you need to set `spec.pd.enableDashboardInternalProxy: true` in the `TidbCluster` CR to ensure normal access to TiDB Dashboard.
 

--- a/zh/access-dashboard.md
+++ b/zh/access-dashboard.md
@@ -169,7 +169,7 @@ spec:
     app.kubernetes.io/name: tidb-cluster
 ```
 
-当 `Service` 部署完成后，可以通过 <https://{nodeIP}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `NodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
+当 `Service` 部署完成后，可以通过 <https://{nodeIP}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `nodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
 
 需要注意如果 PD Pod 数量超过 1 ，需要在 TidbCluster CR 中设置 `spec.pd.enableDashboardInternalProxy: true` 以保证正常访问 TiDB Dashboard。
 

--- a/zh/access-dashboard.md
+++ b/zh/access-dashboard.md
@@ -169,7 +169,7 @@ spec:
     app.kubernetes.io/name: tidb-cluster
 ```
 
-当 `Service` 部署完成后，可以通过 <https://{nodeIP}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `nodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
+当 `Service` 部署完成后，可以通过 <https://{nodeIP}:{nodePort}/dashboard> 访问 TiDB Dashboard, 其中 `NodePort` 默认由 Kubernetes 随机分配，也可以在 yaml 文件中指定一个可用的端口。
 
 需要注意如果 PD Pod 数量超过 1 ，需要在 TidbCluster CR 中设置 `spec.pd.enableDashboardInternalProxy: true` 以保证正常访问 TiDB Dashboard。
 


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
For those don't have available domain configured, an option to access Dashboard would be using `Service` with `NodePort` type.
### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here--> https://github.com/pingcap/docs-tidb-operator/pull/850
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
