### PR TITLE
add clusterScoped for monitor multiple clusters

### DIFF
--- a/en/monitor-a-tidb-cluster.md
+++ b/en/monitor-a-tidb-cluster.md
@@ -337,6 +337,7 @@ kind: TidbMonitor
 metadata:
   name: basic
 spec:
+  clusterScoped: true
   clusters:
     - name: ns1
       namespace: ns1

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -331,6 +331,7 @@ kind: TidbMonitor
 metadata:
   name: basic
 spec:
+  clusterScoped: true
   clusters:
     - name: ns1
       namespace: ns1


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
根据官网文档[多集群监控](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/monitor-a-tidb-cluster#%E5%A4%9A%E9%9B%86%E7%BE%A4%E7%9B%91%E6%8E%A7) 部署后 grafana 上无法显示集群信息，发现是缺少 `clusterScoped: true` 的配置。

参考 operator release 对于 clusterScoped 的说明
![image](https://user-images.githubusercontent.com/13452917/185873989-f08a8e21-2232-4b4b-a5e6-c312658f6a04.png)

参考 operator github example [monitor-multiple-cluster-non-tls](https://github.com/pingcap/tidb-operator/blob/master/examples/monitor-multiple-cluster-non-tls/tidb-monitor.yaml)

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [x] v1.1 (TiDB Operator 1.1 versions)
- [ ] v1.0 (TiDB Operator 1.0 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
