### PR TITLE
add-port-forward-in-clinic-doc

### DIFF
--- a/en/clinic-user-guide.md
+++ b/en/clinic-user-guide.md
@@ -458,7 +458,7 @@ You can collect data using Diag APIs.
 
     - The port to access `diag-collector service` from outside is `31917`.
     - The service type is NodePort. You can access this service from any host in the Kubernetes cluster with its IP address `${host}` and port `${port}`.
-    - If there has network restriction between host, you can use `port-forward` command to redirect Service port `4917` to local, then use `127.0.0.1:4917` to access this service.
+    - If there are network restrictions between hosts, you can use the `port-forward` command to redirect the service port `4917` to local, and then use `127.0.0.1:4917` to access this service.
 
 The following describes how to collect data using Diag APIs.
 

--- a/en/clinic-user-guide.md
+++ b/en/clinic-user-guide.md
@@ -458,6 +458,7 @@ You can collect data using Diag APIs.
 
     - The port to access `diag-collector service` from outside is `31917`.
     - The service type is NodePort. You can access this service from any host in the Kubernetes cluster with its IP address `${host}` and port `${port}`.
+    - If there has network restriction between host, you can use `port-forward` command to redirect Service port `4917` to local, then use `127.0.0.1:4917` to access this service.
 
 The following describes how to collect data using Diag APIs.
 

--- a/zh/clinic-user-guide.md
+++ b/zh/clinic-user-guide.md
@@ -476,6 +476,7 @@ Diag 工具的各项操作均会通过 API 完成。
 
     - 从 Kubernetes 集群外访问该 Service 的端口为 `31917`。
     - 该 Service 类型为 NodePort。你可以通过 Kubernetes 集群中任一宿主机的 IP 地址 `${host}` 和端口号 `${port}` 访问该服务。
+    - 若由于网络限制无法直接访问宿主机，你也可以使用 `port-forward` 命令将 Service 的端口 `4917` 重定向到本地，然后通过 `127.0.0.1:4917` 来访问该服务。
 
 下面为使用 Clinic 调用 API 采集数据的步骤。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
If user's environment do not allow public connection, for example like AWS EC2 with no public network gateway, or AWS EKS cluster with [`privateNetworking: true`](https://eksctl.io/usage/schema/#managedNodeGroups-privateNetworking), which is also recommended in [our doc](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-on-aws-eks#%E5%88%9B%E5%BB%BA-eks-%E9%9B%86%E7%BE%A4%E5%92%8C%E8%8A%82%E7%82%B9%E6%B1%A0), then we can not directly access the clinic diag service, the workaround is use `port-forward` command to redirect the service port to the local, so we can send request to the local service proxy.

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
