### PR TITLE
en, zh: Bump Operator to v1.2.1

### DIFF
--- a/en/cheat-sheet.md
+++ b/en/cheat-sheet.md
@@ -485,7 +485,7 @@ For example:
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm inspect values pingcap/tidb-operator --version=v1.2.0 > values-tidb-operator.yaml
+helm inspect values pingcap/tidb-operator --version=v1.2.1 > values-tidb-operator.yaml
 ```
 
 ### Deploy using Helm chart
@@ -501,7 +501,7 @@ For example:
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.2.0 -f values-tidb-operator.yaml
+helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.2.1 -f values-tidb-operator.yaml
 ```
 
 ### View the deployed Helm release
@@ -525,7 +525,7 @@ For example:
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.0 -f values-tidb-operator.yaml
+helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.1 -f values-tidb-operator.yaml
 ```
 
 ### Delete Helm release

--- a/en/deploy-on-alibaba-cloud.md
+++ b/en/deploy-on-alibaba-cloud.md
@@ -89,7 +89,7 @@ All the instances except ACK mandatory workers are deployed across availability 
     tikv_count = 3
     tidb_count = 2
     pd_count = 3
-    operator_version = "v1.2.0"
+    operator_version = "v1.2.1"
     ```
 
     * To deploy TiFlash in the cluster, set `create_tiflash_node_pool = true` in `terraform.tfvars`. You can also configure the node count and instance type of the TiFlash node pool by modifying `tiflash_count` and `tiflash_instance_type`. By default, the value of `tiflash_count` is `2`, and the value of `tiflash_instance_type` is `ecs.i2.2xlarge`.

--- a/en/deploy-tidb-from-kubernetes-gke.md
+++ b/en/deploy-tidb-from-kubernetes-gke.md
@@ -105,7 +105,7 @@ After the `TidbCluster` CRD is created, install TiDB Operator in your Kubernetes
 
 ```shell
 kubectl create namespace tidb-admin
-helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.0
+helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.1
 kubectl get po -n tidb-admin -l app.kubernetes.io/name=tidb-operator
 ```
 

--- a/en/deploy-tidb-operator.md
+++ b/en/deploy-tidb-operator.md
@@ -99,7 +99,7 @@ After creating CRDs in the step above, there are two methods to deploy TiDB Oper
 
     > **Note:**
     >
-    > `${chart_version}` represents the chart version of TiDB Operator. For example, `v1.2.0`. You can view the currently supported versions by running the `helm search repo -l tidb-operator` command.
+    > `${chart_version}` represents the chart version of TiDB Operator. For example, `v1.2.1`. You can view the currently supported versions by running the `helm search repo -l tidb-operator` command.
 
 2. Configure TiDB Operator
 
@@ -149,15 +149,15 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    wget http://charts.pingcap.org/tidb-operator-v1.2.0.tgz
+    wget http://charts.pingcap.org/tidb-operator-v1.2.1.tgz
     ```
 
-    Copy the `tidb-operator-v1.2.0.tgz` file to the target server and extract it to the current directory:
+    Copy the `tidb-operator-v1.2.1.tgz` file to the target server and extract it to the current directory:
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    tar zxvf tidb-operator.v1.2.0.tgz
+    tar zxvf tidb-operator.v1.2.1.tgz
     ```
 
 2. Download the Docker images used by TiDB Operator
