### PR TITLE
Fix 404 link: Kubernetes scheduler extender

### DIFF
--- a/en/tidb-scheduler.md
+++ b/en/tidb-scheduler.md
@@ -6,7 +6,7 @@ aliases: ['/docs/tidb-in-kubernetes/dev/tidb-scheduler/']
 
 # TiDB Scheduler
 
-TiDB Scheduler is a TiDB implementation of [Kubernetes scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md). TiDB Scheduler is used to add new scheduling rules to Kubernetes. This document introduces these new scheduling rules and how TiDB Scheduler works.
+TiDB Scheduler is a TiDB implementation of [Kubernetes scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md). TiDB Scheduler is used to add new scheduling rules to Kubernetes. This document introduces these new scheduling rules and how TiDB Scheduler works.
 
 ## tidb-scheduler and default-scheduler
 
@@ -82,7 +82,7 @@ Scheduling rule 2: If the number of Kubernetes nodes is less than three (in this
 
 ![TiDB Scheduler Overview](/media/tidb-scheduler-overview.png)
 
-TiDB Scheduler adds customized scheduling rules by implementing Kubernetes [Scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md).
+TiDB Scheduler adds customized scheduling rules by implementing Kubernetes [Scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md).
 
 The TiDB Scheduler component is deployed as one or more Pods, though only one Pod is working at the same time. Each Pod has two Containers inside: one Container is a native `kube-scheduler`, and the other is a `tidb-scheduler` implemented as a Kubernetes scheduler extender.
 

--- a/zh/tidb-scheduler.md
+++ b/zh/tidb-scheduler.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/tidb-scheduler/']
 
 # TiDB Scheduler 扩展调度器
 
-TiDB Scheduler 是 [Kubernetes 调度器扩展](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md) 的 TiDB 实现。TiDB Scheduler 用于向 Kubernetes 添加新的调度规则。本文介绍 TiDB Scheduler 扩展调度器的工作原理。
+TiDB Scheduler 是 [Kubernetes 调度器扩展](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md) 的 TiDB 实现。TiDB Scheduler 用于向 Kubernetes 添加新的调度规则。本文介绍 TiDB Scheduler 扩展调度器的工作原理。
 
 ## tidb-scheduler 与 default-scheduler
 
@@ -82,7 +82,7 @@ kubectl label nodes node1 zone=zone1
 
 ![TiDB Scheduler 工作原理](/media/tidb-scheduler-overview.png)
 
-TiDB Scheduler 通过实现 Kubernetes 调度器扩展（[Scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md)）来添加自定义调度规则。
+TiDB Scheduler 通过实现 Kubernetes 调度器扩展（[Scheduler extender](https://github.com/kubernetes/design-proposals-archive/blob/main/scheduling/scheduler_extender.md)）来添加自定义调度规则。
 
 TiDB Scheduler 组件部署为一个或者多个 Pod，但同时只有一个 Pod 在工作。Pod 内部有两个 Container，一个 Container 是原生的 `kube-scheduler`；另外一个 Container 是 `tidb-scheduler`，实现为一个 Kubernetes scheduler extender。
 


### PR DESCRIPTION
Signed-off-by: Aolin <aolin.zhang@pingcap.com>

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
Close https://github.com/pingcap/docs-tidb-operator/issues/1864
https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md has been removed in https://github.com/kubernetes/community/pull/6591.
<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [x] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
