### PR TITLE
en,zh: Bump operator to v1.3.1

### DIFF
--- a/en/cheat-sheet.md
+++ b/en/cheat-sheet.md
@@ -493,7 +493,7 @@ For example:
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm inspect values pingcap/tidb-operator --version=v1.3.0 > values-tidb-operator.yaml
+helm inspect values pingcap/tidb-operator --version=v1.3.1 > values-tidb-operator.yaml
 ```
 
 ### Deploy using Helm chart
@@ -509,7 +509,7 @@ For example:
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.3.0 -f values-tidb-operator.yaml
+helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.3.1 -f values-tidb-operator.yaml
 ```
 
 ### View the deployed Helm release
@@ -533,7 +533,7 @@ For example:
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.0 -f values-tidb-operator.yaml
+helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.1 -f values-tidb-operator.yaml
 ```
 
 ### Delete Helm release

--- a/en/deploy-cluster-on-arm64.md
+++ b/en/deploy-cluster-on-arm64.md
@@ -17,9 +17,9 @@ The process of deploying TiDB operator on ARM64 machines is the same as the proc
 
 ```yaml
 # ...
-operatorImage: pingcap/tidb-operator-arm64:v1.3.0
+operatorImage: pingcap/tidb-operator-arm64:v1.3.1
 # ...
-tidbBackupManagerImage: pingcap/tidb-backup-manager-arm64:v1.3.0
+tidbBackupManagerImage: pingcap/tidb-backup-manager-arm64:v1.3.1
 # ...
 ```
 

--- a/en/deploy-on-alibaba-cloud.md
+++ b/en/deploy-on-alibaba-cloud.md
@@ -89,7 +89,7 @@ All the instances except ACK mandatory workers are deployed across availability 
     tikv_count = 3
     tidb_count = 2
     pd_count = 3
-    operator_version = "v1.3.0"
+    operator_version = "v1.3.1"
     ```
 
     * To deploy TiFlash in the cluster, set `create_tiflash_node_pool = true` in `terraform.tfvars`. You can also configure the node count and instance type of the TiFlash node pool by modifying `tiflash_count` and `tiflash_instance_type`. By default, the value of `tiflash_count` is `2`, and the value of `tiflash_instance_type` is `ecs.i2.2xlarge`.

--- a/en/deploy-tidb-from-kubernetes-gke.md
+++ b/en/deploy-tidb-from-kubernetes-gke.md
@@ -109,7 +109,7 @@ After the `TidbCluster` CRD is created, install TiDB Operator in your Kubernetes
 
 ```shell
 kubectl create namespace tidb-admin
-helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.0
+helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.1
 kubectl get po -n tidb-admin -l app.kubernetes.io/name=tidb-operator
 ```
 