@@ -169,8 +169,8 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "" >}}
 
     ```shell
-    pingcap/tidb-operator:v1.2.0
-    pingcap/tidb-backup-manager:v1.2.0
+    pingcap/tidb-operator:v1.2.1
+    pingcap/tidb-backup-manager:v1.2.1
     bitnami/kubectl:latest
     pingcap/advanced-statefulset:v0.3.3
     k8s.gcr.io/kube-scheduler:v1.16.9
@@ -183,13 +183,13 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker pull pingcap/tidb-operator:v1.2.0
-    docker pull pingcap/tidb-backup-manager:v1.2.0
+    docker pull pingcap/tidb-operator:v1.2.1
+    docker pull pingcap/tidb-backup-manager:v1.2.1
     docker pull bitnami/kubectl:latest
     docker pull pingcap/advanced-statefulset:v0.3.3
 
-    docker save -o tidb-operator-v1.2.0.tar pingcap/tidb-operator:v1.2.0
-    docker save -o tidb-backup-manager-v1.2.0.tar pingcap/tidb-backup-manager:v1.2.0
+    docker save -o tidb-operator-v1.2.1.tar pingcap/tidb-operator:v1.2.1
+    docker save -o tidb-backup-manager-v1.2.1.tar pingcap/tidb-backup-manager:v1.2.1
     docker save -o bitnami-kubectl.tar bitnami/kubectl:latest
     docker save -o advanced-statefulset-v0.3.3.tar pingcap/advanced-statefulset:v0.3.3
     ```
@@ -199,8 +199,8 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker load -i tidb-operator-v1.2.0.tar
-    docker load -i tidb-backup-manager-v1.2.0.tar
+    docker load -i tidb-operator-v1.2.1.tar
+    docker load -i tidb-backup-manager-v1.2.1.tar
     docker load -i bitnami-kubectl.tar
     docker load -i advanced-statefulset-v0.3.3.tar
     ```

--- a/en/get-started.md
+++ b/en/get-started.md
@@ -304,7 +304,7 @@ This section describes how to install TiDB Operator using Helm 3.
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.0
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.1
     ```
 
     If you have trouble accessing Docker Hub, you can try images hosted in Alibaba Cloud:
@@ -312,9 +312,9 @@ This section describes how to install TiDB Operator using Helm 3.
     {{< copyable "shell-regular" >}}
 
     ```
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.0 \
-        --set operatorImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-operator:v1.2.0 \
-        --set tidbBackupManagerImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-backup-manager:v1.2.0 \
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.1 \
+        --set operatorImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-operator:v1.2.1 \
+        --set tidbBackupManagerImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-backup-manager:v1.2.1 \
         --set scheduler.kubeSchedulerImageName=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler
     ```
 

--- a/en/tidb-toolkit.md
+++ b/en/tidb-toolkit.md
@@ -201,12 +201,12 @@ helm search repo pingcap
 
 ```
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-pingcap/tidb-backup     v1.2.0                  A Helm chart for TiDB Backup or Restore
-pingcap/tidb-cluster    v1.2.0                  A Helm chart for TiDB Cluster
-pingcap/tidb-drainer    v1.2.0                  A Helm chart for TiDB Binlog drainer.
-pingcap/tidb-lightning  v1.2.0                  A Helm chart for TiDB Lightning
-pingcap/tidb-operator   v1.2.0  v1.2.0  tidb-operator Helm chart for Kubernetes
-pingcap/tikv-importer   v1.2.0                  A Helm chart for TiKV Importer
+pingcap/tidb-backup     v1.2.1                  A Helm chart for TiDB Backup or Restore
+pingcap/tidb-cluster    v1.2.1                  A Helm chart for TiDB Cluster
+pingcap/tidb-drainer    v1.2.1                  A Helm chart for TiDB Binlog drainer.
+pingcap/tidb-lightning  v1.2.1                  A Helm chart for TiDB Lightning
+pingcap/tidb-operator   v1.2.1  v1.2.1  tidb-operator Helm chart for Kubernetes
+pingcap/tikv-importer   v1.2.1                  A Helm chart for TiKV Importer
 ```
 
 When a new version of chart has been released, you can use `helm repo update` to update the repository cached locally:
@@ -268,9 +268,9 @@ Use the following command to download the chart file required for cluster instal
 {{< copyable "shell-regular" >}}
 
 ```shell
-wget http://charts.pingcap.org/tidb-operator-v1.2.0.tgz
-wget http://charts.pingcap.org/tidb-drainer-v1.2.0.tgz
-wget http://charts.pingcap.org/tidb-lightning-v1.2.0.tgz
+wget http://charts.pingcap.org/tidb-operator-v1.2.1.tgz
+wget http://charts.pingcap.org/tidb-drainer-v1.2.1.tgz
+wget http://charts.pingcap.org/tidb-lightning-v1.2.1.tgz
 ```
 
 Copy these chart files to the server and decompress them. You can use these charts to install the corresponding components by running the `helm install` command. Take `tidb-operator` as an example:
