### PR TITLE
zh, en: update the CA expiration date to 10 years

### DIFF
--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -88,6 +88,9 @@ This section describes how to issue certificates using two methods: `cfssl` and 
     cat << EOF > ca-csr.json
     {
         "CN": "TiDB",
+        "CA": {
+            "expiry": "87600h"
+        },
         "key": {
             "algo": "rsa",
             "size": 2048
@@ -570,6 +573,8 @@ This section describes how to issue certificates using two methods: `cfssl` and 
       secretName: ${cluster_name}-ca-secret
       commonName: "TiDB"
       isCA: true
+      duration: 87600h # 10yrs
+      renewBefore: 720h # 30d
       issuerRef:
         name: ${cluster_name}-selfsigned-ca-issuer
         kind: Issuer

--- a/en/enable-tls-for-dm.md
+++ b/en/enable-tls-for-dm.md
@@ -84,6 +84,9 @@ This section describes how to issue certificates using two methods: `cfssl` and 
     cat << EOF > ca-csr.json
     {
         "CN": "TiDB",
+        "CA": {
+            "expiry": "87600h"
+        },
         "key": {
             "algo": "rsa",
             "size": 2048
@@ -294,6 +297,8 @@ This section describes how to issue certificates using two methods: `cfssl` and 
       secretName: ${cluster_name}-ca-secret
       commonName: "TiDB"
       isCA: true
+      duration: 87600h # 10yrs
+      renewBefore: 720h # 30d
       issuerRef:
         name: ${cluster_name}-selfsigned-ca-issuer
         kind: Issuer

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -79,6 +79,9 @@ This section describes how to issue certificates for the TiDB cluster using two 
     ```json
     {
         "CN": "TiDB Server",
+        "CA": {
+            "expiry": "87600h"
+        },
         "key": {
             "algo": "rsa",
             "size": 2048
@@ -228,6 +231,8 @@ You can generate multiple sets of client-side certificates. At least one set of 
       secretName: ${cluster_name}-ca-secret
       commonName: "TiDB CA"
       isCA: true
+      duration: 87600h # 10yrs
+      renewBefore: 720h # 30d
       issuerRef:
         name: ${cluster_name}-selfsigned-ca-issuer
         kind: Issuer

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -82,6 +82,9 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
     cat << EOF > ca-csr.json
     {
         "CN": "TiDB",
+        "CA": {
+            "expiry": "87600h"
+        },
         "key": {
             "algo": "rsa",
             "size": 2048
@@ -654,6 +657,8 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
       secretName: ${cluster_name}-ca-secret
       commonName: "TiDB"
       isCA: true
+      duration: 87600h # 10yrs
+      renewBefore: 720h # 30d
       issuerRef:
         name: ${cluster_name}-selfsigned-ca-issuer
         kind: Issuer

--- a/zh/enable-tls-for-dm.md
+++ b/zh/enable-tls-for-dm.md
@@ -80,6 +80,9 @@ TiDB Operator 从 v1.2 开始已经支持为 Kubernetes 上 DM 集群组件间�
     cat << EOF > ca-csr.json
     {
         "CN": "TiDB",
+        "CA": {
+            "expiry": "87600h"
+        },
         "key": {
             "algo": "rsa",
             "size": 2048
@@ -285,6 +288,8 @@ TiDB Operator 从 v1.2 开始已经支持为 Kubernetes 上 DM 集群组件间�
       secretName: ${cluster_name}-ca-secret
       commonName: "TiDB"
       isCA: true
+      duration: 87600h # 10yrs
+      renewBefore: 720h # 30d
       issuerRef:
         name: ${cluster_name}-selfsigned-ca-issuer
         kind: Issuer

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -73,6 +73,9 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
     ``` json
     {
         "CN": "TiDB Server",
+        "CA": {
+            "expiry": "87600h"
+        },
         "key": {
             "algo": "rsa",
             "size": 2048
@@ -222,6 +225,8 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
       secretName: ${cluster_name}-ca-secret
       commonName: "TiDB CA"
       isCA: true
+      duration: 87600h # 10yrs
+      renewBefore: 720h # 30d
       issuerRef:
         name: ${cluster_name}-selfsigned-ca-issuer
         kind: Issuer


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

update the CA expiration date to 10 years for cfssl (default 5 years) and cert-manager (default 90 days)

close #980

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