--- a/en/deploy-tidb-operator.md
+++ b/en/deploy-tidb-operator.md
@@ -101,7 +101,7 @@ When you use TiDB Operator, `tidb-scheduler` is not mandatory. Refer to [tidb-sc
 
     > **Note:**
     >
-    > `${chart_version}` represents the chart version of TiDB Operator. For example, `v1.3.0`. You can view the currently supported versions by running the `helm search repo -l tidb-operator` command.
+    > `${chart_version}` represents the chart version of TiDB Operator. For example, `v1.3.1`. You can view the currently supported versions by running the `helm search repo -l tidb-operator` command.
 
 2. Configure TiDB Operator
 
@@ -149,15 +149,15 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    wget http://charts.pingcap.org/tidb-operator-v1.3.0.tgz
+    wget http://charts.pingcap.org/tidb-operator-v1.3.1.tgz
     ```
 
-    Copy the `tidb-operator-v1.3.0.tgz` file to the target server and extract it to the current directory:
+    Copy the `tidb-operator-v1.3.1.tgz` file to the target server and extract it to the current directory:
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    tar zxvf tidb-operator.v1.3.0.tgz
+    tar zxvf tidb-operator.v1.3.1.tgz
     ```
 
 2. Download the Docker images used by TiDB Operator
@@ -169,8 +169,8 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "" >}}
 
     ```shell
-    pingcap/tidb-operator:v1.3.0
-    pingcap/tidb-backup-manager:v1.3.0
+    pingcap/tidb-operator:v1.3.1
+    pingcap/tidb-backup-manager:v1.3.1
     bitnami/kubectl:latest
     pingcap/advanced-statefulset:v0.3.3
     k8s.gcr.io/kube-scheduler:v1.16.9
@@ -183,13 +183,13 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker pull pingcap/tidb-operator:v1.3.0
-    docker pull pingcap/tidb-backup-manager:v1.3.0
+    docker pull pingcap/tidb-operator:v1.3.1
+    docker pull pingcap/tidb-backup-manager:v1.3.1
     docker pull bitnami/kubectl:latest
     docker pull pingcap/advanced-statefulset:v0.3.3
 
-    docker save -o tidb-operator-v1.3.0.tar pingcap/tidb-operator:v1.3.0
-    docker save -o tidb-backup-manager-v1.3.0.tar pingcap/tidb-backup-manager:v1.3.0
+    docker save -o tidb-operator-v1.3.1.tar pingcap/tidb-operator:v1.3.1
+    docker save -o tidb-backup-manager-v1.3.1.tar pingcap/tidb-backup-manager:v1.3.1
     docker save -o bitnami-kubectl.tar bitnami/kubectl:latest
     docker save -o advanced-statefulset-v0.3.3.tar pingcap/advanced-statefulset:v0.3.3
     ```
@@ -199,8 +199,8 @@ If your server cannot access the Internet, install TiDB Operator offline by the 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker load -i tidb-operator-v1.3.0.tar
-    docker load -i tidb-backup-manager-v1.3.0.tar
+    docker load -i tidb-operator-v1.3.1.tar
+    docker load -i tidb-backup-manager-v1.3.1.tar
     docker load -i bitnami-kubectl.tar
     docker load -i advanced-statefulset-v0.3.3.tar
     ```

--- a/en/get-started.md
+++ b/en/get-started.md
@@ -258,7 +258,7 @@ This section describes how to install TiDB Operator using [Helm 3](https://helm.
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.0
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.1
     ```
 
     <details>

--- a/en/tidb-toolkit.md
+++ b/en/tidb-toolkit.md
@@ -201,12 +201,12 @@ helm search repo pingcap
 
 ```
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-pingcap/tidb-backup     v1.3.0                  A Helm chart for TiDB Backup or Restore
-pingcap/tidb-cluster    v1.3.0                  A Helm chart for TiDB Cluster
-pingcap/tidb-drainer    v1.3.0                  A Helm chart for TiDB Binlog drainer.
-pingcap/tidb-lightning  v1.3.0                  A Helm chart for TiDB Lightning
-pingcap/tidb-operator   v1.3.0  v1.3.0  tidb-operator Helm chart for Kubernetes
-pingcap/tikv-importer   v1.3.0                  A Helm chart for TiKV Importer
+pingcap/tidb-backup     v1.3.1                  A Helm chart for TiDB Backup or Restore
+pingcap/tidb-cluster    v1.3.1                  A Helm chart for TiDB Cluster
+pingcap/tidb-drainer    v1.3.1                  A Helm chart for TiDB Binlog drainer.
+pingcap/tidb-lightning  v1.3.1                  A Helm chart for TiDB Lightning
+pingcap/tidb-operator   v1.3.1  v1.3.1  tidb-operator Helm chart for Kubernetes
+pingcap/tikv-importer   v1.3.1                  A Helm chart for TiKV Importer
 ```
 
 When a new version of chart has been released, you can use `helm repo update` to update the repository cached locally:
