### PR TITLE
en, zh: v1.1 abandon "tkctl" tool

### DIFF
--- a/en/maintain-a-kubernetes-node.md
+++ b/en/maintain-a-kubernetes-node.md
@@ -86,14 +86,6 @@ Migrating PD and TiDB instances from a node is relatively fast, so you can proac
     watch kubectl get -n $namespace pod -o wide
     ```
 
-    Or:
-
-    {{< copyable "shell-regular" >}}
-
-    ```sql
-    watch tkctl get all
-    ```
-
     When you confirm that all Pods are running normally, then you have successfully finished the maintenance task.
 
 ## Maintain nodes that hold TiKV instances

--- a/en/tips.md
+++ b/en/tips.md
@@ -10,9 +10,9 @@ This document describes the commonly used tips for troubleshooting TiDB in Kuber
 
 ## Use the diagnostic mode
 
-When a Pod is in the `CrashLoopBackoff` state, the containers in the Pod exit continually. As a result, you cannot use `kubectl exec` or `tkctl debug` normally, making it inconvenient to diagnose issues.
+When a Pod is in the `CrashLoopBackoff` state, the containers in the Pod exit continually. As a result, you cannot use `kubectl exec`normally, making it inconvenient to diagnose issues.
 
-To solve this problem, TiDB Operator provides the Pod diagnostic mode for PD, TiKV, and TiDB components. In this mode, the containers in the Pod hang directly after they are started, and will not repeatedly crash. Then you can use `kubectl exec` or `tkctl debug` to connect to the Pod containers for diagnosis.
+To solve this problem, TiDB Operator provides the Pod diagnostic mode for PD, TiKV, and TiDB components. In this mode, the containers in the Pod hang directly after they are started, and will not repeatedly crash. Then you can use `kubectl exec` to connect to the Pod containers for diagnosis.
 
 To use the diagnostic mode for troubleshooting:
 

--- a/en/tips.md
+++ b/en/tips.md
@@ -10,7 +10,7 @@ This document describes the commonly used tips for troubleshooting TiDB in Kuber
 
 ## Use the diagnostic mode
 
-When a Pod is in the `CrashLoopBackoff` state, the containers in the Pod exit continually. As a result, you cannot use `kubectl exec`normally, making it inconvenient to diagnose issues.
+When a Pod is in the `CrashLoopBackoff` state, the containers in the Pod exit continually. As a result, you cannot use `kubectl exec` normally, making it inconvenient to diagnose issues.
 
 To solve this problem, TiDB Operator provides the Pod diagnostic mode for PD, TiKV, and TiDB components. In this mode, the containers in the Pod hang directly after they are started, and will not repeatedly crash. Then you can use `kubectl exec` to connect to the Pod containers for diagnosis.
 

--- a/en/use-tkctl.md
+++ b/en/use-tkctl.md
@@ -10,7 +10,7 @@ TiDB Kubernetes Control (`tkctl`) is a command line utility that is used for TiD
 
 > **Note:**
 >
-> PingCAP is no longer maintaining `tkctl` from v1.1.x, some of the following functions may not be usable, please use the equivalant `kubectl` commands directly.
+> PingCAP is no longer maintaining `tkctl` from v1.1.x, some of the following functions may not be usable, please use the equivalent `kubectl` commands directly.
 
 ## Installation
 

--- a/en/use-tkctl.md
+++ b/en/use-tkctl.md
@@ -8,6 +8,10 @@ aliases: ['/docs/tidb-in-kubernetes/stable/use-tkctl/','/docs/tidb-in-kubernetes
 
 TiDB Kubernetes Control (`tkctl`) is a command line utility that is used for TiDB Operator to maintain and diagnose the TiDB cluster in Kubernetes.
 
+> **Note:**
+>
+> PingCAP is no longer maintaining `tkctl` from v1.1.x, some of the following functions may not be usable, please use the equivalant `kubectl` commands directly.
+
 ## Installation
 
 To install `tkctl`, you can download the pre-built binary or build `tkctl` from source.

--- a/zh/maintain-a-kubernetes-node.md
+++ b/zh/maintain-a-kubernetes-node.md
@@ -86,7 +86,6 @@ PD 和 TiDB 实例的迁移较快，可以采取主动驱逐实例到其它节�
     watch kubectl get -n $namespace pod -o wide
     ```
 
