### PR TITLE
Make TiDB supported versions table exclusive

### DIFF
--- a/en/tidb-operator-overview.md
+++ b/en/tidb-operator-overview.md
@@ -14,7 +14,7 @@ The corresponding relationship between TiDB Operator and TiDB versions is as fol
 |:---|:---|
 | dev               | dev                 |
 | TiDB >= 6.5       | 1.4 (Recommended), 1.3 |
-| TiDB >= 5.4       | 1.4, 1.3 (Recommended)   |
+| 5.4 <= TiDB < 6.5 | 1.4, 1.3 (Recommended)   |
 | 5.1 <= TiDB < 5.4 | 1.4, 1.3 (Recommended), 1.2      |
 | 3.0 <= TiDB < 5.1 | 1.4, 1.3 (Recommended), 1.2, 1.1 |
 | 2.1 <= TiDB < v3.0| 1.0 (End of support)       |


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

This pull request makes TiDB supported versions table exclusive. 
When the `TiDB >= 6.5` row was added via https://github.com/pingcap/docs-tidb-operator/pull/2144/files , the following `TiDB >= 5.4` row was not updated.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