@@ -278,7 +278,7 @@ Copy these chart files to the server and decompress them. You can use these char
 {{< copyable "shell-regular" >}}
 
 ```shell
-tar zxvf tidb-operator.v1.2.0.tgz
+tar zxvf tidb-operator.v1.2.1.tgz
 helm install ${release_name} ./tidb-operator --namespace=${namespace}
 ```
 

--- a/en/upgrade-tidb-operator.md
+++ b/en/upgrade-tidb-operator.md
@@ -20,7 +20,7 @@ This document describes how to upgrade TiDB Operator and Kubernetes.
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.0/manifests/crd.yaml && \
+    kubectl apply -f https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.1/manifests/crd.yaml && \
     kubectl get crd tidbclusters.pingcap.com
     ```
 
@@ -29,16 +29,16 @@ This document describes how to upgrade TiDB Operator and Kubernetes.
     {{< copyable "shell-regular" >}}
 
     ```shell
-    mkdir -p ${HOME}/tidb-operator/v1.2.0 && \
-    helm inspect values pingcap/tidb-operator --version=v1.2.0 > ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+    mkdir -p ${HOME}/tidb-operator/v1.2.1 && \
+    helm inspect values pingcap/tidb-operator --version=v1.2.1 > ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
     ```
 
-3. In the `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version. Merge the customized configuration in the old `values.yaml` file to the `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml` file, and then execute `helm upgrade`:
+3. In the `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version. Merge the customized configuration in the old `values.yaml` file to the `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml` file, and then execute `helm upgrade`:
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.0 -f ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.1 -f ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
     ```
 
     After all the Pods start normally, execute the following command to check the image of TiDB Operator:
@@ -49,13 +49,13 @@ This document describes how to upgrade TiDB Operator and Kubernetes.
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-    If TiDB Operator is successfully upgraded, the expected output is as follows. `v1.2.0` represents the desired version of TiDB Operator.
+    If TiDB Operator is successfully upgraded, the expected output is as follows. `v1.2.1` represents the desired version of TiDB Operator.
 
     ```
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
     ```
 
     > **Note:**
@@ -73,7 +73,7 @@ If your server cannot access the Internet, you can take the following steps to u
         {{< copyable "shell-regular" >}}
 
         ```shell
-        wget https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.0/manifests/crd.yaml
+        wget https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.1/manifests/crd.yaml
         ```
 
     2. Download the `tidb-operator` chart package file.
@@ -81,7 +81,7 @@ If your server cannot access the Internet, you can take the following steps to u
         {{< copyable "shell-regular" >}}
 
         ```shell
-        wget http://charts.pingcap.org/tidb-operator-v1.2.0.tgz
+        wget http://charts.pingcap.org/tidb-operator-v1.2.1.tgz
         ```
 
     3. Download the Docker images required for the new TiDB Operator version:
@@ -89,11 +89,11 @@ If your server cannot access the Internet, you can take the following steps to u
         {{< copyable "shell-regular" >}}
     
         ```shell
-        docker pull pingcap/tidb-operator:v1.2.0
-        docker pull pingcap/tidb-backup-manager:v1.2.0
+        docker pull pingcap/tidb-operator:v1.2.1
+        docker pull pingcap/tidb-backup-manager:v1.2.1
 
-        docker save -o tidb-operator-v1.2.0.tar pingcap/tidb-operator:v1.2.0
-        docker save -o tidb-backup-manager-v1.2.0.tar pingcap/tidb-backup-manager:v1.2.0
+        docker save -o tidb-operator-v1.2.1.tar pingcap/tidb-operator:v1.2.1
+        docker save -o tidb-backup-manager-v1.2.1.tar pingcap/tidb-backup-manager:v1.2.1
         ```
 
 2. Upload the downloaded files and images to the server that needs to be upgraded, and then take the following steps for installation:
