### PR TITLE
update the deprecated set-output command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,6 @@
 - [ ] v1.4 (TiDB Operator 1.4 versions)
 - [ ] v1.3 (TiDB Operator 1.3 versions)
 - [ ] v1.2 (TiDB Operator 1.2 versions)
-- [ ] v1.1 (TiDB Operator 1.1 versions)
 
 ### What is the related PR or file link(s)?
 

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -15,7 +15,7 @@ jobs:
         id: extract
         shell: bash
         run: |
-          echo "::set-output name=sha::$(sha=${{ github.sha }}; echo ${sha:0:6})"
+          echo "sha=$(sha=${{ github.sha }}; echo ${sha:0:6})" >> $GITHUB_OUTPUT
 
       - name: trigger docs-staging workflow
         run: |

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -26,7 +26,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
-        uses: peter-evans/create-issue-from-file@v3
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: Broken Link Detected
           content-filepath: out.md


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

- Remove `v1.1` from the pull_request_template
- Update the `set-output` command to `$GITHUB_OUTPUT` (set-output is deprecated)
- Update `peter-evans/create-issue-from-file` from v3 to v4 (Node.js 12 actions (peter-evans/create-issue-from-file@v3) are deprecated)

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)
- [ ] v1.1 (TiDB Operator 1.1 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: https://github.com/pingcap/docs-cn/pull/13612
- Other reference link(s): <!--Give links here-->
