### PR TITLE
zh,en: Use drop-in directory to configure docker service

### DIFF
--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -214,6 +214,14 @@ After the installation, take the following steps:
     >
     > `LimitNOFILE` must be explicitly set to `1048576` or a greater value, other than `infinity` by default. Due to [a bug of `systemd`](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186), the `infinity` value in some versions of `systemd` is `65536`.
 
+    4. Reload configuration.
+
+       {{< copyable "shell-regular" >}}
+
+       ```shell
+       systemctl daemon-reload && systemctl restart docker
+       ```
+
 ## Kubernetes service
 
 To deploy a multi-master, highly available cluster, see [Kubernetes documentation](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/).

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -194,7 +194,7 @@ After the installation, take the following steps:
         {{< copyable "shell-regular" >}}
 
         ```shell
-        sudo mkdir -p /etc/systemd/system/docker.service.d
+        mkdir -p /etc/systemd/system/docker.service.d
         ```
 
     2. Create a file named as `/etc/systemd/system/docker.service.d/limit-nofile.conf`, and configure the value of the  `LimitNOFILE` parameter. The value must be a number equal to or greater than `1048576`.

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -191,36 +191,34 @@ After the installation, take the following steps:
 
     1. Create the systemd drop-in directory for the docker service:
 
-    {{< copyable "shell-regular" >}}
+        {{< copyable "shell-regular" >}}
 
-    ```shell
-    sudo mkdir -p /etc/systemd/system/docker.service.d
-    ```
+        ```shell
+        sudo mkdir -p /etc/systemd/system/docker.service.d
+        ```
 
-    2. Create a file named as `/etc/systemd/system/docker.service.d/limit-nofile.conf`, and add the configuration of the `LimitNOFILE` parameter to the file:
+    2. Create a file named as `/etc/systemd/system/docker.service.d/limit-nofile.conf`, and configure the value of the  `LimitNOFILE` parameter. The value must be a number equal to or greater than `1048576`.
 
-    {{< copyable "shell-regular" >}}
+        {{< copyable "shell-regular" >}}
 
-    ```shell
-    cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
-    [Service]
-    LimitNOFILE=1048576
-    EOF
-    ```
+        ```shell
+        cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
+        [Service]
+        LimitNOFILE=1048576
+        EOF
+        ```
 
-    3. Configure the value of the  `LimitNOFILE` parameter. The value must be a number equal to or greater than `1048576`.
+        > **Note:**
+        >
+        > DO NOT set the value of `LimitNOFILE` to `infinity`. Due to [a bug of `systemd`](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186), the `infinity` value of `systemd` in some versions is `65536`.
 
-    > **Note:**
-    >
-    > DO NOT set the value of `LimitNOFILE` to `infinity`. Due to [a bug of `systemd`](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186), the `infinity` value of `systemd` in some versions is `65536`.
+    3. Reload configuration.
 
-    4. Reload configuration.
+        {{< copyable "shell-regular" >}}
 
-       {{< copyable "shell-regular" >}}
-
-       ```shell
-       systemctl daemon-reload && systemctl restart docker
-       ```
+        ```shell
+        systemctl daemon-reload && systemctl restart docker
+        ```
 
 ## Kubernetes service
 

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -189,12 +189,22 @@ After the installation, take the following steps:
 
 2. Set `ulimit` for the Docker daemon:
 
-    Edit the file:
+    create systemd drop-in directory for the docker service:
+
+    {{< copyable "shell-regular" >}}
+    ```shell
+    sudo mkdir -p /etc/systemd/system/docker.service.d
+    ```
+
+    create a file named `/etc/systemd/system/docker.service.d/limit-nofile.conf` that set the `LimitNOFILE` parameter：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    vim /etc/systemd/system/docker.service
+    cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
+    [Service]
+    LimitNOFILE=1048576
+    EOF
     ```
 
     Set `LimitNOFILE` to `1048576`. Here, you can set `LimitNOFILE` to a number equal to or greater than `1048576`.

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -189,7 +189,7 @@ After the installation, take the following steps:
 
 2. Set `ulimit` for the Docker daemon:
 
-    create systemd drop-in directory for the docker service:
+    1. Create the systemd drop-in directory for the docker service:
 
     {{< copyable "shell-regular" >}}
 
@@ -197,7 +197,7 @@ After the installation, take the following steps:
     sudo mkdir -p /etc/systemd/system/docker.service.d
     ```
 
