### PR TITLE
Update deploy-on-gcp-gke.md, give storageclass demo, change command error  

### DIFF
--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -66,11 +66,11 @@ gcloud config set compute/region <gcp-region>
 
     ```shell
     gcloud container node-pools create pd --cluster tidb --machine-type n2-standard-4 --num-nodes=1 \
-        --node-labels=dedicated=pd --node-taints=dedicated=pd:NoSchedule
+        --node-labels=dedicated=pd --node-taints=dedicated=pd:NoSchedule --region us-east1
     gcloud container node-pools create tikv --cluster tidb --machine-type n2-highmem-8 --num-nodes=1 \
-        --node-labels=dedicated=tikv --node-taints=dedicated=tikv:NoSchedule
+        --node-labels=dedicated=tikv --node-taints=dedicated=tikv:NoSchedule --region us-east1
     gcloud container node-pools create tidb --cluster tidb --machine-type n2-standard-8 --num-nodes=1 \
-        --node-labels=dedicated=tidb --node-taints=dedicated=tidb:NoSchedule
+        --node-labels=dedicated=tidb --node-taints=dedicated=tidb:NoSchedule --region us-east1
     ```
 
     The process might take a few minutes.
@@ -86,9 +86,15 @@ After the GKE cluster is created, the cluster contains three StorageClasses of d
 To improve I/O write performance, it is recommended to configure `nodelalloc` and `noatime` in the `mountOptions` field of the StorageClass resource. For details, see [TiDB Environment and System Configuration Check](https://docs.pingcap.com/tidb/stable/check-before-deployment#mount-the-data-disk-ext4-filesystem-with-options-on-the-target-machines-that-deploy-tikv).
 
 ```yaml
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
-# ...
+kind: StorageClass
+metadata:
+  name: pd-custom
+provisioner: kubernetes.io/gce-pd 
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: pd-ssd
 mountOptions:
 - nodelalloc,noatime
 ```
@@ -218,7 +224,7 @@ After you deploy a TiDB cluster, you can access the TiDB database via MySQL clie
 
 ### Prepare a bastion host
 
-The LoadBalancer created for your TiDB cluster is an intranet LoadBalancer. You can create a [bastion host](https://cloud.google.com/solutions/connecting-securely#bastion) in the cluster VPC to access the database.
+The LoadBalancer created for your TiDB cluster is an intranet LoadBalancer. You can create a [bastion host](https://cloud.google.com/solutions/connecting-securely#bastion) in the cluster VPC or using an external LoadBalancer to access the database. 
 
 {{< copyable "shell-regular" >}}
 


### PR DESCRIPTION
1. add --region to gcloud command, if not add the parameter, the command will throw a error.
2. add detailed storageclass demo
3. give description of external LB

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [x] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