@@ -111,9 +111,9 @@ If your server cannot access the Internet, you can take the following steps to u
         {{< copyable "shell-regular" >}}
 
         ```shell
-        tar zxvf tidb-operator-v1.2.0.tgz && \
-        mkdir -p ${HOME}/tidb-operator/v1.2.0 &&
-        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+        tar zxvf tidb-operator-v1.2.1.tgz && \
+        mkdir -p ${HOME}/tidb-operator/v1.2.1 &&
+        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
         ```
 
     3. Install the Docker images on the server:
@@ -121,16 +121,16 @@ If your server cannot access the Internet, you can take the following steps to u
         {{< copyable "shell-regular" >}}
 
         ```shell
-        docker load -i tidb-operator-v1.2.0.tar
-        docker load -i tidb-backup-manager-v1.2.0.tar
+        docker load -i tidb-operator-v1.2.1.tar
+        docker load -i tidb-backup-manager-v1.2.1.tar
         ```
 
-3. In the `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version. Merge the customized configuration in the old `values.yaml` file to the `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml` file, and then execute `helm upgrade`:
+3. In the `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version. Merge the customized configuration in the old `values.yaml` file to the `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml` file, and then execute `helm upgrade`:
 
    {{< copyable "shell-regular" >}}
 
     ```shell
-    helm upgrade tidb-operator ./tidb-operator --version=v1.2.0 -f ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator ./tidb-operator --version=v1.2.1 -f ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
     ```
 
    After all the Pods start normally, execute the following command to check the image version of TiDB Operator:
@@ -141,13 +141,13 @@ If your server cannot access the Internet, you can take the following steps to u
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-   If TiDB Operator is successfully upgraded, the expected output is as follows. `v1.2.0` represents the new version of TiDB Operator.
+   If TiDB Operator is successfully upgraded, the expected output is as follows. `v1.2.1` represents the new version of TiDB Operator.
 
     ```
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
     ```
 
    > **Note:**

--- a/zh/cheat-sheet.md
+++ b/zh/cheat-sheet.md
@@ -485,7 +485,7 @@ helm inspect values ${chart_name} --version=${chart_version} > values.yaml
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm inspect values pingcap/tidb-operator --version=v1.2.0 > values-tidb-operator.yaml
+helm inspect values pingcap/tidb-operator --version=v1.2.1 > values-tidb-operator.yaml
 ```
 
 ### 使用 Helm Chart 部署
@@ -501,7 +501,7 @@ helm install ${name} ${chart_name} --namespace=${namespace} --version=${chart_ve
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.2.0 -f values-tidb-operator.yaml
+helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.2.1 -f values-tidb-operator.yaml
 ```
 
 ### 查看已经部署的 Helm Release
@@ -525,7 +525,7 @@ helm upgrade ${name} ${chart_name} --version=${chart_version} -f ${values_file}
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.0 -f values-tidb-operator.yaml
+helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.1 -f values-tidb-operator.yaml
 ```
 
 ### 删除 Helm Release

--- a/zh/deploy-on-alibaba-cloud.md
+++ b/zh/deploy-on-alibaba-cloud.md
@@ -89,7 +89,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-on-alibaba-cloud/']
     tikv_count = 3
     tidb_count = 2
     pd_count = 3
-    operator_version = "v1.2.0"
+    operator_version = "v1.2.1"
     ```
 
     如果需要在集群中部署 TiFlash，需要在 `terraform.tfvars` 中设置 `create_tiflash_node_pool = true`，也可以设置 `tiflash_count` 和 `tiflash_instance_type` 来配置 TiFlash 节点池的节点数量和实例类型，`tiflash_count` 默认为 `2`，`tiflash_instance_type` 默认为 `ecs.i2.2xlarge`。

--- a/zh/deploy-tidb-from-kubernetes-gke.md
+++ b/zh/deploy-tidb-from-kubernetes-gke.md
@@ -102,7 +102,7 @@ kubectl get crd tidbclusters.pingcap.com
 
 ```shell
 kubectl create namespace tidb-admin
-helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.0
+helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.1
 kubectl get po -n tidb-admin -l app.kubernetes.io/name=tidb-operator
 ```
 

