### PR TITLE
en: add doc for Backoff retry policy and auto truncate log backup by backupschedule

### DIFF
--- a/en/backup-restore-cr.md
+++ b/en/backup-restore-cr.md
@@ -348,11 +348,11 @@ The `backupSchedule` configuration consists of three parts: the configuration of
 
     > **Note:**
     >
-    > Before you delete the log backup data, you need to stop the log backup task to avoid resource waste or the inability to restart the log backup task in the future due to the log backup task in TiKV is not stopped.
+    > Before you delete the log backup data, you need to stop the log backup task to avoid resource waste or the inability to restart the log backup task in the future because the log backup task in TiKV is not stopped.
 
 * The unique configuration items of `backupSchedule` are as follows:
 
     * `.spec.maxBackups`: a backup retention policy, which determines the maximum number of backup files to be retained. When the number of backup files exceeds this value, the outdated backup file will be deleted. If you set this field to `0`, all backup items are retained.
     * `.spec.maxReservedTime`: a backup retention policy based on time. For example, if you set the value of this field to `24h`, only backup files within the recent 24 hours are retained. All backup files older than this value are deleted. For the time format, refer to [`func ParseDuration`](https://golang.org/pkg/time/#ParseDuration). If you have set `.spec.maxBackups` and `.spec.maxReservedTime` at the same time, the latter takes effect.
     * `.spec.schedule`: the time scheduling format of Cron. Refer to [Cron](https://en.wikipedia.org/wiki/Cron) for details.
-    * `.spec.pause`: `false` by default. If this field is set to `true`, the scheduled scheduling is paused. In this situation, the backup operation will not be performed even if the scheduling time point is reached. During this pause, the backup garbage collection runs normally. If you change `true` to `false`, the scheduled snapshot backup process is restarted. Because currently log backup does not support pause, this configuration does not take effect in log backup.
+    * `.spec.pause`: `false` by default. If this field is set to `true`, the scheduled scheduling is paused. In this situation, the backup operation will not be performed even if the scheduling time point is reached. During this pause, the backup garbage collection runs normally. If you change `true` to `false`, the scheduled snapshot backup process is restarted. Because currently, log backup does not support pause, this configuration does not take effect for log backup.

--- a/en/backup-restore-cr.md
+++ b/en/backup-restore-cr.md
@@ -120,10 +120,10 @@ This section introduces the fields in the `Backup` CR.
     > - "!db.table"
     > ```
 
-* `.spec.backoffRetryPolicy`: the retry policy for abnormal failures (such as Kubernetes killing the node due to insufficient resources) of the Job/Pod during the backup. This parameter only takes effect for the `snapshot` backup.
-    * `minRetryDuration`: the minimum retry interval after an abnormal failure is found. The retry interval increases with the number of failures. `RetryDuration` = `minRetryDuration` << (`retryNum` -1). The unit is seconds. The default value is `300`.
+* `.spec.backoffRetryPolicy`: the retry policy for abnormal failures (such as Kubernetes killing the node due to insufficient resources) of the Job/Pod during the backup. This configuration currently only takes effect on the `snapshot` backup.
+    * `minRetryDuration`: the minimum retry interval after an abnormal failure is found. The retry interval increases with the number of failures. `RetryDuration` = `minRetryDuration` << (`retryNum` -1). The time format is specified in [`func ParseDuration`](https://golang.org/pkg/time/#ParseDuration), and the default value is `300s`.
     * `maxRetryTimes`: the maximum number of retries. The default value is `2`.
-    * `retryTimeout`: the retry timeout. The timeout starts from the first abnormal failure. The unit is minutes. The default value is `30`.
+    * `retryTimeout`: the retry timeout. The timeout starts from the first abnormal failure. The time format is specified in [`func ParseDuration`](https://golang.org/pkg/time/#ParseDuration), and the default value is `30m`.
 
 ### BR fields
 

--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -778,7 +778,7 @@ kubectl get bk -l tidb.pingcap.com/backup-schedule=demo1-backup-schedule-s3 -n t
 
 You can use the `BackupSchedule` CR to integrate the management of scheduled snapshot backup and log backup for TiDB clusters. By setting the backup retention time, you can regularly recycle the scheduled snapshot backup and log backup, and ensure that you can perform PITR recovery through the scheduled snapshot backup and log backup within the retention period.
 
-The following example creates a `BackupSchedule` CR named `integrated-backup-schedule-aws-s3`. In the example, accessKey and secretKey are used to access the remote storage. For more information about the authorization method, refer to [AWS account permissions](grant-permissions-to-remote-storage.md#aws-account-permissions).
+The following example creates a `BackupSchedule` CR named `integrated-backup-schedule-s3`. In the example, accessKey and secretKey are used to access the remote storage. For more information about the authorization method, refer to [AWS account permissions](grant-permissions-to-remote-storage.md#aws-account-permissions).
 
 ### Prerequisites: Prepare for a scheduled snapshot backup environment
 
@@ -786,13 +786,13 @@ The steps to prepare for a scheduled snapshot backup are the same as that of [Pr
 
 ### Create `BackupSchedule`
 
-1. Create a `BackupSchedule` CR named `integrated-backup-schedule-aws-s3` in the `backup-test` namespace.
+1. Create a `BackupSchedule` CR named `integrated-backup-schedule-s3` in the `backup-test` namespace.
 
     ```shell
-    kubectl apply -f integrated-backup-scheduler-aws-s3.yaml
+    kubectl apply -f integrated-backup-schedule-s3.yaml
     ```
 
-    The content of `integrated-backup-scheduler-aws-s3.yaml` is as follows:
+    The content of `integrated-backup-schedule-s3.yaml` is as follows:
 
     ```yaml
     ---
@@ -831,7 +831,7 @@ The steps to prepare for a scheduled snapshot backup are the same as that of [Pr
           prefix: my-folder-log
     ```
 
-    In the above example of `integrated-backup-scheduler-aws-s3.yaml`, the `backupSchedule` configuration consists of three parts: the unique configuration of `backupSchedule`, the configuration of the snapshot backup `backupTemplate`, and the configuration of the log backup `logBackupTemplate`.
+    In the above example of `integrated-backup-schedule-s3.yaml`, the `backupSchedule` configuration consists of three parts: the unique configuration of `backupSchedule`, the configuration of the snapshot backup `backupTemplate`, and the configuration of the log backup `logBackupTemplate`.
 
     For the field description of `backupSchedule`, refer to [BackupSchedule CR fields](backup-restore-cr.md#backupschedule-cr-fields).
 

--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -782,7 +782,7 @@ The following example creates a `BackupSchedule` CR named `integrated-backup-sch
 
 ### Prerequisites: Prepare for a scheduled snapshot backup environment
 
-The steps to prepare for a scheduled snapshot backup are the same as that of [Prepare for an ad-hoc backup](#prerequisites-prepare-for-an-ad-hoc-backup).
+The steps to prepare for a scheduled snapshot backup are the same as those of [Prepare for an ad-hoc backup](#prerequisites-prepare-for-an-ad-hoc-backup).
 
 ### Create `BackupSchedule`
 

--- a/en/backup-to-azblob-using-br.md
+++ b/en/backup-to-azblob-using-br.md
@@ -606,6 +606,91 @@ You can run the following command to check all the backup items:
 kubectl get backup -l tidb.pingcap.com/backup-schedule=demo1-backup-schedule-azblob -n backup-test
 ```
 
+## Integrated management of scheduled snapshot backup and log backup
+
+You can use the `BackupSchedule` CR to integrate the management of scheduled snapshot backup and log backup for TiDB clusters. By setting the backup retention time, you can regularly recycle the scheduled snapshot backup and log backup, and ensure that you can perform PITR recovery through the scheduled snapshot backup and log backup within the retention period.
+
+The following example creates a `BackupSchedule` CR named `integrated-backup-schedule-azblob`. For more information about the authorization method, refer to [Azure account permissions](grant-permissions-to-remote-storage.md#azure-account-permissions).
+
+### Prerequisites: Prepare a scheduled snapshot backup environment
+
+The steps to prepare for a scheduled snapshot backup are the same as that of [Prepare for an ad-hoc backup](#prerequisites-prepare-an-ad-hoc-backup-environment).
+
+### Create `BackupSchedule`
+
+1. Create a `BackupSchedule` CR named `integrated-backup-schedule-azblob` in the `backup-test` namespace.
+
+    ```shell
+    kubectl apply -f integrated-backup-scheduler-azblob.yaml
+    ```
+
+    The content of `integrated-backup-scheduler-azblob.yaml` is as follows:
+
+    ```yaml
+    ---
+    apiVersion: pingcap.com/v1alpha1
+    kind: BackupSchedule
+    metadata:
+      name: integrated-backup-schedule-azblob
+      namespace: backup-test
+    spec:
+      maxReservedTime: "3h"
+      schedule: "* */2 * * *"
+      backupTemplate:
+        backupType: full
+        cleanPolicy: Delete
+        br:
+          cluster: demo1
+          clusterNamespace: test1
+          sendCredToTikv: true
+        azblob:
+          secretName: azblob-secret
+          container: my-container
+          prefix: schedule-backup-folder-snapshot
+          #accessTier: Hot
+      logBackupTemplate:
+        backupMode: log
+        br:
+          cluster: demo1
+          clusterNamespace: test1
+          sendCredToTikv: true
+        azblob:
+          secretName: azblob-secret
+          container: my-container
+          prefix: schedule-backup-folder-log
+          #accessTier: Hot
+    ```
+
+    In the above example of `integrated-backup-scheduler-azblob.yaml`, the `backupSchedule` configuration consists of three parts: the unique configuration of `backupSchedule`, the configuration of the snapshot backup `backupTemplate`, and the configuration of the log backup `logBackupTemplate`.
+
+    For the field description of `backupSchedule`, refer to [BackupSchedule CR fields](backup-restore-cr.md#backupschedule-cr-fields).
+
+2. After creating `backupSchedule`, use the following command to check the backup status:
+
+    ```shell
+    kubectl get bks -n backup-test -o wide
+    ```
+
+    A log backup task is created together with `backupSchedule`. You can check the log backup name through the `status.logBackup` field of the `backupSchedule` CR.
+
+    ```shell
+    kubectl describe bks integrated-backup-schedule-azblob -n backup-test
+    ```
+
+3. To perform data restoration for a cluster, you need to specify the backup path. You can use the following command to check all the backup items under the scheduled snapshot backup.
+
+    ```shell
+    kubectl get bk -l tidb.pingcap.com/backup-schedule=integrated-backup-schedule-azblob -n backup-test
+    ```
+
+    The `MODE` field in the output indicates the backup mode. `snapshot` indicates the scheduled snapshot backup, and `log` indicates the log backup.
+
+    ```
+    NAME                                                       MODE       STATUS    ....
+    integrated-backup-schedule-azblob-2023-03-08t02-48-00      snapshot   Complete  ....
+    log-integrated-backup-schedule-azblob                      log        Running   ....
+    ```
+
 ## Delete the backup CR
 
 If you no longer need the backup CR, you can delete it by referring to [Delete the Backup CR](backup-restore-overview.md#delete-the-backup-cr).

--- a/en/backup-to-azblob-using-br.md
+++ b/en/backup-to-azblob-using-br.md
@@ -614,7 +614,7 @@ The following example creates a `BackupSchedule` CR named `integrated-backup-sch
 
 ### Prerequisites: Prepare a scheduled snapshot backup environment
 
-The steps to prepare for a scheduled snapshot backup are the same as that of [Prepare for an ad-hoc backup](#prerequisites-prepare-an-ad-hoc-backup-environment).
+The steps to prepare for a scheduled snapshot backup are the same as those of [Prepare for an ad-hoc backup](#prerequisites-prepare-an-ad-hoc-backup-environment).
 
 ### Create `BackupSchedule`
 

--- a/en/backup-to-gcs-using-br.md
+++ b/en/backup-to-gcs-using-br.md
@@ -575,7 +575,7 @@ The following example creates a `BackupSchedule` CR named `integrated-backup-sch
 
 ### Prerequisites: Prepare for a scheduled snapshot backup environment
 
-The steps to prepare for a scheduled snapshot backup are the same as that of [Prepare for an ad-hoc backup](#prerequisites-prepare-for-an-ad-hoc-backup).
+The steps to prepare for a scheduled snapshot backup are the same as those of [Prepare for an ad-hoc backup](#prerequisites-prepare-for-an-ad-hoc-backup).
 
 ### Create `BackupSchedule`
 

--- a/en/backup-to-gcs-using-br.md
+++ b/en/backup-to-gcs-using-br.md
@@ -567,6 +567,91 @@ The steps to prepare for a scheduled snapshot backup are the same as that of [Pr
     kubectl get bk -l tidb.pingcap.com/backup-schedule=demo1-backup-schedule-gcs -n backup-test
     ```
 
+## Integrated management of scheduled snapshot backup and log backup
+
+You can use the `BackupSchedule` CR to integrate the management of scheduled snapshot backup and log backup for TiDB clusters. By setting the backup retention time, you can regularly recycle the scheduled snapshot backup and log backup, and ensure that you can perform PITR recovery through the scheduled snapshot backup and log backup within the retention period.
+
+The following example creates a `BackupSchedule` CR named `integrated-backup-schedule-gcs`. For more information about the authorization method, refer to [GCS account permissions](grant-permissions-to-remote-storage.md#gcs-account-permissions).
+
+### Prerequisites: Prepare for a scheduled snapshot backup environment
+
+The steps to prepare for a scheduled snapshot backup are the same as that of [Prepare for an ad-hoc backup](#prerequisites-prepare-for-an-ad-hoc-backup).
+
+### Create `BackupSchedule`
+
+1. Create a `BackupSchedule` CR named `integrated-backup-schedule-gcs` in the `backup-test` namespace.
+
+    ```shell
+    kubectl apply -f integrated-backup-scheduler-gcs.yaml
+    ```
+
+    The content of `integrated-backup-schedule-gcs.yaml` is as follows:
+
+    ```yaml
+    ---
+    apiVersion: pingcap.com/v1alpha1
+    kind: BackupSchedule
+    metadata:
+      name: integrated-backup-schedule-gcs
+      namespace: backup-test
+    spec:
+      maxReservedTime: "3h"
+      schedule: "* */2 * * *"
+      backupTemplate:
+        backupType: full
+        cleanPolicy: Delete
+        br:
+          cluster: demo1
+          clusterNamespace: test1
+          sendCredToTikv: true
+        gcs:
+          projectId: ${project_id}
+          secretName: gcs-secret
+          bucket: my-bucket
+          prefix: schedule-backup-folder-snapshot
+      logBackupTemplate:
+        backupMode: log
+        br:
+          cluster: demo1
+          clusterNamespace: test1
+          sendCredToTikv: true
+        gcs:
+          projectId: ${project_id}
+          secretName: gcs-secret
+          bucket: my-bucket
+          prefix: schedule-backup-folder-log
+    ```
+
+    In the above example of `integrated-backup-scheduler-gcs.yaml`, the `backupSchedule` configuration consists of three parts: the unique configuration of `backupSchedule`, the configuration of the snapshot backup `backupTemplate`, and the configuration of the log backup `logBackupTemplate`.
+
+    For the field description of `backupSchedule`, refer to [BackupSchedule CR fields](backup-restore-cr.md#backupschedule-cr-fields).
+
+2. After creating `backupSchedule`, use the following command to check the backup status:
+
+    ```shell
+    kubectl get bks -n backup-test -o wide
+    ```
+
+    A log backup task is created together with `backupSchedule`. You can check the log backup name through the `status.logBackup` field of the `backupSchedule` CR.
+
+    ```shell
+    kubectl describe bks integrated-backup-schedule-gcs -n backup-test
+    ```
+
+3. To perform data restoration for a cluster, you need to specify the backup path. You can use the following command to check all the backup items under the scheduled snapshot backup.
+
+    ```shell
+    kubectl get bk -l tidb.pingcap.com/backup-schedule=integrated-backup-schedule-gcs -n backup-test
+    ```
+
+    The `MODE` field in the output indicates the backup mode. `snapshot` indicates the scheduled snapshot backup, and `log` indicates the log backup.
+
+    ```
+    NAME                                                       MODE       STATUS    ....
+    integrated-backup-schedule-gcs-2023-03-08t02-50-00         snapshot   Complete  ....
+    log-integrated-backup-schedule-gcs                         log        Running   ....
+    ```
+
 ## Delete the backup CR
 
 If you no longer need the backup CR, refer to [Delete the Backup CR](backup-restore-overview.md#delete-the-backup-cr).


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

as title.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->https://github.com/pingcap/docs-tidb-operator/pull/2236
- Other reference link(s): <!--Give links here-->