-
     Pod 恢复正常运行后，操作结束。
 
 ## 维护 TiKV 实例所在节点

--- a/zh/maintain-a-kubernetes-node.md
+++ b/zh/maintain-a-kubernetes-node.md
@@ -86,13 +86,6 @@ PD 和 TiDB 实例的迁移较快，可以采取主动驱逐实例到其它节�
     watch kubectl get -n $namespace pod -o wide
     ```
 
-    或者：
-
-    {{< copyable "shell-regular" >}}
-
-    ```sql
-    watch tkctl get all
-    ```
 
     Pod 恢复正常运行后，操作结束。
 

--- a/zh/tips.md
+++ b/zh/tips.md
@@ -10,7 +10,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/stable/tips/','/docs-cn/tidb-in-kubernete
 
 ## 诊断模式
 
-当 Pod 处于 `CrashLoopBackoff` 状态时，Pod 内容器不断退出，导致无法正常使用 `kubectl exec` 或 `tkctl debug`，给诊断带来不便。为了解决这个问题，TiDB in Kubernetes 提供了 PD/TiKV/TiDB Pod 诊断模式。在诊断模式下，Pod 内的容器启动后会直接挂起，不会再进入重复 Crash 的状态，此时，便可以通过 `kubectl exec` 或 `tkctl debug` 连接 Pod 内的容器进行诊断。
+当 Pod 处于 `CrashLoopBackoff` 状态时，Pod 内容器不断退出，导致无法正常使用 `kubectl exec`，给诊断带来不便。为了解决这个问题，TiDB in Kubernetes 提供了 PD/TiKV/TiDB Pod 诊断模式。在诊断模式下，Pod 内的容器启动后会直接挂起，不会再进入重复 Crash 的状态，此时，便可以通过 `kubectl exec` 连接 Pod 内的容器进行诊断。
 
 操作方式：
 

--- a/zh/use-tkctl.md
+++ b/zh/use-tkctl.md
@@ -10,7 +10,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/stable/use-tkctl/','/docs-cn/tidb-in-kube
 
 > **注意：**
 >
-> PingCAP从v1.1.x开始不再维护`tkctl`，以下部分功能可能不可用，请直接使用等价的`kubectl`命令
+> PingCAP 从 v1.1.x 开始不再维护 `tkctl`，以下部分功能可能不可用，请直接使用对应的 `kubectl` 命令。
 
 ## 安装
 

--- a/zh/use-tkctl.md
+++ b/zh/use-tkctl.md
@@ -8,6 +8,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/stable/use-tkctl/','/docs-cn/tidb-in-kube
 
 `tkctl` (TiDB Kubernetes Control) 是为 TiDB in Kubernetes 设计的命令行工具，用于运维集群和诊断集群问题。
 
+> **注意：**
+>
+> PingCAP从v1.1.x开始不再维护`tkctl`，以下部分功能可能不可用，请直接使用等价的`kubectl`命令
+
 ## 安装
 
 安装 `tkctl` 时，可以直接下载预编译的可执行文件，也可以自行从源码进行编译。


### PR DESCRIPTION
- [x] en,zh: Marked as deprecated in the introduction of `tkctl`
- [x] en,zh: Delete the `tkctl` commands in "tips.md" and "maintain-a-kubernetes-node.md"
- [ ] en,zh: Delete the `tkctl` commands in "network-issues.md"
**why the third target is not done?**
The origin docs didn't offer any alternative `kubectl` commands ("network-issues.md") and I don't know how to get the result in the docs.

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
The `tkctl` tool is no longer usable, update the relevant docs.
<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- Other reference link(s): https://github.com/pingcap/docs-tidb-operator/issues/908
### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
