### PR TITLE
add cleanPolicy for BackupSchedule

### DIFF
--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -458,6 +458,8 @@ Depending on which method you choose to grant permissions to the remote storage,
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         br:
           cluster: demo1
           sendCredToTikv: false
@@ -508,6 +510,8 @@ Depending on which method you choose to grant permissions to the remote storage,
       serviceAccount: tidb-backup-manager
       backupTemplate:
         backupType: full
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         br:
           cluster: demo1
           sendCredToTikv: false

--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -404,6 +404,8 @@ Depending on which method you choose to grant permissions to the remote storage,
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -404,7 +404,7 @@ Depending on which method you choose to grant permissions to the remote storage,
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         br:
           cluster: demo1
@@ -458,7 +458,7 @@ Depending on which method you choose to grant permissions to the remote storage,
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         br:
           cluster: demo1
@@ -510,7 +510,7 @@ Depending on which method you choose to grant permissions to the remote storage,
       serviceAccount: tidb-backup-manager
       backupTemplate:
         backupType: full
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         br:
           cluster: demo1

--- a/en/backup-to-gcs-using-br.md
+++ b/en/backup-to-gcs-using-br.md
@@ -304,7 +304,7 @@ The steps to prepare for a scheduled full backup are the same as that of [Prepar
       maxReservedTime: "3h"
       schedule: "*/2 * * * *"
       backupTemplate:
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
         from:

--- a/en/backup-to-gcs-using-br.md
+++ b/en/backup-to-gcs-using-br.md
@@ -304,6 +304,8 @@ The steps to prepare for a scheduled full backup are the same as that of [Prepar
       maxReservedTime: "3h"
       schedule: "*/2 * * * *"
       backupTemplate:
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
         from:
           host: ${tidb_host}

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -397,6 +397,8 @@ spec:
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -449,7 +449,7 @@ spec:
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         br:
           cluster: demo1
@@ -499,7 +499,7 @@ spec:
       serviceAccount: tidb-backup-manager
       backupTemplate:
         backupType: full
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         br:
           cluster: demo1

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -397,7 +397,7 @@ spec:
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         br:
           cluster: demo1

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -449,6 +449,8 @@ spec:
       schedule: "*/2 * * * *"
       backupTemplate:
         backupType: full
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         br:
           cluster: demo1
           sendCredToTikv: false
@@ -497,6 +499,8 @@ spec:
       serviceAccount: tidb-backup-manager
       backupTemplate:
         backupType: full
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         br:
           cluster: demo1
           sendCredToTikv: false

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -304,7 +304,7 @@ spec:
       maxReservedTime: "3h"
       schedule: "*/2 * * * *"
       backupTemplate:
-        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
         from:

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -304,6 +304,8 @@ spec:
       maxReservedTime: "3h"
       schedule: "*/2 * * * *"
       backupTemplate:
+        # Clean outdated backup data based on maxBackups or maxReservedTime, default policy is Retain
+        # cleanPolicy: Delete
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
         from:
           host: ${tidb_host}


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
the sample code in [scheduled-full-backup](https://docs.pingcap.com/tidb-in-kubernetes/stable/backup-to-aws-s3-using-br#step-2-perform-a-scheduled-full-backup) only mentioned `#maxBackups: 5` and `maxReservedTime: "3h"`, but **it only delete `backup CR`**, if user also want clean outdated backup data in S3 or GCS they need config `spec.backupTemplate.cleanPolicy: Delete`, which maybe missed because user already config the `#maxBackups: 5` and `maxReservedTime: "3h"` as sample code show.

This PR add comment for `cleanPolicy: Delete` in the sample code.

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
