### PR TITLE
ci: update specified actions to the latest

### DIFF
--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -17,7 +17,7 @@ jobs:
           curl https://raw.githubusercontent.com/pingcap/docs/master/.lycheeignore --output .lycheeignore
 
       - name: Check Links
-        uses: lycheeverse/lychee-action@v1.5.0
+        uses: lycheeverse/lychee-action@v1.6.1
         with:
           # For parameter description, see https://github.com/lycheeverse/lychee#commandline-parameters
           args: -E --exclude-mail -v -i -n -t 45 -- zh/*.md en/*.md *.md

--- a/.github/workflows/media.yml
+++ b/.github/workflows/media.yml
@@ -11,7 +11,7 @@ jobs:
     name: Upload media files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
         with:
           # Must use at least depth 2!
           fetch-depth: 2

--- a/.github/workflows/vale.yaml
+++ b/.github/workflows/vale.yaml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
 
     - name: Vale Linter
-      uses: errata-ai/vale-action@v1.4.3
+      uses: errata-ai/vale-action@v2.0.1
       with:
         # Optional
         #styles: |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Node.js 12 actions and the `set-output` command are deprecated.

This PR updates the following actions to use Node.js 16:

- `actions/checkout@v2`
- `actions/setup-node@v1`
- `andstor/file-existence-action@v1`

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