-    create a file named `/etc/systemd/system/docker.service.d/limit-nofile.conf` that set the `LimitNOFILE` parameter：
+    2. Create a file named as `/etc/systemd/system/docker.service.d/limit-nofile.conf`, and add the configuration of the `LimitNOFILE` parameter to the file:
 
     {{< copyable "shell-regular" >}}
 
@@ -208,7 +208,7 @@ After the installation, take the following steps:
     EOF
     ```
 
-    Set `LimitNOFILE` to `1048576`. Here, you can set `LimitNOFILE` to a number equal to or greater than `1048576`.
+    3. Configure the value of the  `LimitNOFILE` parameter. The value must be a number equal to or greater than `1048576`.
 
     > **Note:**
     >

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -212,7 +212,7 @@ After the installation, take the following steps:
 
     > **Note:**
     >
-    > `LimitNOFILE` must be explicitly set to `1048576` or a greater value, other than `infinity` by default. Due to [a bug of `systemd`](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186), the `infinity` value in some versions of `systemd` is `65536`.
+    > DO NOT set the value of `LimitNOFILE` to `infinity`. Due to [a bug of `systemd`](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186), the `infinity` value of `systemd` in some versions is `65536`.
 
     4. Reload configuration.
 

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -192,6 +192,7 @@ After the installation, take the following steps:
     create systemd drop-in directory for the docker service:
 
     {{< copyable "shell-regular" >}}
+
     ```shell
     sudo mkdir -p /etc/systemd/system/docker.service.d
     ```

--- a/en/prerequisites.md
+++ b/en/prerequisites.md
@@ -212,7 +212,7 @@ After the installation, take the following steps:
         >
         > DO NOT set the value of `LimitNOFILE` to `infinity`. Due to [a bug of `systemd`](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186), the `infinity` value of `systemd` in some versions is `65536`.
 
-    3. Reload configuration.
+    3. Reload the configuration.
 
         {{< copyable "shell-regular" >}}
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -191,12 +191,23 @@ sysctl --system
 
 2. 设置 Docker daemon 的 ulimit。
 
-    编辑文件：
+    创建 docker service 的 systemd drop-in 目录 `/etc/systemd/system/docker.service.d`：
+
+    {{< copyable "shell-regular" >}}
+    ```shell
+    sudo mkdir -p /etc/systemd/system/docker.service.d
+    ```
+
+
+    创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并添加 `LimitNOFILE` 参数：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    vim /etc/systemd/system/docker.service
+    cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
+    [Service]
+    LimitNOFILE=1048576
+    EOF
     ```
 
     设置 `LimitNOFILE=1048576`，这里设置 `LimitNOFILE` 为大于等于 `1048576` 的数字即可。

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -193,15 +193,15 @@ sysctl --system
 
     1. 创建 docker service 的 systemd drop-in 目录 `/etc/systemd/system/docker.service.d`：
 
-       {{< copyable "shell-regular" >}}
+        {{< copyable "shell-regular" >}}
 
         ```shell
         sudo mkdir -p /etc/systemd/system/docker.service.d
         ```
 
-    2. 创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并添加 `LimitNOFILE` 参数：
+    2. 创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并配置 `LimitNOFILE` 参数的值，取值范围为大于等于 `1048576` 的数字即可。
 
-       {{< copyable "shell-regular" >}}
+        {{< copyable "shell-regular" >}}
 
         ```shell
         cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
@@ -210,19 +210,17 @@ sysctl --system
         EOF
         ```
 
-    3. 配置 `LimitNOFILE` 参数的值。取值范围为大于等于 `1048576` 的数字即可。
+        > **注意：**
+        >
+        > 请勿将 `LimitNOFILE` 的值设置为 `infinity`。由于 [`systemd` 的 bug](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186)，`infinity` 在 `systemd` 某些版本中指的是 `65536`。
 
-    > **注意：**
-    >
-    > 请勿将 `LimitNOFILE` 的值设置为 `infinity`。由于 [`systemd` 的 bug](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186)，`infinity` 在 `systemd` 某些版本中指的是 `65536`。
+    3. 重新加载配置。
 
-    4. 重新加载配置。
+        {{< copyable "shell-regular" >}}
 
