### PR TITLE
Update storage class description for GKE deploy

### DIFF
--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -85,12 +85,20 @@ After the GKE cluster is created, the cluster contains three StorageClasses of d
 
 To improve I/O write performance, it is recommended to configure `nodelalloc` and `noatime` in the `mountOptions` field of the StorageClass resource. For details, see [TiDB Environment and System Configuration Check](https://docs.pingcap.com/tidb/stable/check-before-deployment#mount-the-data-disk-ext4-filesystem-with-options-on-the-target-machines-that-deploy-tikv).
 
+It is recommended to use default pd-ssd storageclass `premium-rwo` or to setup a customized storage class:
+
 ```yaml
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
-# ...
+metadata:
+  name: pd-custom
+provisioner: kubernetes.io/gce-pd 
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: pd-ssd
 mountOptions:
-- nodelalloc,noatime
+  - nodelalloc,noatime
 ```
 
 > **Note:**

--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -85,7 +85,7 @@ After the GKE cluster is created, the cluster contains three StorageClasses of d
 
 To improve I/O write performance, it is recommended to configure `nodelalloc` and `noatime` in the `mountOptions` field of the StorageClass resource. For details, see [TiDB Environment and System Configuration Check](https://docs.pingcap.com/tidb/stable/check-before-deployment#mount-the-data-disk-ext4-filesystem-with-options-on-the-target-machines-that-deploy-tikv).
 
-It is recommended to use default pd-ssd storageclass `premium-rwo` or to setup a customized storage class:
+It is recommended to use the default `pd-ssd` storage class `premium-rwo` or to set up a customized storage class:
 
 ```yaml
 kind: StorageClass

--- a/zh/deploy-on-gcp-gke.md
+++ b/zh/deploy-on-gcp-gke.md
@@ -83,12 +83,20 @@ gcloud config set compute/region <gcp-region>
 
 为了提高存储的 IO 性能，推荐在 StorageClass 的 `mountOptions` 字段中，添加存储挂载选项 `nodelalloc` 和 `noatime`。详情可见 [TiDB 环境与系统配置检查](https://docs.pingcap.com/zh/tidb/stable/check-before-deployment#在-tikv-部署目标机器上添加数据盘-ext4-文件系统挂载参数)。
 
+建议使用默认的 `pd-ssd` 存储类型 `premium-rwo`，或设置一个自定义的存储类型。
+
 ```yaml
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
-# ...
+metadata:
+  name: pd-custom
+provisioner: kubernetes.io/gce-pd
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: pd-ssd
 mountOptions:
-- nodelalloc,noatime
+  - nodelalloc,noatime
 ```
 
 > **注意：**


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
The original doc will cause someone don't familiar with GKE be confused, and spend more time on the deployment a correct cluster.
After changing the doc, we also need to consider to give a default storageclass setup in https://raw.githubusercontent.com/pingcap/tidb-operator/master/examples/gcp/tidb-cluster.yaml
If we don't give default sc to pd-ssd, we will also need to step, to tell the user they need to change the default sc type in the yaml for best practice.
<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [x] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
