### PR TITLE
monitor: bump prometheus version to v2.27.1 and grafana to 7.5.11

### DIFF
--- a/en/deploy-heterogeneous-tidb-cluster.md
+++ b/en/deploy-heterogeneous-tidb-cluster.md
@@ -214,10 +214,10 @@ If you need to deploy a monitoring component for a heterogeneous cluster, take t
         - name: ${heterogeneous_cluster_name}
     prometheus:
         baseImage: prom/prometheus
-        version: v2.11.1
+        version: v2.27.1
     grafana:
         baseImage: grafana/grafana
-        version: 6.1.6
+        version: 7.5.11
     initializer:
         baseImage: pingcap/tidb-monitor-initializer
         version: v5.4.0

--- a/en/monitor-a-tidb-cluster.md
+++ b/en/monitor-a-tidb-cluster.md
@@ -39,12 +39,12 @@ spec:
   storage: 5G
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     service:
       type: NodePort
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: NodePort
   initializer:
@@ -155,12 +155,12 @@ spec:
   alertmanagerURL: alertmanager-main.monitoring:9093
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     service:
       type: NodePort
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: NodePort
   initializer:
@@ -201,7 +201,7 @@ spec:
   persistent: false
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     ingress:
       hosts:
       - example.com
@@ -209,7 +209,7 @@ spec:
         foo: "bar"
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: ClusterIP
     ingress:
@@ -241,7 +241,7 @@ spec:
   persistent: false
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     ingress:
       hosts:
       - example.com
@@ -251,7 +251,7 @@ spec:
         secretName: testsecret-tls
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: ClusterIP
   initializer:
@@ -323,12 +323,12 @@ spec:
   storage: 5G
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     service:
       type: NodePort
   grafana:
     baseImage: grafana/grafana
-    version: 6.7.6
+    version: 7.5.11
     service:
       type: NodePort
   initializer:

--- a/zh/deploy-heterogeneous-tidb-cluster.md
+++ b/zh/deploy-heterogeneous-tidb-cluster.md
@@ -213,10 +213,10 @@ summary: 本文档介绍如何为已有的 TiDB 集群部署一个异构集群�
         - name: ${heterogeneous_cluster_name}
     prometheus:
         baseImage: prom/prometheus
-        version: v2.11.1
+        version: v2.27.1
     grafana:
         baseImage: grafana/grafana
-        version: 6.1.6
+        version: 7.5.11
     initializer:
         baseImage: pingcap/tidb-monitor-initializer
         version: v5.4.0

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -37,12 +37,12 @@ spec:
   storage: 5G
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     service:
       type: NodePort
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: NodePort
   initializer:
@@ -153,12 +153,12 @@ spec:
   alertmanagerURL: alertmanager-main.monitoring:9093
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     service:
       type: NodePort
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: NodePort
   initializer:
@@ -197,7 +197,7 @@ spec:
   persistent: false
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     ingress:
       hosts:
       - example.com
@@ -205,7 +205,7 @@ spec:
         foo: "bar"
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: ClusterIP
     ingress:
@@ -237,7 +237,7 @@ spec:
   persistent: false
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     ingress:
       hosts:
       - example.com
@@ -247,7 +247,7 @@ spec:
         secretName: testsecret-tls
   grafana:
     baseImage: grafana/grafana
-    version: 6.1.6
+    version: 7.5.11
     service:
       type: ClusterIP
   initializer:
@@ -317,12 +317,12 @@ spec:
   storage: 5G
   prometheus:
     baseImage: prom/prometheus
-    version: v2.18.1
+    version: v2.27.1
     service:
       type: NodePort
   grafana:
     baseImage: grafana/grafana
-    version: 6.7.6
+    version: 7.5.11
     service:
       type: NodePort
   initializer:


### PR DESCRIPTION
Signed-off-by: just1900 <legendj228@gmail.com>

### What is changed, added, or deleted? (Required)

bump prometheus version to v2.27.1 and grafana to 7.5.11
close #1459 
<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
