### PR TITLE
Typo in the kubectl edit command

### DIFF
--- a/en/deploy-tiflash.md
+++ b/en/deploy-tiflash.md
@@ -33,7 +33,7 @@ If you need to deploy TiFlash for an existing TiDB cluster, do the following:
     {{< copyable "shell-regular" >}}
 
     ``` shell
-    kubectl eidt tc ${cluster_name} -n ${namespace}
+    kubectl edit tc ${cluster_name} -n ${namespace}
     ```
 
 2. Add the TiFlash configuration as the following example:


### PR DESCRIPTION
Fixed the typo

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)
Fixed the typo `eidt` to `edit` in the docs

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