-       {{< copyable "shell-regular" >}}
-
-       ```shell
-       systemctl daemon-reload && systemctl restart docker
-       ```
+        ```shell
+        systemctl daemon-reload && systemctl restart docker
+        ```
 
 ## Kubernetes 服务
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -196,7 +196,7 @@ sysctl --system
         {{< copyable "shell-regular" >}}
 
         ```shell
-        sudo mkdir -p /etc/systemd/system/docker.service.d
+        mkdir -p /etc/systemd/system/docker.service.d
         ```
 
     2. 创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并配置 `LimitNOFILE` 参数的值，取值范围为大于等于 `1048576` 的数字即可。

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -194,10 +194,10 @@ sysctl --system
     创建 docker service 的 systemd drop-in 目录 `/etc/systemd/system/docker.service.d`：
 
     {{< copyable "shell-regular" >}}
+
     ```shell
     sudo mkdir -p /etc/systemd/system/docker.service.d
     ```
-
 
     创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并添加 `LimitNOFILE` 参数：
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -193,22 +193,22 @@ sysctl --system
 
     1. 创建 docker service 的 systemd drop-in 目录 `/etc/systemd/system/docker.service.d`：
 
-    {{< copyable "shell-regular" >}}
+       {{< copyable "shell-regular" >}}
 
-    ```shell
-    sudo mkdir -p /etc/systemd/system/docker.service.d
-    ```
+        ```shell
+        sudo mkdir -p /etc/systemd/system/docker.service.d
+        ```
 
     2. 创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并添加 `LimitNOFILE` 参数：
 
-    {{< copyable "shell-regular" >}}
+       {{< copyable "shell-regular" >}}
 
-    ```shell
-    cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
-    [Service]
-    LimitNOFILE=1048576
-    EOF
-    ```
+        ```shell
+        cat > /etc/systemd/system/docker.service.d/limit-nofile.conf <<EOF
+        [Service]
+        LimitNOFILE=1048576
+        EOF
+        ```
 
     3. 配置 `LimitNOFILE` 参数的值。取值范围为大于等于 `1048576` 的数字即可。
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -214,7 +214,7 @@ sysctl --system
 
     > **注意：**
     >
-    > `LimitNOFILE` 需要显式设置为 `1048576` 或者更大，而不是默认的 `infinity`，由于 [`systemd` 的 bug](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186)，`infinity` 在 `systemd` 某些版本中指的是 `65536`。
+    > 请勿将 `LimitNOFILE` 的值设置为 `infinity`。由于 [`systemd` 的 bug](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186)，`infinity` 在 `systemd` 某些版本中指的是 `65536`。
 
     4. 重新加载配置。
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -216,6 +216,14 @@ sysctl --system
     >
     > `LimitNOFILE` 需要显式设置为 `1048576` 或者更大，而不是默认的 `infinity`，由于 [`systemd` 的 bug](https://github.com/systemd/systemd/commit/6385cb31ef443be3e0d6da5ea62a267a49174688#diff-108b33cf1bd0765d116dd401376ca356L1186)，`infinity` 在 `systemd` 某些版本中指的是 `65536`。
 
+    4. 重新加载配置。
+
+       {{< copyable "shell-regular" >}}
+
+       ```shell
+       systemctl daemon-reload && systemctl restart docker
+       ```
+
 ## Kubernetes 服务
 
 参考 [Kubernetes 官方文档](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/high-availability/)，部署一套多 Master 节点高可用集群。

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -191,7 +191,7 @@ sysctl --system
 
 2. 设置 Docker daemon 的 ulimit。
 
-    创建 docker service 的 systemd drop-in 目录 `/etc/systemd/system/docker.service.d`：
+    1. 创建 docker service 的 systemd drop-in 目录 `/etc/systemd/system/docker.service.d`：
 
     {{< copyable "shell-regular" >}}
 
@@ -199,7 +199,7 @@ sysctl --system
     sudo mkdir -p /etc/systemd/system/docker.service.d
     ```
 
-    创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并添加 `LimitNOFILE` 参数：
+    2. 创建 `/etc/systemd/system/docker.service.d/limit-nofile.conf` 文件，并添加 `LimitNOFILE` 参数：
 
     {{< copyable "shell-regular" >}}
 
@@ -210,7 +210,7 @@ sysctl --system
     EOF
     ```
 
-    设置 `LimitNOFILE=1048576`，这里设置 `LimitNOFILE` 为大于等于 `1048576` 的数字即可。
+    3. 配置 `LimitNOFILE` 参数的值。取值范围为大于等于 `1048576` 的数字即可。
 
     > **注意：**
     >


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added, or deleted? (Required)

Use drop-in directory to configure docker service.

Closes #1257 

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
