### PR TITLE
add-note-for-aws-gp2

### DIFF
--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -176,6 +176,10 @@ This section describes how to configure the storage class for different storage 
 
 ### Configure `gp2`
 
+> **note:**
+>
+> From EKS Kubernetes 1.23 you need to deploy Amazon EBS CSI driver first to allow Amazon EKS cluster to manage the lifecycle of gp2 volumes. See [Amazon EKS Kubernetes 1.23 important note](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23) for details.
+
 After you create an EKS cluster, the default StorageClass is `gp2`. To improve I/O write performance, it is recommended to configure `nodelalloc` and `noatime` in the `mountOptions` field of the `StorageClass` resource.
 
 ```yaml

--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -178,7 +178,7 @@ This section describes how to configure the storage class for different storage 
 
 > **note:**
 >
-> From EKS Kubernetes 1.23 you need to deploy Amazon EBS CSI driver first to allow Amazon EKS cluster to manage the lifecycle of gp2 volumes. See [Amazon EKS Kubernetes 1.23 important note](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23) for details.
+> Starting from EKS Kubernetes 1.23, you need to deploy the EBS CSI driver before using the default gp2 storage class. For details, refer to [the notice for Amazon EKS Kubernetes 1.23](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23).
 
 After you create an EKS cluster, the default StorageClass is `gp2`. To improve I/O write performance, it is recommended to configure `nodelalloc` and `noatime` in the `mountOptions` field of the `StorageClass` resource.
 

--- a/zh/deploy-on-aws-eks.md
+++ b/zh/deploy-on-aws-eks.md
@@ -173,6 +173,10 @@ eksctl create cluster -f cluster.yaml
 
 ### gp2
 
+> **注意：**
+>
+> 从 EKS Kubernetes 1.23 开始需要先部署 EBS CSI 驱动后才能使用默认的 gp2 存储类型，详情可见 [Amazon EKS Kubernetes 1.23 的重要通知](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23)。
+
 创建 EKS 集群后默认会存在一个 gp2 存储类型的 StorageClass。为了提高存储的 IO 写入性能，推荐配置 StorageClass 的 `mountOptions` 字段来设置存储挂载选项 `nodelalloc` 和 `noatime`。详情可见 [TiDB 环境与系统配置检查](https://docs.pingcap.com/zh/tidb/stable/check-before-deployment#%E5%9C%A8-tikv-%E9%83%A8%E7%BD%B2%E7%9B%AE%E6%A0%87%E6%9C%BA%E5%99%A8%E4%B8%8A%E6%B7%BB%E5%8A%A0%E6%95%B0%E6%8D%AE%E7%9B%98-ext4-%E6%96%87%E4%BB%B6%E7%B3%BB%E7%BB%9F%E6%8C%82%E8%BD%BD%E5%8F%82%E6%95%B0)。
 
 ```yaml

--- a/zh/deploy-on-aws-eks.md
+++ b/zh/deploy-on-aws-eks.md
@@ -175,7 +175,7 @@ eksctl create cluster -f cluster.yaml
 
 > **注意：**
 >
-> 从 EKS Kubernetes 1.23 开始需要先部署 EBS CSI 驱动后才能使用默认的 gp2 存储类型，详情可见 [Amazon EKS Kubernetes 1.23 的重要通知](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23)。
+> 从 EKS Kubernetes 1.23 开始，你需要先部署 EBS CSI 驱动，然后才能使用默认的 gp2 存储类型。详情可见 [Amazon EKS Kubernetes 1.23 的重要通知](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23)。
 
 创建 EKS 集群后默认会存在一个 gp2 存储类型的 StorageClass。为了提高存储的 IO 写入性能，推荐配置 StorageClass 的 `mountOptions` 字段来设置存储挂载选项 `nodelalloc` 和 `noatime`。详情可见 [TiDB 环境与系统配置检查](https://docs.pingcap.com/zh/tidb/stable/check-before-deployment#%E5%9C%A8-tikv-%E9%83%A8%E7%BD%B2%E7%9B%AE%E6%A0%87%E6%9C%BA%E5%99%A8%E4%B8%8A%E6%B7%BB%E5%8A%A0%E6%95%B0%E6%8D%AE%E7%9B%98-ext4-%E6%96%87%E4%BB%B6%E7%B3%BB%E7%BB%9F%E6%8C%82%E8%BD%BD%E5%8F%82%E6%95%B0)。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
New deployed EKS cluster may use newly Kubernetes 1.24 version, and from Kubernetes 1.23 the in-tree plugins seems is deprecated, see [important note in EKS Kubernetes 1.23](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23), so user can not directly deploy TiDB cluster using gp2 disk after EKS cluster created.
Add a note for this in operator doc, if user use EKS cluster  Kubernetes version >= 1.23, need follow [Amazon EBS CSI driver doc](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) to deploy iam sa and EKS gp2 add-on first.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