@@ -268,9 +268,9 @@ Use the following command to download the chart file required for cluster instal
 {{< copyable "shell-regular" >}}
 
 ```shell
-wget http://charts.pingcap.org/tidb-operator-v1.3.0.tgz
-wget http://charts.pingcap.org/tidb-drainer-v1.3.0.tgz
-wget http://charts.pingcap.org/tidb-lightning-v1.3.0.tgz
+wget http://charts.pingcap.org/tidb-operator-v1.3.1.tgz
+wget http://charts.pingcap.org/tidb-drainer-v1.3.1.tgz
+wget http://charts.pingcap.org/tidb-lightning-v1.3.1.tgz
 ```
 
 Copy these chart files to the server and decompress them. You can use these charts to install the corresponding components by running the `helm install` command. Take `tidb-operator` as an example:
@@ -278,7 +278,7 @@ Copy these chart files to the server and decompress them. You can use these char
 {{< copyable "shell-regular" >}}
 
 ```shell
-tar zxvf tidb-operator.v1.3.0.tgz
+tar zxvf tidb-operator.v1.3.1.tgz
 helm install ${release_name} ./tidb-operator --namespace=${namespace}
 ```
 

--- a/en/upgrade-tidb-operator.md
+++ b/en/upgrade-tidb-operator.md
@@ -60,27 +60,27 @@ If your server has access to the internet, you can perform online upgrade by tak
             kubectl get crd tidbclusters.pingcap.com
             ```
 
-    This document takes TiDB v1.3.0 as an example. You can replace `${operator_version}` with the specific version you want to upgrade to.
+    This document takes TiDB v1.3.1 as an example. You can replace `${operator_version}` with the specific version you want to upgrade to.
 
 3. Get the `values.yaml` file of the `tidb-operator` chart:
 
     {{< copyable "shell-regular" >}}
 
     ```bash
-    mkdir -p ${HOME}/tidb-operator/v1.3.0 && \
-    helm inspect values pingcap/tidb-operator --version=v1.3.0 > ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+    mkdir -p ${HOME}/tidb-operator/v1.3.1 && \
+    helm inspect values pingcap/tidb-operator --version=v1.3.1 > ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
     ```
 
-4. In the `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version.
+4. In the `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version.
 
-5. If you have added customized configuration in the old `values.yaml` file, merge your customized configuration to the `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` file.
+5. If you have added customized configuration in the old `values.yaml` file, merge your customized configuration to the `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` file.
 
 6. Perform upgrade:
 
     {{< copyable "shell-regular" >}}
 
     ```bash
-    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.0 -f ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.1 -f ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
     ```
 
 7. After all the Pods start normally, check the image of TiDB Operator:
@@ -91,13 +91,13 @@ If your server has access to the internet, you can perform online upgrade by tak
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-    If you see a similar output as follows, TiDB Operator is successfully upgraded. `v1.3.0` represents the TiDB Operator version you have upgraded to.
+    If you see a similar output as follows, TiDB Operator is successfully upgraded. `v1.3.1` represents the TiDB Operator version you have upgraded to.
 
     ```
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
     ```
 
 ## offline upgrade
@@ -124,14 +124,14 @@ If your server cannot access the Internet, you can offline upgrade by taking the
             wget -O crd.yaml https://raw.githubusercontent.com/pingcap/tidb-operator/${operator_version}/manifests/crd_v1beta1.yaml
             ```
 
-        This document takes TiDB v1.3.0 as an example. You can replace `${operator_version}` with the specific version you want to upgrade to.
+        This document takes TiDB v1.3.1 as an example. You can replace `${operator_version}` with the specific version you want to upgrade to.
 
     2. Download the `tidb-operator` chart package file.
 
         {{< copyable "shell-regular" >}}
 
         ```bash
-        wget http://charts.pingcap.org/tidb-operator-v1.3.0.tgz
+        wget http://charts.pingcap.org/tidb-operator-v1.3.1.tgz
         ```
 
     3. Download the Docker images required for the new TiDB Operator version:
@@ -139,11 +139,11 @@ If your server cannot access the Internet, you can offline upgrade by taking the
         {{< copyable "shell-regular" >}}
 
         ```bash
-        docker pull pingcap/tidb-operator:v1.3.0
-        docker pull pingcap/tidb-backup-manager:v1.3.0
+        docker pull pingcap/tidb-operator:v1.3.1
+        docker pull pingcap/tidb-backup-manager:v1.3.1
 
-        docker save -o tidb-operator-v1.3.0.tar pingcap/tidb-operator:v1.3.0
-        docker save -o tidb-backup-manager-v1.3.0.tar pingcap/tidb-backup-manager:v1.3.0
+        docker save -o tidb-operator-v1.3.1.tar pingcap/tidb-operator:v1.3.1
+        docker save -o tidb-backup-manager-v1.3.1.tar pingcap/tidb-backup-manager:v1.3.1
         ```
 
 2. Upload the downloaded files and images to the server where TiDB Operator is deployed, and install the new TiDB Operator version:
@@ -171,9 +171,9 @@ If your server cannot access the Internet, you can offline upgrade by taking the
         {{< copyable "shell-regular" >}}
 
         ```bash
-        tar zxvf tidb-operator-v1.3.0.tgz && \
-        mkdir -p ${HOME}/tidb-operator/v1.3.0 && \
-        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+        tar zxvf tidb-operator-v1.3.1.tgz && \
+        mkdir -p ${HOME}/tidb-operator/v1.3.1 && \
+        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
         ```
 
     4. Install the Docker images on the server:
@@ -181,20 +181,20 @@ If your server cannot access the Internet, you can offline upgrade by taking the
         {{< copyable "shell-regular" >}}
 
         ```bash
-        docker load -i tidb-operator-v1.3.0.tar && \
-        docker load -i tidb-backup-manager-v1.3.0.tar
+        docker load -i tidb-operator-v1.3.1.tar && \
+        docker load -i tidb-backup-manager-v1.3.1.tar
         ```
 
-3. In the `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version.
+3. In the `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` file, modify the `operatorImage` version to the new TiDB Operator version.
 
-4. If you have added customized configuration in the old `values.yaml` file, merge your customized configuration to the `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` file.
+4. If you have added customized configuration in the old `values.yaml` file, merge your customized configuration to the `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` file.
 
 5. Perform upgrade:
 
     {{< copyable "shell-regular" >}}
 
     ```bash
-    helm upgrade tidb-operator ./tidb-operator --version=v1.3.0 -f ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator ./tidb-operator --version=v1.3.1 -f ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
     ```
 
 6. After all the Pods start normally, check the image version of TiDB Operator:
@@ -205,13 +205,13 @@ If your server cannot access the Internet, you can offline upgrade by taking the
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-    If you see a similar output as follows, TiDB Operator is successfully upgraded. `v1.3.0` represents the TiDB Operator version you have upgraded to.
+    If you see a similar output as follows, TiDB Operator is successfully upgraded. `v1.3.1` represents the TiDB Operator version you have upgraded to.
 
     ```
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
     ```
 
     > **Note:**

--- a/zh/cheat-sheet.md
+++ b/zh/cheat-sheet.md
@@ -493,7 +493,7 @@ helm inspect values ${chart_name} --version=${chart_version} > values.yaml
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm inspect values pingcap/tidb-operator --version=v1.3.0 > values-tidb-operator.yaml
+helm inspect values pingcap/tidb-operator --version=v1.3.1 > values-tidb-operator.yaml
 ```
 
 ### 使用 Helm Chart 部署
