### PR TITLE
en, zh: Use the recommended method to enter a TiCDC Pod

### DIFF
--- a/en/deploy-ticdc.md
+++ b/en/deploy-ticdc.md
@@ -53,7 +53,7 @@ To deploy TiCDC when deploying the TiDB cluster, refer to [Deploy TiDB in Genera
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl exec -it ${pod_name} -n ${namespace} sh
+    kubectl exec -it ${pod_name} -n ${namespace} -- sh
     ```
 
 4. [Manage the cluster and data replication tasks](https://pingcap.com/docs/stable/ticdc/manage-ticdc/#use-cdc-cli-to-manage-cluster-status-and-data-replication-task) by using `cdc cli`.

--- a/zh/deploy-ticdc.md
+++ b/zh/deploy-ticdc.md
@@ -50,7 +50,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-ticdc/']
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl exec -it ${pod_name} -n ${namespace} sh
+    kubectl exec -it ${pod_name} -n ${namespace} -- sh
     ```
 
 4. 然后通过 `cdc cli` 进行[管理集群和同步任务](https://pingcap.com/docs-cn/stable/ticdc/manage-ticdc/)。


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)
Use the recommended method to enter a TiCDC Pod.

> kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.


<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