--- a/zh/deploy-tidb-operator.md
+++ b/zh/deploy-tidb-operator.md
@@ -99,7 +99,7 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
 
     > **注意：**
     >
-    > `${chart_version}` 在后续文档中代表 chart 版本，例如 `v1.2.0`，可以通过 `helm search repo -l tidb-operator` 查看当前支持的版本。
+    > `${chart_version}` 在后续文档中代表 chart 版本，例如 `v1.2.1`，可以通过 `helm search repo -l tidb-operator` 查看当前支持的版本。
 
 2. 配置 TiDB Operator
 
@@ -149,15 +149,15 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     {{< copyable "shell-regular" >}}
 
     ```shell
-    wget http://charts.pingcap.org/tidb-operator-v1.2.0.tgz
+    wget http://charts.pingcap.org/tidb-operator-v1.2.1.tgz
     ```
 
-    将 `tidb-operator-v1.2.0.tgz` 文件拷贝到服务器上并解压到当前目录：
+    将 `tidb-operator-v1.2.1.tgz` 文件拷贝到服务器上并解压到当前目录：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    tar zxvf tidb-operator.v1.2.0.tgz
+    tar zxvf tidb-operator.v1.2.1.tgz
     ```
 
 2. 下载 TiDB Operator 运行所需的 Docker 镜像
@@ -167,8 +167,8 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     TiDB Operator 用到的 Docker 镜像有：
 
     ```shell
-    pingcap/tidb-operator:v1.2.0
-    pingcap/tidb-backup-manager:v1.2.0
+    pingcap/tidb-operator:v1.2.1
+    pingcap/tidb-backup-manager:v1.2.1
     bitnami/kubectl:latest
     pingcap/advanced-statefulset:v0.3.3
     k8s.gcr.io/kube-scheduler:v1.16.9
@@ -181,13 +181,13 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker pull pingcap/tidb-operator:v1.2.0
-    docker pull pingcap/tidb-backup-manager:v1.2.0
+    docker pull pingcap/tidb-operator:v1.2.1
+    docker pull pingcap/tidb-backup-manager:v1.2.1
     docker pull bitnami/kubectl:latest
     docker pull pingcap/advanced-statefulset:v0.3.3
 
-    docker save -o tidb-operator-v1.2.0.tar pingcap/tidb-operator:v1.2.0
-    docker save -o tidb-backup-manager-v1.2.0.tar pingcap/tidb-backup-manager:v1.2.0
+    docker save -o tidb-operator-v1.2.1.tar pingcap/tidb-operator:v1.2.1
+    docker save -o tidb-backup-manager-v1.2.1.tar pingcap/tidb-backup-manager:v1.2.1
     docker save -o bitnami-kubectl.tar bitnami/kubectl:latest
     docker save -o advanced-statefulset-v0.3.3.tar pingcap/advanced-statefulset:v0.3.3
     ```
@@ -197,8 +197,8 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker load -i tidb-operator-v1.2.0.tar
-    docker load -i tidb-backup-manager-v1.2.0.tar
+    docker load -i tidb-operator-v1.2.1.tar
+    docker load -i tidb-backup-manager-v1.2.1.tar
     docker load -i bitnami-kubectl.tar
     docker load -i advanced-statefulset-v0.3.3.tar
     ```

