### PR TITLE
learning path: remove v1.4 new features for v1.5

### DIFF
--- a/en/_index.md
+++ b/en/_index.md
@@ -14,8 +14,6 @@ hide_commit: true
 
 [TiDB Operator Architecture](https://docs.pingcap.com/tidb-in-kubernetes/dev/architecture)
 
-[What's New in v1.4](https://docs.pingcap.com/tidb-in-kubernetes/dev/whats-new-in-v1.4)
-
 [Get Started](https://docs.pingcap.com/tidb-in-kubernetes/dev/get-started)
 
 [Relationship between TiDB Operator and TiDB Versions](https://docs.pingcap.com/tidb-in-kubernetes/dev/tidb-operator-overview)

--- a/zh/_index.md
+++ b/zh/_index.md
@@ -14,8 +14,6 @@ hide_commit: true
 
 [TiDB Operator 架构](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/architecture)
 
-[TiDB Operator v1.4 新特性](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/whats-new-in-v1.4)
-
 [快速上手](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/get-started)
 
 [TiDB 与 TiDB Operator 版本关系](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/tidb-operator-overview)


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Remove `whats-new-in-v1.4.md` from learning path.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
