### PR TITLE
update all old links for docs.pingcap.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TiDB in Kubernetes Documentation
 
-This repository stores all the source files of [TiDB in Kubernetes documentation](https://pingcap.com/docs/tidb-in-kubernetes/stable/) at the PingCAP website. That is, the documentation for [TiDB Operator](https://github.com/pingcap/tidb-operator).
+This repository stores all the source files of [TiDB in Kubernetes documentation](https://docs.pingcap.com/tidb-in-kubernetes/stable/) at the PingCAP website. That is, the documentation for [TiDB Operator](https://github.com/pingcap/tidb-operator).
 
 Currently, the official documentation supports two languages:
 

--- a/en/releases/release-1.0-ga.md
+++ b/en/releases/release-1.0-ga.md
@@ -139,7 +139,7 @@ monitor:
   ...
 ```
 
-Please check [cluster configuration](https://pingcap.com/docs/v3.0/tidb-in-kubernetes/reference/configuration/tidb-cluster/) for detailed configuration.
+Please check [cluster configuration](../configure-a-tidb-cluster.md) for detailed configuration.
 
 ### Stability Test Cases Added
 

--- a/en/releases/release-1.0.4.md
+++ b/en/releases/release-1.0.4.md
@@ -16,7 +16,7 @@ There is no action required if you are upgrading from [v1.0.3](release-1.0.3.md)
 
 ### Highlights
 
-[#1202](https://github.com/pingcap/tidb-operator/pull/1202) introduced `HostNetwork` support, which offers better performance compared to the Pod network. Check out our [benchmark report](https://pingcap.com/docs/dev/benchmark/sysbench-in-k8s/#pod-network-vs-host-network) for details.
+[#1202](https://github.com/pingcap/tidb-operator/pull/1202) introduced `HostNetwork` support, which offers better performance compared to the Pod network. Check out our [benchmark report](../benchmark-sysbench.md) for details.
 
 > **Note:**
 >
@@ -27,11 +27,11 @@ There is no action required if you are upgrading from [v1.0.3](release-1.0.3.md)
 > - `v1.15.4` or later
 > - any version since `v1.16.0`
 
-[#1175](https://github.com/pingcap/tidb-operator/pull/1175) added the `podSecurityContext` support for TiDB cluster Pods. We recommend setting the namespaced kernel parameters for TiDB cluster Pods according to our [Environment Recommendation](https://pingcap.com/docs/dev/tidb-in-kubernetes/deploy/prerequisites/#the-configuration-of-kernel-parameters).
+[#1175](https://github.com/pingcap/tidb-operator/pull/1175) added the `podSecurityContext` support for TiDB cluster Pods. We recommend setting the namespaced kernel parameters for TiDB cluster Pods according to our [Environment Recommendation](../prerequisites.md).
 
-New Helm chart `tidb-lightning` brings [TiDB Lightning](https://pingcap.com/docs/stable/reference/tools/tidb-lightning/overview/) support for TiDB in Kubernetes. Check out the [document](https://pingcap.com/docs/dev/tidb-in-kubernetes/maintain/lightning/) for detailed user guide.
+New Helm chart `tidb-lightning` brings [TiDB Lightning](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview) support for TiDB in Kubernetes. Check out the [document](../restore-data-using-tidb-lightning.md) for detailed user guide.
 
-Another new Helm chart `tidb-drainer` brings multiple drainers support for TiDB Binlog in Kubernetes. Check out the [document](https://pingcap.com/docs/dev/tidb-in-kubernetes/maintain/tidb-binlog/#deploy-multiple-drainers) for detailed user guide.
+Another new Helm chart `tidb-drainer` brings multiple drainers support for TiDB Binlog in Kubernetes. Check out the [document](../deploy-tidb-binlog.md) for detailed user guide.
 
 ### Improvements
 

--- a/zh/configure-a-tidb-cluster.md
+++ b/zh/configure-a-tidb-cluster.md
@@ -17,7 +17,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/configure-a-tidb-cluster/','/zh/tidb-
 
 ## 资源配置
 
-部署前需要根据实际情况和需求，为 TiDB 集群各个组件配置资源，其中 PD、TiKV、TiDB 是 TiDB 集群的核心服务组件，在生产环境下它们的资源配置还需要按组件要求指定，具体参考：[资源配置推荐](https://pingcap.com/docs-cn/stable/how-to/deploy/hardware-recommendations)。
+部署前需要根据实际情况和需求，为 TiDB 集群各个组件配置资源，其中 PD、TiKV、TiDB 是 TiDB 集群的核心服务组件，在生产环境下它们的资源配置还需要按组件要求指定，具体参考：[资源配置推荐](https://docs.pingcap.com/zh/tidb/stable/hardware-and-software-requirements)。
 
 为了保证 TiDB 集群的组件在 Kubernetes 中合理的调度和稳定的运行，建议为其设置 Guaranteed 级别的 QoS，通过在配置资源时让 limits 等于 requests 来实现, 具体参考：[配置 QoS](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/)。
 
@@ -305,7 +305,7 @@ spec:
       oom-action = "log"
 ```
 
-获取所有可以配置的 TiDB 配置参数，请参考 [TiDB 配置文档](https://pingcap.com/docs-cn/stable/tidb-configuration-file/)。
+获取所有可以配置的 TiDB 配置参数，请参考 [TiDB 配置文档](https://docs.pingcap.com/zh/tidb/stable/tidb-configuration-file)。
 
 > **注意：**
 >
@@ -324,7 +324,7 @@ spec:
           capacity = "16GB"
 ```
 
-获取所有可以配置的 TiKV 配置参数，请参考 [TiKV 配置文档](https://pingcap.com/docs-cn/stable/tikv-configuration-file/)
+获取所有可以配置的 TiKV 配置参数，请参考 [TiKV 配置文档](https://docs.pingcap.com/zh/tidb/stable/tikv-configuration-file)
 
 > **注意：**
 >
@@ -342,7 +342,7 @@ spec:
       enable-prevote = true
 ```
 
-获取所有可以配置的 PD 配置参数，请参考 [PD 配置文档](https://pingcap.com/docs-cn/stable/pd-configuration-file/)
+获取所有可以配置的 PD 配置参数，请参考 [PD 配置文档](https://docs.pingcap.com/zh/tidb/stable/pd-configuration-file)
 
 > **注意：**
 >
@@ -368,7 +368,7 @@ spec:
           log = "/data0/logs/server.log"
 ```
 
-获取所有可以配置的 TiFlash 配置参数，请参考 [TiFlash 配置文档](https://pingcap.com/docs-cn/stable/tiflash/tiflash-configuration/)
+获取所有可以配置的 TiFlash 配置参数，请参考 [TiFlash 配置文档](https://docs.pingcap.com/zh/tidb/stable/tiflash-configuration)
 
 #### 配置 TiCDC 启动参数
 
@@ -756,7 +756,7 @@ topologySpreadConstraints:
 
 ### 数据的高可用
 
-在开始数据高可用配置前，首先请阅读[集群拓扑信息配置](https://pingcap.com/docs-cn/stable/schedule-replicas-by-topology-labels/)。该文档描述了 TiDB 集群数据高可用的实现原理。
+在开始数据高可用配置前，首先请阅读[集群拓扑信息配置](https://docs.pingcap.com/zh/tidb/stable/schedule-replicas-by-topology-labels)。该文档描述了 TiDB 集群数据高可用的实现原理。
 
 在 Kubernetes 上支持数据高可用的功能，需要如下操作：
 

--- a/zh/deploy-failures.md
+++ b/zh/deploy-failures.md
@@ -112,7 +112,7 @@ kubectl -n ${namespace} logs -f ${pod_name}
 kubectl -n ${namespace} logs -p ${pod_name}
 ```
 
-确认日志中的错误信息后，可以根据 [tidb-server 启动报错](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/cluster-setup/#tidb-server-启动报错)，[tikv-server 启动报错](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/cluster-setup/#tikv-server-启动报错)，[pd-server 启动报错](https://pingcap.com/docs-cn/v3.0/how-to/troubleshoot/cluster-setup/#pd-server-启动报错)中的指引信息进行进一步排查解决。
+确认日志中的错误信息后，可以根据 [tidb-server 启动报错](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tidb-cluster#tidb-server-%E5%90%AF%E5%8A%A8%E6%8A%A5%E9%94%99)，[tikv-server 启动报错](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tidb-cluster#tikv-server-%E5%90%AF%E5%8A%A8%E6%8A%A5%E9%94%99)，[pd-server 启动报错](https://docs.pingcap.com/zh/tidb/stable/troubleshoot-tidb-cluster#pd-server-%E5%90%AF%E5%8A%A8%E6%8A%A5%E9%94%99)中的指引信息进行进一步排查解决。
 
 ### cluster id mismatch
 

--- a/zh/deploy-ticdc.md
+++ b/zh/deploy-ticdc.md
@@ -47,7 +47,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-ticdc/']
     kubectl exec -it ${pod_name} -n ${namespace} -- sh
     ```
 
-5. 然后通过 `cdc cli` 进行[管理集群和同步任务](https://pingcap.com/docs-cn/stable/ticdc/manage-ticdc/)。
+5. 然后通过 `cdc cli` 进行[管理集群和同步任务](https://docs.pingcap.com/zh/tidb/stable/manage-ticdc)。
 
     {{< copyable "shell-regular" >}}
 

--- a/zh/deploy-tidb-binlog.md
+++ b/zh/deploy-tidb-binlog.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-tidb-binlog/']
 
 # 部署 TiDB Binlog
 
-本文档介绍如何在 Kubernetes 上部署 TiDB 集群的 [TiDB Binlog](https://pingcap.com/docs-cn/stable/tidb-binlog/tidb-binlog-overview/)。
+本文档介绍如何在 Kubernetes 上部署 TiDB 集群的 [TiDB Binlog](https://docs.pingcap.com/zh/tidb/stable/tidb-binlog-overview)。
 
 ## 部署准备
 

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -677,7 +677,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
 
 ## 第三步：配置 MySQL 客户端使用加密连接
 
-可以根据[官网文档](https://pingcap.com/docs-cn/stable/how-to/secure/enable-tls-clients/#配置-mysql-客户端使用加密连接)提示，使用上面创建的 Client 证书，通过下面的方法连接 TiDB 集群：
+可以根据[官网文档](https://docs.pingcap.com/zh/tidb/stable/enable-tls-between-clients-and-servers#配置-mysql-client-使用安全连接)提示，使用上面创建的 Client 证书，通过下面的方法连接 TiDB 集群：
 
 获取 Client 证书的方式并连接 TiDB Server 的方法是：
 
@@ -699,4 +699,4 @@ mysql --comments -uroot -p -P 4000 -h ${tidb_host} --ssl-cert=client-tls.crt --s
 >
 > [MySQL 8.0 默认认证插件](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin)从 `mysql_native_password` 更新为 `caching_sha2_password`，因此如果使用 MySQL 8.0 客户端访问 TiDB 服务（TiDB 版本 < v4.0.7），并且用户账户有配置密码，需要显示指定 `--default-auth=mysql_native_password` 参数。
 
-最后请参考 [官网文档](https://pingcap.com/docs-cn/stable/enable-tls-between-clients-and-servers/#检查当前连接是否是加密连接) 来验证是否正确开启了 TLS。
+最后请参考 [官网文档](hhttps://docs.pingcap.com/zh/tidb/stable/enable-tls-between-clients-and-servers#检查当前连接是否是加密连接) 来验证是否正确开启了 TLS。

--- a/zh/faq.md
+++ b/zh/faq.md
@@ -44,7 +44,7 @@ spec:
 
 2. 修改 TiDB 支持新的时区
 
-    参考[时区支持](https://pingcap.com/docs-cn/stable/configure-time-zone/)，修改 TiDB 服务时区配置。
+    参考[时区支持](https://docs.pingcap.com/zh/tidb/stable/configure-time-zone)，修改 TiDB 服务时区配置。
 
 ## TiDB 相关组件可以配置 HPA 或 VPA 么？
 
@@ -71,7 +71,7 @@ TiDB 集群目前还不支持 HPA（Horizontal Pod Autoscaling，自动水平扩
 
 TiDB Operator 尚不支持自动编排 TiSpark。
 
-假如要为 TiDB in Kubernetes 添加 TiSpark 组件，你需要在**同一个** Kubernetes 集群中自行维护 Spark，确保 Spark 能够访问到 PD 和 TiKV 实例的 IP 与端口，并为 Spark 安装 TiSpark 插件，TiSpark 插件的安装方式可以参考 [TiSpark](https://pingcap.com/docs-cn/stable/tispark-overview/#已有-spark-集群的部署方式)。
+假如要为 TiDB in Kubernetes 添加 TiSpark 组件，你需要在**同一个** Kubernetes 集群中自行维护 Spark，确保 Spark 能够访问到 PD 和 TiKV 实例的 IP 与端口，并为 Spark 安装 TiSpark 插件，TiSpark 插件的安装方式可以参考 [TiSpark](https://docs.pingcap.com/zh/tidb/stable/tispark-overview#在已有-spark-集群上部署-tispark)。
 
 在 Kubernetes 上维护 Spark 可以参考 Spark 的官方文档：[Spark on Kubernetes](http://spark.apache.org/docs/latest/running-on-kubernetes.html)。
 

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -12,7 +12,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/monitor-a-tidb-cluster/', '/docs-cn/t
 
 TiDB 通过 Prometheus 和 Grafana 监控 TiDB 集群。在通过 TiDB Operator 创建新的 TiDB 集群时，可以对于每个 TiDB 集群，创建、配置一套独立的监控系统，与 TiDB 集群运行在同一 Namespace，包括 Prometheus 和 Grafana 两个组件。
 
-在 [TiDB 集群监控](https://pingcap.com/docs-cn/stable/deploy-monitoring-services/)中有一些监控系统配置的细节可供参考。
+在 [TiDB 集群监控](https://docs.pingcap.com/zh/tidb/stable/deploy-monitoring-services)中有一些监控系统配置的细节可供参考。
 
 在 v1.1 及更高版本的 TiDB Operator 中，可以通过简单的 CR 文件（即 TidbMonitor，可参考 [tidb-operator 中的示例](https://github.com/pingcap/tidb-operator/blob/master/manifests/monitor/tidb-monitor.yaml)）来快速建立对 Kubernetes 集群上的 TiDB 集群的监控。
 

--- a/zh/pd-recover.md
+++ b/zh/pd-recover.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/pd-recover/']
 
 # 使用 PD Recover 恢复 PD 集群
 
-PD Recover 是对 PD 进行灾难性恢复的工具，用于恢复无法正常启动或服务的 PD 集群。该工具的详细介绍参见 [TiDB 文档 - PD Recover](https://pingcap.com/docs-cn/stable/reference/tools/pd-recover)。本文档介绍如何下载 PD Recover 工具，以及如何使用该工具恢复 PD 集群。
+PD Recover 是对 PD 进行灾难性恢复的工具，用于恢复无法正常启动或服务的 PD 集群。该工具的详细介绍参见 [TiDB 文档 - PD Recover](https://docs.pingcap.com/zh/tidb/stable/pd-recover)。本文档介绍如何下载 PD Recover 工具，以及如何使用该工具恢复 PD 集群。
 
 ## 下载 PD Recover
 

--- a/zh/prerequisites.md
+++ b/zh/prerequisites.md
@@ -91,7 +91,7 @@ Kubelet 正常工作需要关闭 Swap，并且把 `/etc/fstab` 里面有关 Swap
 
 ```shell
 swapoff -a
-sed -i 's/^\(.*swap.*\)$/#\1/' /etc/fstab 
+sed -i 's/^\(.*swap.*\)$/#\1/' /etc/fstab
 ```
 
 ## 内核参数设置
@@ -136,7 +136,7 @@ systemctl start irqbalance
 
 ## CPUfreq 调节器模式设置
 
-为了让 CPU 发挥最大性能，请将 CPUfreq 调节器模式设置为 performance 模式。详细参考[在部署目标机器上配置 CPUfreq 调节器模式](https://pingcap.com/docs-cn/stable/online-deployment-using-ansible/#查看系统支持的调节器模式)。
+为了让 CPU 发挥最大性能，请将 CPUfreq 调节器模式设置为 performance 模式。详细参考[在部署目标机器上配置 CPUfreq 调节器模式](https://docs.pingcap.com/zh/tidb/stable/check-before-deployment#检查和配置操作系统优化参数)。
 
 {{< copyable "shell-regular" >}}
 
@@ -242,18 +242,18 @@ Kubernetes Master 节点的配置取决于 Kubernetes 集群中 Node 节点个�
 1. 将 Kubelet 的数据保存到一块单独盘上（可跟 Docker 共用一块盘），Kubelet 主要占盘的数据是 [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) 所使用的数据。通过设置 `--root-dir` 参数来实现：
 
     {{< copyable "shell-regular" >}}
-    
+
     ```shell
     echo "KUBELET_EXTRA_ARGS=--root-dir=/data1/kubelet" > /etc/sysconfig/kubelet
     systemctl restart kubelet
     ```
-   
+
     上面会将 Kubelet 数据目录设置为 `/data1/kubelet`。
-    
+
 2. 通过 kubelet 设置[预留资源](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/)，保证机器上的系统进程以及 Kubernetes 的核心进程在工作负载很高的情况下仍然有足够的资源来运行，从而保证整个系统的稳定。
 
 ## TiDB 集群资源需求
 
-请根据[服务器建议配置](https://pingcap.com/docs-cn/stable/hardware-and-software-requirements/#生产环境)来规划机器的配置。
+请根据[服务器建议配置](https://docs.pingcap.com/zh/tidb/stable/hardware-and-software-requirements#生产环境)来规划机器的配置。
 
 另外，在生产环境中，尽量不要在 Kubernetes Master 节点部署 TiDB 实例，或者尽可能少地部署 TiDB 实例。因为网卡带宽的限制，Master 节点网卡满负荷工作会影响到 Worker 节点和 Master 节点之间的心跳信息汇报，导致比较严重的问题。

--- a/zh/releases/release-1.0-ga.md
+++ b/zh/releases/release-1.0-ga.md
@@ -139,7 +139,7 @@ monitor:
   ...
 ```
 
-Please check [cluster configuration](https://pingcap.com/docs/v3.0/tidb-in-kubernetes/reference/configuration/tidb-cluster/) for detailed configuration.
+Please check [cluster configuration](../configure-a-tidb-cluster.md) for detailed configuration.
 
 ### Stability Test Cases Added
 

--- a/zh/releases/release-1.0.4.md
+++ b/zh/releases/release-1.0.4.md
@@ -16,7 +16,7 @@ There is no action required if you are upgrading from [v1.0.3](release-1.0.3.md)
 
 ### Highlights
 
-[#1202](https://github.com/pingcap/tidb-operator/pull/1202) introduced `HostNetwork` support, which offers better performance compared to the Pod network. Check out our [benchmark report](https://pingcap.com/docs/dev/benchmark/sysbench-in-k8s/#pod-network-vs-host-network) for details.
+[#1202](https://github.com/pingcap/tidb-operator/pull/1202) introduced `HostNetwork` support, which offers better performance compared to the Pod network. Check out our [benchmark report](../benchmark-sysbench.md) for details.
 
 > **Note:**
 >
@@ -27,11 +27,11 @@ There is no action required if you are upgrading from [v1.0.3](release-1.0.3.md)
 > - `v1.15.4` or later
 > - any version since `v1.16.0`
 
-[#1175](https://github.com/pingcap/tidb-operator/pull/1175) added the `podSecurityContext` support for TiDB cluster Pods. We recommend setting the namespaced kernel parameters for TiDB cluster Pods according to our [Environment Recommendation](https://pingcap.com/docs/dev/tidb-in-kubernetes/deploy/prerequisites/#the-configuration-of-kernel-parameters).
+[#1175](https://github.com/pingcap/tidb-operator/pull/1175) added the `podSecurityContext` support for TiDB cluster Pods. We recommend setting the namespaced kernel parameters for TiDB cluster Pods according to our [Environment Recommendation](../prerequisites.md).
 
-New Helm chart `tidb-lightning` brings [TiDB Lightning](https://pingcap.com/docs/stable/reference/tools/tidb-lightning/overview/) support for TiDB in Kubernetes. Check out the [document](https://pingcap.com/docs/dev/tidb-in-kubernetes/maintain/lightning/) for detailed user guide.
+New Helm chart `tidb-lightning` brings [TiDB Lightning](https://docs.pingcap.com/tidb/stable/tidb-lightning-overview) support for TiDB in Kubernetes. Check out the [document](../restore-data-using-tidb-lightning.md) for detailed user guide.
 
-Another new Helm chart `tidb-drainer` brings multiple drainers support for TiDB Binlog in Kubernetes. Check out the [document](https://pingcap.com/docs/dev/tidb-in-kubernetes/maintain/tidb-binlog/#deploy-multiple-drainers) for detailed user guide.
+Another new Helm chart `tidb-drainer` brings multiple drainers support for TiDB Binlog in Kubernetes. Check out the [document](../deploy-tidb-binlog.md) for detailed user guide.
 
 ### Improvements
 

--- a/zh/restore-data-using-tidb-lightning.md
+++ b/zh/restore-data-using-tidb-lightning.md
@@ -15,11 +15,11 @@ TiDB Lightning 包含两个组件：tidb-lightning 和 tikv-importer。在 Kuber
 - 对于 `Importer-backend` 后端，需要分别部署 tikv-importer 与 tidb-lightning。
 
     > **注意：**
-    > 
+    >
     > `Importer-backend` 后端在 TiDB 5.3 及之后的版本被废弃。如果必须使用 `Importer-backend` 后端，请参考 v1.2 及以前的[旧版文档](https://docs.pingcap.com/zh/tidb-in-kubernetes/v1.2/restore-data-using-tidb-lightning#部署-tikv-importer)部署 tikv-importer。
 
 - 对于 `Local-backend` 后端，只需要部署 tidb-lightning。
-  
+
 - 对于 `TiDB-backend` 后端，只需要部署 tidb-lightning。推荐使用基于 TiDB Operator 新版（v1.1 及以上）的 CustomResourceDefinition (CRD) 实现。具体信息可参考[使用 TiDB Lightning 恢复 GCS 上的备份数据](restore-from-gcs.md)或[使用 TiDB Lightning 恢复 S3 兼容存储上的备份数据](restore-from-s3.md)。
 
 ## 部署 TiDB Lightning
@@ -186,7 +186,7 @@ dataSource:
             ```
 
 2. 配置 `dataSource` 字段。示例如下：
-   
+
     ```yaml
     dataSource:
       remote:
@@ -197,9 +197,9 @@ dataSource:
         path: s3:bench-data-us/sysbench/sbtest_16_1e7.tar.gz
         # directory: s3:bench-data-us
     ```
-    
+
     相关字段含义如下：
-    
+
     * `dataSource.remote.storageClassName`：创建 PV 使用的 StorageClass 名称。
     * `dataSource.remote.secretName`：上一步所创建的 Secret 的名称。
     * `dataSource.remote.path`：如果备份数据打包为 tarball 文件，使用该字段表明 tarball 文件的路径。
@@ -312,7 +312,7 @@ helm uninstall ${release_name} -n ${namespace}
 
     如果使用远程模式进行数据恢复，且异常发生在从网络存储下载数据的过程中，则依据 log 信息进行处理后，直接重新部署 tidb-lightning 进行数据恢复。否则，继续按下述步骤进行处理。
 
-2. 依据 log 并参考 [TiDB Lightning 故障排除指南](https://pingcap.com/docs-cn/stable/troubleshoot-tidb-lightning/)，了解各故障类型的处理方法。
+2. 依据 log 并参考 [TiDB Lightning 故障排除指南](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-faq)，了解各故障类型的处理方法。
 
 3. 对于不同的故障类型，分别进行处理：
 
@@ -340,13 +340,13 @@ helm uninstall ${release_name} -n ${namespace}
 
         5. 运行 `cat /proc/1/cmdline`，获得启动脚本。
 
-        6. 根据启动脚本中的命令行参数，参考 [TiDB Lightning 故障排除指南](https://pingcap.com/docs-cn/stable/troubleshoot-tidb-lightning/)并使用 tidb-lightning-ctl 进行故障处理。
+        6. 根据启动脚本中的命令行参数，参考 [TiDB Lightning 故障排除指南](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-faq)并使用 tidb-lightning-ctl 进行故障处理。
 
         7. 故障处理完成后，将 `values.yaml` 中的 `failFast` 设置为 `true` 并再次创建新的 `Job` 用于继续数据恢复。
 
     - 如果不需要使用 tidb-lightning-ctl 进行处理：
 
-        1. 参考 [TiDB Lightning 故障排除指南](https://pingcap.com/docs-cn/stable/troubleshoot-tidb-lightning/)进行故障处理。
+        1. 参考 [TiDB Lightning 故障排除指南](https://docs.pingcap.com/zh/tidb/stable/tidb-lightning-faq)进行故障处理。
 
         2. 设置 `values.yaml` 的 `dataSource` 以确保新 `Job` 将使用发生故障的 `Job` 已有的数据源及 checkpoint 信息：
 

--- a/zh/restore-from-aws-s3-using-br.md
+++ b/zh/restore-from-aws-s3-using-br.md
@@ -8,7 +8,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/restore-from-aws-s3-using-br/']
 
 本文介绍如何将 S3 兼容存储上的 SST 备份数据恢复到 AWS Kubernetes 环境中的 TiDB 集群。
 
-本文使用的恢复方式基于 TiDB Operator 的 Custom Resource Definition (CRD) 实现，底层使用 [BR](https://pingcap.com/docs-cn/stable/br/backup-and-restore-tool/) 进行数据恢复。BR 全称为 Backup & Restore，是 TiDB 分布式备份恢复的命令行工具，用于对 TiDB 集群进行数据备份和恢复。
+本文使用的恢复方式基于 TiDB Operator 的 Custom Resource Definition (CRD) 实现，底层使用 [BR](https://docs.pingcap.com/zh/tidb/stable/backup-and-restore-overview) 进行数据恢复。BR 全称为 Backup & Restore，是 TiDB 分布式备份恢复的命令行工具，用于对 TiDB 集群进行数据备份和恢复。
 
 ## 使用场景
 

--- a/zh/tidb-toolkit.md
+++ b/zh/tidb-toolkit.md
@@ -10,7 +10,7 @@ Kubernetes 上的 TiDB 运维管理需要使用一些开源工具。同时，在
 
 ## 在 Kubernetes 上使用 PD Control
 
-[PD Control](https://pingcap.com/docs-cn/stable/pd-control/) 是 PD 的命令行工具，在使用 PD Control 操作 Kubernetes 上的 TiDB 集群时，需要先使用 `kubectl port-forward` 打开本地到 PD 服务的连接：
+[PD Control](https://docs.pingcap.com/zh/tidb/stable/pd-control) 是 PD 的命令行工具，在使用 PD Control 操作 Kubernetes 上的 TiDB 集群时，需要先使用 `kubectl port-forward` 打开本地到 PD 服务的连接：
 
 {{< copyable "shell-regular" >}}
 
@@ -44,7 +44,7 @@ pd-ctl -u 127.0.0.1:${local_port} -d config show
 
 ## 在 Kubernetes 上使用 TiKV Control
 
-[TiKV Control](https://pingcap.com/docs-cn/stable/tikv-control/) 是 TiKV 的命令行工具。在使用 TiKV Control 操作 Kubernetes 上的 TiDB 集群时，针对 TiKV Control 的不同操作模式，有不同的操作步骤。
+[TiKV Control](https://docs.pingcap.com/zh/tidb/stable/tikv-control) 是 TiKV 的命令行工具。在使用 TiKV Control 操作 Kubernetes 上的 TiDB 集群时，针对 TiKV Control 的不同操作模式，有不同的操作步骤。
 
 * **远程模式**：此模式下 `tikv-ctl` 命令需要通过网络访问 TiKV 服务或 PD 服务，因此需要先使用 `kubectl port-forward` 打开本地到 PD 服务以及目标 TiKV 节点的连接：
 
@@ -110,7 +110,7 @@ pd-ctl -u 127.0.0.1:${local_port} -d config show
 
 ## 在 Kubernetes 上使用 TiDB Control
 
-[TiDB Control](https://pingcap.com/docs-cn/stable/tidb-control/) 是 TiDB 的命令行工具，使用 TiDB Control 时，需要从本地访问 TiDB 节点和 PD 服务，因此建议使用 `kubectl port-forward` 打开到集群中 TiDB 节点和 PD 服务的连接：
+[TiDB Control](https://docs.pingcap.com/zh/tidb/stable/tidb-control) 是 TiDB 的命令行工具，使用 TiDB Control 时，需要从本地访问 TiDB 节点和 PD 服务，因此建议使用 `kubectl port-forward` 打开到集群中 TiDB 节点和 PD 服务的连接：
 
 {{< copyable "shell-regular" >}}
 


### PR DESCRIPTION
Signed-off-by: Ran <huangran.alex@gmail.com>

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
The old links redirect users to v4.0 TiDB docs. I'm updating them to use the stable version of TiDB docs.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