--- a/zh/get-started.md
+++ b/zh/get-started.md
@@ -299,7 +299,7 @@ TiDB Operator 使用 Helm 3 安装。
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.0
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.1
     ```
 
     如果访问 Docker Hub 网速较慢，可以使用阿里云上的镜像：
@@ -307,9 +307,9 @@ TiDB Operator 使用 Helm 3 安装。
     {{< copyable "shell-regular" >}}
 
     ```
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.0 \
-        --set operatorImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-operator:v1.2.0 \
-        --set tidbBackupManagerImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-backup-manager:v1.2.0 \
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.2.1 \
+        --set operatorImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-operator:v1.2.1 \
+        --set tidbBackupManagerImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-backup-manager:v1.2.1 \
         --set scheduler.kubeSchedulerImageName=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler
     ```
 

--- a/zh/tidb-toolkit.md
+++ b/zh/tidb-toolkit.md
@@ -201,12 +201,12 @@ helm search repo pingcap
 
 ```
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-pingcap/tidb-backup     v1.2.0                          A Helm chart for TiDB Backup or Restore
-pingcap/tidb-cluster    v1.2.0                          A Helm chart for TiDB Cluster
-pingcap/tidb-drainer    v1.2.0                          A Helm chart for TiDB Binlog drainer.
-pingcap/tidb-lightning  v1.2.0                          A Helm chart for TiDB Lightning
-pingcap/tidb-operator   v1.2.0          v1.2.0          tidb-operator Helm chart for Kubernetes
-pingcap/tikv-importer   v1.2.0                          A Helm chart for TiKV Importer
+pingcap/tidb-backup     v1.2.1                          A Helm chart for TiDB Backup or Restore
+pingcap/tidb-cluster    v1.2.1                          A Helm chart for TiDB Cluster
+pingcap/tidb-drainer    v1.2.1                          A Helm chart for TiDB Binlog drainer.
+pingcap/tidb-lightning  v1.2.1                          A Helm chart for TiDB Lightning
+pingcap/tidb-operator   v1.2.1          v1.2.1          tidb-operator Helm chart for Kubernetes
+pingcap/tikv-importer   v1.2.1                          A Helm chart for TiKV Importer
 ```
 
 当新版本的 chart 发布后，你可以使用 `helm repo update` 命令更新本地对于仓库的缓存：
@@ -266,9 +266,9 @@ helm uninstall ${release_name} -n ${namespace}
 {{< copyable "shell-regular" >}}
 
 ```shell
-wget http://charts.pingcap.org/tidb-operator-v1.2.0.tgz
-wget http://charts.pingcap.org/tidb-drainer-v1.2.0.tgz
-wget http://charts.pingcap.org/tidb-lightning-v1.2.0.tgz
+wget http://charts.pingcap.org/tidb-operator-v1.2.1.tgz
+wget http://charts.pingcap.org/tidb-drainer-v1.2.1.tgz
+wget http://charts.pingcap.org/tidb-lightning-v1.2.1.tgz
 ```
 
 将这些 chart 文件拷贝到服务器上并解压，可以通过 `helm install` 命令使用这些 chart 来安装相应组件，以 `tidb-operator` 为例：
@@ -276,7 +276,7 @@ wget http://charts.pingcap.org/tidb-lightning-v1.2.0.tgz
 {{< copyable "shell-regular" >}}
 
 ```shell
-tar zxvf tidb-operator.v1.2.0.tgz
+tar zxvf tidb-operator.v1.2.1.tgz
 helm install ${release_name} ./tidb-operator --namespace=${namespace}
 ```
 

--- a/zh/upgrade-tidb-operator.md
+++ b/zh/upgrade-tidb-operator.md
@@ -20,7 +20,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
     {{< copyable "shell-regular" >}}
 
     ```shell
-    kubectl apply -f https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.0/manifests/crd.yaml && \
+    kubectl apply -f https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.1/manifests/crd.yaml && \
     kubectl get crd tidbclusters.pingcap.com
     ```
 
@@ -29,16 +29,16 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
     {{< copyable "shell-regular" >}}
 
     ```shell
-    mkdir -p ${HOME}/tidb-operator/v1.2.0 && \
-    helm inspect values pingcap/tidb-operator --version=v1.2.0 > ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+    mkdir -p ${HOME}/tidb-operator/v1.2.1 && \
+    helm inspect values pingcap/tidb-operator --version=v1.2.1 > ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
     ```
 
-3. 修改 `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本，并将旧版本 `values.yaml` 中的自定义配置合并到 `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml`，然后执行 `helm upgrade`：
+3. 修改 `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本，并将旧版本 `values.yaml` 中的自定义配置合并到 `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml`，然后执行 `helm upgrade`：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.0 -f ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.2.1 -f ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
     ```
     
     Pod 全部正常启动之后，运行以下命令确认 TiDB Operator 镜像版本：