@@ -509,7 +509,7 @@ helm install ${name} ${chart_name} --namespace=${namespace} --version=${chart_ve
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.3.0 -f values-tidb-operator.yaml
+helm install tidb-operator pingcap/tidb-operator --namespace=tidb-admin --version=v1.3.1 -f values-tidb-operator.yaml
 ```
 
 ### 查看已经部署的 Helm Release
@@ -533,7 +533,7 @@ helm upgrade ${name} ${chart_name} --version=${chart_version} -f ${values_file}
 {{< copyable "shell-regular" >}}
 
 ```shell
-helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.0 -f values-tidb-operator.yaml
+helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.1 -f values-tidb-operator.yaml
 ```
 
 ### 删除 Helm Release

--- a/zh/deploy-cluster-on-arm64.md
+++ b/zh/deploy-cluster-on-arm64.md
@@ -17,9 +17,9 @@ summary: 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
 
 ```yaml
 # ...
-operatorImage: pingcap/tidb-operator-arm64:v1.3.0
+operatorImage: pingcap/tidb-operator-arm64:v1.3.1
 # ...
-tidbBackupManagerImage: pingcap/tidb-backup-manager-arm64:v1.3.0
+tidbBackupManagerImage: pingcap/tidb-backup-manager-arm64:v1.3.1
 # ...
 ```
 

--- a/zh/deploy-on-alibaba-cloud.md
+++ b/zh/deploy-on-alibaba-cloud.md
@@ -89,7 +89,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-on-alibaba-cloud/']
     tikv_count = 3
     tidb_count = 2
     pd_count = 3
-    operator_version = "v1.3.0"
+    operator_version = "v1.3.1"
     ```
 
     如果需要在集群中部署 TiFlash，需要在 `terraform.tfvars` 中设置 `create_tiflash_node_pool = true`，也可以设置 `tiflash_count` 和 `tiflash_instance_type` 来配置 TiFlash 节点池的节点数量和实例类型，`tiflash_count` 默认为 `2`，`tiflash_instance_type` 默认为 `ecs.i2.2xlarge`。

--- a/zh/deploy-tidb-from-kubernetes-gke.md
+++ b/zh/deploy-tidb-from-kubernetes-gke.md
@@ -106,7 +106,7 @@ kubectl get crd tidbclusters.pingcap.com
 
 ```shell
 kubectl create namespace tidb-admin
-helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.0
+helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.1
 kubectl get po -n tidb-admin -l app.kubernetes.io/name=tidb-operator
 ```
 

--- a/zh/deploy-tidb-operator.md
+++ b/zh/deploy-tidb-operator.md
@@ -101,7 +101,7 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
 
     > **注意：**
     >
-    > `${chart_version}` 在后续文档中代表 chart 版本，例如 `v1.3.0`，可以通过 `helm search repo -l tidb-operator` 查看当前支持的版本。
+    > `${chart_version}` 在后续文档中代表 chart 版本，例如 `v1.3.1`，可以通过 `helm search repo -l tidb-operator` 查看当前支持的版本。
 
 2. 配置 TiDB Operator
 
@@ -151,15 +151,15 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     {{< copyable "shell-regular" >}}
 
     ```shell
-    wget http://charts.pingcap.org/tidb-operator-v1.3.0.tgz
+    wget http://charts.pingcap.org/tidb-operator-v1.3.1.tgz
     ```
 
-    将 `tidb-operator-v1.3.0.tgz` 文件拷贝到服务器上并解压到当前目录：
+    将 `tidb-operator-v1.3.1.tgz` 文件拷贝到服务器上并解压到当前目录：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    tar zxvf tidb-operator.v1.3.0.tgz
+    tar zxvf tidb-operator.v1.3.1.tgz
     ```
 
 2. 下载 TiDB Operator 运行所需的 Docker 镜像
@@ -169,8 +169,8 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     TiDB Operator 用到的 Docker 镜像有：
 
     ```shell
-    pingcap/tidb-operator:v1.3.0
-    pingcap/tidb-backup-manager:v1.3.0
+    pingcap/tidb-operator:v1.3.1
+    pingcap/tidb-backup-manager:v1.3.1
     bitnami/kubectl:latest
     pingcap/advanced-statefulset:v0.3.3
     k8s.gcr.io/kube-scheduler:v1.16.9
@@ -183,13 +183,13 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker pull pingcap/tidb-operator:v1.3.0
-    docker pull pingcap/tidb-backup-manager:v1.3.0
+    docker pull pingcap/tidb-operator:v1.3.1
+    docker pull pingcap/tidb-backup-manager:v1.3.1
     docker pull bitnami/kubectl:latest
     docker pull pingcap/advanced-statefulset:v0.3.3
 
-    docker save -o tidb-operator-v1.3.0.tar pingcap/tidb-operator:v1.3.0
-    docker save -o tidb-backup-manager-v1.3.0.tar pingcap/tidb-backup-manager:v1.3.0
+    docker save -o tidb-operator-v1.3.1.tar pingcap/tidb-operator:v1.3.1
+    docker save -o tidb-backup-manager-v1.3.1.tar pingcap/tidb-backup-manager:v1.3.1
     docker save -o bitnami-kubectl.tar bitnami/kubectl:latest
     docker save -o advanced-statefulset-v0.3.3.tar pingcap/advanced-statefulset:v0.3.3
     ```
@@ -199,8 +199,8 @@ tidbmonitors.pingcap.com             2020-06-11T07:59:41Z
     {{< copyable "shell-regular" >}}
 
     ```shell
-    docker load -i tidb-operator-v1.3.0.tar
-    docker load -i tidb-backup-manager-v1.3.0.tar
+    docker load -i tidb-operator-v1.3.1.tar
+    docker load -i tidb-backup-manager-v1.3.1.tar
     docker load -i bitnami-kubectl.tar
     docker load -i advanced-statefulset-v0.3.3.tar
     ```

--- a/zh/get-started.md
+++ b/zh/get-started.md
@@ -271,7 +271,7 @@ customresourcedefinition.apiextensions.k8s.io/tidbclusterautoscalers.pingcap.com
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.0
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.1
     ```
 
     如果访问 Docker Hub 网速较慢，可以使用阿里云上的镜像：
@@ -279,9 +279,9 @@ customresourcedefinition.apiextensions.k8s.io/tidbclusterautoscalers.pingcap.com
     {{< copyable "shell-regular" >}}
 
     ```
-    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.0 \
-        --set operatorImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-operator:v1.3.0 \
-        --set tidbBackupManagerImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-backup-manager:v1.3.0 \
+    helm install --namespace tidb-admin tidb-operator pingcap/tidb-operator --version v1.3.1 \
+        --set operatorImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-operator:v1.3.1 \
+        --set tidbBackupManagerImage=registry.cn-beijing.aliyuncs.com/tidb/tidb-backup-manager:v1.3.1 \
         --set scheduler.kubeSchedulerImageName=registry.cn-hangzhou.aliyuncs.com/google_containers/kube-scheduler
     ```
 

--- a/zh/tidb-toolkit.md
+++ b/zh/tidb-toolkit.md
@@ -201,12 +201,12 @@ helm search repo pingcap
 
 ```
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-pingcap/tidb-backup     v1.3.0                          A Helm chart for TiDB Backup or Restore
-pingcap/tidb-cluster    v1.3.0                          A Helm chart for TiDB Cluster
-pingcap/tidb-drainer    v1.3.0                          A Helm chart for TiDB Binlog drainer.
-pingcap/tidb-lightning  v1.3.0                          A Helm chart for TiDB Lightning
-pingcap/tidb-operator   v1.3.0          v1.3.0          tidb-operator Helm chart for Kubernetes
-pingcap/tikv-importer   v1.3.0                          A Helm chart for TiKV Importer
+pingcap/tidb-backup     v1.3.1                          A Helm chart for TiDB Backup or Restore
+pingcap/tidb-cluster    v1.3.1                          A Helm chart for TiDB Cluster
+pingcap/tidb-drainer    v1.3.1                          A Helm chart for TiDB Binlog drainer.
+pingcap/tidb-lightning  v1.3.1                          A Helm chart for TiDB Lightning
+pingcap/tidb-operator   v1.3.1          v1.3.1          tidb-operator Helm chart for Kubernetes
+pingcap/tikv-importer   v1.3.1                          A Helm chart for TiKV Importer
 ```
 
 当新版本的 chart 发布后，你可以使用 `helm repo update` 命令更新本地对于仓库的缓存：
@@ -266,9 +266,9 @@ helm uninstall ${release_name} -n ${namespace}
 {{< copyable "shell-regular" >}}
 
 ```shell
-wget http://charts.pingcap.org/tidb-operator-v1.3.0.tgz
-wget http://charts.pingcap.org/tidb-drainer-v1.3.0.tgz
-wget http://charts.pingcap.org/tidb-lightning-v1.3.0.tgz
+wget http://charts.pingcap.org/tidb-operator-v1.3.1.tgz
+wget http://charts.pingcap.org/tidb-drainer-v1.3.1.tgz
+wget http://charts.pingcap.org/tidb-lightning-v1.3.1.tgz
 ```
 
 将这些 chart 文件拷贝到服务器上并解压，可以通过 `helm install` 命令使用这些 chart 来安装相应组件，以 `tidb-operator` 为例：
@@ -276,7 +276,7 @@ wget http://charts.pingcap.org/tidb-lightning-v1.3.0.tgz
 {{< copyable "shell-regular" >}}
 
 ```shell
-tar zxvf tidb-operator.v1.3.0.tgz
+tar zxvf tidb-operator.v1.3.1.tgz
 helm install ${release_name} ./tidb-operator --namespace=${namespace}
 ```
 

--- a/zh/upgrade-tidb-operator.md
+++ b/zh/upgrade-tidb-operator.md
@@ -70,27 +70,27 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
             kubectl get crd tidbclusters.pingcap.com
             ```
 
-    本文以 TiDB Operator v1.3.0 为例，你需要替换 `${operator_version}` 为你要升级到的 TiDB Operator 版本。
+    本文以 TiDB Operator v1.3.1 为例，你需要替换 `${operator_version}` 为你要升级到的 TiDB Operator 版本。
 
 3. 获取你要升级的 `tidb-operator` chart 中的 `values.yaml` 文件：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    mkdir -p ${HOME}/tidb-operator/v1.3.0 && \
-    helm inspect values pingcap/tidb-operator --version=v1.3.0 > ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+    mkdir -p ${HOME}/tidb-operator/v1.3.1 && \
+    helm inspect values pingcap/tidb-operator --version=v1.3.1 > ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
     ```
 
-4. 修改 `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本。
+4. 修改 `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本。
 
-5. 如果你在旧版本 `values.yaml` 中设置了自定义配置，将自定义配置合并到 `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` 中。
+5. 如果你在旧版本 `values.yaml` 中设置了自定义配置，将自定义配置合并到 `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` 中。
 
 6. 执行升级：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.0 -f ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator pingcap/tidb-operator --version=v1.3.1 -f ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
     ```
 
 7. Pod 全部正常启动之后，运行以下命令确认 TiDB Operator 镜像版本：
@@ -101,13 +101,13 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-    如果输出类似下方的结果，则表示升级成功。其中，`v1.3.0` 表示已升级到的版本号。
+    如果输出类似下方的结果，则表示升级成功。其中，`v1.3.1` 表示已升级到的版本号。
 
     ```
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
     ```
 
     > **注意：**
@@ -138,14 +138,14 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
             wget -O crd.yaml https://raw.githubusercontent.com/pingcap/tidb-operator/${operator_version}/manifests/crd_v1beta1.yaml
             ```
 
-        本文以 TiDB Operator v1.3.0 为例，你需要替换 `${operator_version}` 为你要升级到的 TiDB Operator 版本。
+        本文以 TiDB Operator v1.3.1 为例，你需要替换 `${operator_version}` 为你要升级到的 TiDB Operator 版本。
 
     2. 下载 `tidb-operator` chart 包文件：
 
         {{< copyable "shell-regular" >}}
 
         ```shell
-        wget http://charts.pingcap.org/tidb-operator-v1.3.0.tgz
+        wget http://charts.pingcap.org/tidb-operator-v1.3.1.tgz
         ```
 
     3. 下载 TiDB Operator 升级所需的 Docker 镜像:
@@ -153,11 +153,11 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        docker pull pingcap/tidb-operator:v1.3.0
-        docker pull pingcap/tidb-backup-manager:v1.3.0
+        docker pull pingcap/tidb-operator:v1.3.1
+        docker pull pingcap/tidb-backup-manager:v1.3.1
 
-        docker save -o tidb-operator-v1.3.0.tar pingcap/tidb-operator:v1.3.0
-        docker save -o tidb-backup-manager-v1.3.0.tar pingcap/tidb-backup-manager:v1.3.0
+        docker save -o tidb-operator-v1.3.1.tar pingcap/tidb-operator:v1.3.1
+        docker save -o tidb-backup-manager-v1.3.1.tar pingcap/tidb-backup-manager:v1.3.1
         ```
 
 2. 将下载的文件和镜像上传到需要升级的服务器上，在服务器上按照以下步骤进行安装：
@@ -185,9 +185,9 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        tar zxvf tidb-operator-v1.3.0.tgz && \
-        mkdir -p ${HOME}/tidb-operator/v1.3.0 && \
-        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+        tar zxvf tidb-operator-v1.3.1.tgz && \
+        mkdir -p ${HOME}/tidb-operator/v1.3.1 && \
+        cp tidb-operator/values.yaml ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
         ```
 
     4. 安装 Docker 镜像到服务器上：
@@ -195,20 +195,20 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
         {{< copyable "shell-regular" >}}
 
         ```shell
-        docker load -i tidb-operator-v1.3.0.tar && \
-        docker load -i tidb-backup-manager-v1.3.0.tar
+        docker load -i tidb-operator-v1.3.1.tar && \
+        docker load -i tidb-backup-manager-v1.3.1.tar
         ```
 
-3. 修改 `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本。
+3. 修改 `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` 中 `operatorImage` 镜像版本为要升级到的版本。
 
-4. 如果你在旧版本 `values.yaml` 中设置了自定义配置，将自定义配置合并到 `${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml` 中。
+4. 如果你在旧版本 `values.yaml` 中设置了自定义配置，将自定义配置合并到 `${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml` 中。
 
 5. 执行升级：
 
     {{< copyable "shell-regular" >}}
 
     ```shell
-    helm upgrade tidb-operator ./tidb-operator --version=v1.3.0 -f ${HOME}/tidb-operator/v1.3.0/values-tidb-operator.yaml
+    helm upgrade tidb-operator ./tidb-operator --version=v1.3.1 -f ${HOME}/tidb-operator/v1.3.1/values-tidb-operator.yaml
     ```
 
 6. Pod 全部正常启动之后，运行以下命令确认 TiDB Operator 镜像版本：
@@ -219,13 +219,13 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/upgrade-tidb-operator/']
     kubectl get po -n tidb-admin -l app.kubernetes.io/instance=tidb-operator -o yaml | grep 'image:.*operator:'
     ```
 
-    如果输出类似下方的结果，则表示升级成功。其中，`v1.3.0` 表示已升级到的版本号。
+    如果输出类似下方的结果，则表示升级成功。其中，`v1.3.1` 表示已升级到的版本号。
 
     ```
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
-    image: pingcap/tidb-operator:v1.3.0
-    image: docker.io/pingcap/tidb-operator:v1.3.0
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
+    image: pingcap/tidb-operator:v1.3.1
+    image: docker.io/pingcap/tidb-operator:v1.3.1
     ```
 
     > **注意：**


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added, or deleted? (Required)

Run commands and some manual fix:

```shell
find . -type f | xargs sed -i "s/v1.3.0/v1.3.1/g"
git checkout -- zh/releases en/releases
```

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
