### PR TITLE
en,zh: Use `mysql --comments` everywhere

### DIFF
--- a/en/deploy-on-alibaba-cloud.md
+++ b/en/deploy-on-alibaba-cloud.md
@@ -277,7 +277,7 @@ ssh -i credentials/${cluster_name}-key.pem root@${bastion_ip}
 {{< copyable "shell-regular" >}}
 
 ```shell
-mysql -h ${tidb_lb_ip} -P 4000 -u root
+mysql --comments -h ${tidb_lb_ip} -P 4000 -u root
 ```
 
 `tidb_lb_ip` is the LoadBalancer IP of the TiDB service.

--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -269,7 +269,7 @@ After the bastion host is created, you can connect to the bastion host via SSH a
     {{< copyable "shell-regular" >}}
 
     ```shell
-    mysql -h ${tidb-nlb-dnsname} -P 4000 -u root
+    mysql --comments -h ${tidb-nlb-dnsname} -P 4000 -u root
     ```
 
     `${tidb-nlb-dnsname}` is the LoadBalancer domain name of the TiDB service. You can view the domain name in the `EXTERNAL-IP` field by executing `kubectl get svc basic-tidb -n tidb-cluster`.
@@ -277,7 +277,7 @@ After the bastion host is created, you can connect to the bastion host via SSH a
     For example:
 
     ```shell
-    $ mysql -h abfc623004ccb4cc3b363f3f37475af1-9774d22c27310bc1.elb.us-west-2.amazonaws.com -P 4000 -u root
+    $ mysql --comments -h abfc623004ccb4cc3b363f3f37475af1-9774d22c27310bc1.elb.us-west-2.amazonaws.com -P 4000 -u root
     Welcome to the MariaDB monitor.  Commands end with ; or \g.
     Your MySQL connection id is 1189
     Server version: 5.7.25-TiDB-v4.0.2 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible

--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -186,7 +186,7 @@ After the bastion host is created, you can connect to the bastion host via SSH a
     {{< copyable "shell-regular" >}}
 
     ```shell
-    mysql -h ${tidb-nlb-dnsname} -P 4000 -u root
+    mysql --comments -h ${tidb-nlb-dnsname} -P 4000 -u root
     ```
 
     `${tidb-nlb-dnsname}` is the LoadBalancer IP of the TiDB service. You can view the IP in the `EXTERNAL-IP` field of the `kubectl get svc basic-tidb -n tidb-cluster` execution result.
@@ -194,7 +194,7 @@ After the bastion host is created, you can connect to the bastion host via SSH a
     For example:
 
     ```shell
-    $ mysql -h 10.128.15.243 -P 4000 -u root
+    $ mysql --comments -h 10.128.15.243 -P 4000 -u root
     Welcome to the MariaDB monitor.  Commands end with ; or \g.
     Your MySQL connection id is 7823
     Server version: 5.7.25-TiDB-v4.0.4 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible

--- a/en/deploy-tidb-from-kubernetes-gke.md
+++ b/en/deploy-tidb-from-kubernetes-gke.md
@@ -157,7 +157,7 @@ From your Cloud Shell:
 
 ```shell
 sudo apt-get install -y mysql-client && \
-mysql -h 127.0.0.1 -u root -P 4000
+mysql --comments -h 127.0.0.1 -u root -P 4000
 ```
 
 Try out a MySQL command inside your MySQL terminal:

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -678,7 +678,7 @@ kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret  -ojsonpat
 {{< copyable "shell-regular" >}}
 
 ``` shell
-mysql -uroot -p -P 4000 -h ${tidb_host} --ssl-cert=client-tls.crt --ssl-key=client-tls.key --ssl-ca=client-ca.crt
+mysql --comments -uroot -p -P 4000 -h ${tidb_host} --ssl-cert=client-tls.crt --ssl-key=client-tls.key --ssl-ca=client-ca.crt
 ```
 
 > **Note:**

--- a/en/get-started.md
+++ b/en/get-started.md
@@ -487,7 +487,7 @@ This command runs in the background and writes its output to a file called `pf40
 {{< copyable "shell-regular" >}}
 
 ``` shell
-mysql -h 127.0.0.1 -P 4000 -u root
+mysql --comments -h 127.0.0.1 -P 4000 -u root
 ```
 
 Expected output:
@@ -692,7 +692,7 @@ kubectl port-forward -n tidb-cluster svc/basic-tidb 4000 > pf4000.out &
 {{< copyable "shell-regular" >}}
 
 ```
-mysql -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
+mysql --comments -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
 ```
 
 Expected output:

--- a/zh/deploy-on-alibaba-cloud.md
+++ b/zh/deploy-on-alibaba-cloud.md
@@ -276,7 +276,7 @@ ssh -i credentials/${cluster_name}-key.pem root@${bastion_ip}
 {{< copyable "shell-regular" >}}
 
 ```shell
-mysql -h ${tidb_lb_ip} -P 4000 -u root
+mysql --comments -h ${tidb_lb_ip} -P 4000 -u root
 ```
 
 `tidb_lb_ip` 为 TiDB Service 的 LoadBalancer IP。

--- a/zh/deploy-on-aws-eks.md
+++ b/zh/deploy-on-aws-eks.md
@@ -411,7 +411,7 @@ sudo yum install mysql -y
 {{< copyable "shell-regular" >}}
 
 ```shell
-mysql -h ${tidb-nlb-dnsname} -P 4000 -u root
+mysql --comments -h ${tidb-nlb-dnsname} -P 4000 -u root
 ```
 
 其中 `${tidb-nlb-dnsname}` 为 TiDB Service 的 LoadBalancer 域名，可以通过命令 `kubectl get svc basic-tidb -n tidb-cluster` 输出中的 `EXTERNAL-IP` 字段查看。
@@ -419,7 +419,7 @@ mysql -h ${tidb-nlb-dnsname} -P 4000 -u root
 以下为一个连接 TiDB 集群的示例：
 
 ```shell
-$ mysql -h abfc623004ccb4cc3b363f3f37475af1-9774d22c27310bc1.elb.us-west-2.amazonaws.com -P 4000 -u root
+$ mysql --comments -h abfc623004ccb4cc3b363f3f37475af1-9774d22c27310bc1.elb.us-west-2.amazonaws.com -P 4000 -u root
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1189
 Server version: 5.7.25-TiDB-v4.0.2 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible

--- a/zh/deploy-on-gcp-gke.md
+++ b/zh/deploy-on-gcp-gke.md
@@ -186,7 +186,7 @@ gcloud compute instances create bastion \
     {{< copyable "shell-regular" >}}
 
     ```shell
-    mysql -h ${tidb-nlb-dnsname} -P 4000 -u root
+    mysql --comments -h ${tidb-nlb-dnsname} -P 4000 -u root
     ```
 
     `${tidb-nlb-dnsname}` 为 TiDB Service 的 LoadBalancer IP，可以通过 `kubectl get svc basic-tidb -n tidb-cluster` 输出中的 `EXTERNAL-IP` 字段查看。
@@ -194,7 +194,7 @@ gcloud compute instances create bastion \
     示例：
 
     ```shell
-    $ mysql -h 10.128.15.243 -P 4000 -u root
+    $ mysql --comments -h 10.128.15.243 -P 4000 -u root
     Welcome to the MariaDB monitor.  Commands end with ; or \g.
     Your MySQL connection id is 7823
     Server version: 5.7.25-TiDB-v5.2.1 TiDB Server (Apache License 2.0) Community Edition, MySQL 5.7 compatible

--- a/zh/deploy-tidb-from-kubernetes-gke.md
+++ b/zh/deploy-tidb-from-kubernetes-gke.md
@@ -154,7 +154,7 @@ kubectl -n demo port-forward svc/basic-tidb 4000:4000 &>/tmp/pf4000.log &
 
 ``` shell
 sudo apt-get install -y mysql-client && \
-mysql -h 127.0.0.1 -u root -P 4000
+mysql --comments -h 127.0.0.1 -u root -P 4000
 ```
 
 在 MySQL 终端中输入一条 MySQL 命令：

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -673,7 +673,7 @@ kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret  -ojsonpat
 {{< copyable "shell-regular" >}}
 
 ``` shell
-mysql -uroot -p -P 4000 -h ${tidb_host} --ssl-cert=client-tls.crt --ssl-key=client-tls.key --ssl-ca=client-ca.crt
+mysql --comments -uroot -p -P 4000 -h ${tidb_host} --ssl-cert=client-tls.crt --ssl-key=client-tls.key --ssl-ca=client-ca.crt
 ```
 
 > **注意：**

--- a/zh/get-started.md
+++ b/zh/get-started.md
@@ -483,7 +483,7 @@ kubectl port-forward -n tidb-cluster svc/basic-tidb 4000 > pf4000.out &
 {{< copyable "shell-regular" >}}
 
 ``` shell
-mysql -h 127.0.0.1 -P 4000 -u root
+mysql --comments -h 127.0.0.1 -P 4000 -u root
 ```
 
 期望输出：
@@ -686,7 +686,7 @@ kubectl port-forward -n tidb-cluster svc/basic-tidb 4000 > pf4000.out &
 {{< copyable "shell-regular" >}}
 
 ```
-mysql -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
+mysql --comments -h 127.0.0.1 -P 4000 -u root -e 'select tidb_version()\G'
 ```
 
 期望输出：


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

With TIDB in general `--comments` is needed. This is because without that option comments are stripped before they are sent to the server. This causes problems as TiDB specific code like `/*T![clustered_index] CLUSTERED */` for TiDB and TiDB feature specific parts of statements. This is used by `SHOW CREATE TABLE...` etc.

While it might not be strictly required here, it would be good to add it anyway as it is a best practice to use `--comments` for all TiDB sessions as forgetting this might cause statements to silently behave differently which can be very frustrating for users and cause all kinds of issues. And you never know what a user might use the session for after doing this step of the docs.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)