@@ -49,13 +49,13 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-    输出类似下方结果则表示升级成功，`v1.2.0`表示要升级到的版本号。
+    输出类似下方结果则表示升级成功，`v1.2.1`表示要升级到的版本号。
 
     ```
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
     ```
 
     > **注意：**
@@ -73,7 +73,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        wget https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.0/manifests/crd.yaml
+        wget https://raw.githubusercontent.com/pingcap/tidb-operator/v1.2.1/manifests/crd.yaml
         ```
 
     2. 下载 `tidb-operator` chart 包文件：
@@ -81,7 +81,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        wget http://charts.pingcap.org/tidb-operator-v1.2.0.tgz
+        wget http://charts.pingcap.org/tidb-operator-v1.2.1.tgz
         ```
    
     3. 下载 TiDB Operator 升级所需的 Docker 镜像:
@@ -89,11 +89,11 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        docker pull pingcap/tidb-operator:v1.2.0
-        docker pull pingcap/tidb-backup-manager:v1.2.0
+        docker pull pingcap/tidb-operator:v1.2.1
+        docker pull pingcap/tidb-backup-manager:v1.2.1
 
-        docker save -o tidb-operator-v1.2.0.tar pingcap/tidb-operator:v1.2.0
-        docker save -o tidb-backup-manager-v1.2.0.tar pingcap/tidb-backup-manager:v1.2.0
+        docker save -o tidb-operator-v1.2.1.tar pingcap/tidb-operator:v1.2.1
+        docker save -o tidb-backup-manager-v1.2.1.tar pingcap/tidb-backup-manager:v1.2.1
         ```
    
 2. 将下载的文件和镜像上传到需要升级的服务器上，然后按照以下步骤进行安装：
@@ -111,9 +111,9 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        tar zxvf tidb-operator-v1.2.0.tgz && \
-        mkdir -p ${HOME}/tidb-operator/v1.2.0 && \
-        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+        tar zxvf tidb-operator-v1.2.1.tgz && \
+        mkdir -p ${HOME}/tidb-operator/v1.2.1 && \
+        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
         ```
 
     3. 安装 Docker 镜像到服务器上：
@@ -121,16 +121,16 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        docker load -i tidb-operator-v1.2.0.tar
-        docker load -i tidb-backup-manager-v1.2.0.tar
+        docker load -i tidb-operator-v1.2.1.tar
+        docker load -i tidb-backup-manager-v1.2.1.tar
         ```
 
-3. 修改 `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本，并将旧版本 `values.yaml` 中的自定义配置合并到 `${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml`，然后执行 `helm upgrade`：
+3. 修改 `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本，并将旧版本 `values.yaml` 中的自定义配置合并到 `${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml`，然后执行 `helm upgrade`：
 
    {{< copyable "shell-regular" >}}
 
     ```shell
-    helm upgrade tidb-operator ./tidb-operator --version=v1.2.0 -f ${HOME}/tidb-operator/v1.2.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator ./tidb-operator --version=v1.2.1 -f ${HOME}/tidb-operator/v1.2.1/values-tidb-operator.yaml
     ```
 
    Pod 全部正常启动之后，运行以下命令确认 TiDB Operator 镜像版本：
@@ -141,13 +141,13 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-   输出类似下方结果则表示升级成功，`v1.2.0`表示要升级到的版本号。
+   输出类似下方结果则表示升级成功，`v1.2.1`表示要升级到的版本号。
 
     ```
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
-    image: pingcap/tidb-operator:v1.2.0
-    image: docker.io/pingcap/tidb-operator:v1.2.0
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
+    image: pingcap/tidb-operator:v1.2.1
+    image: docker.io/pingcap/tidb-operator:v1.2.1
     ```
 
    > **注意：**


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Bump Operator to v1.2.1
ref #1330
Run commands:

```shell
find . -type f | xargs sed -i "s/v1.2.0/v1.2.1/g"
git checkout -- zh/releases en/releases
```

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch