### PR TITLE
en, zh: update GCP name to Google Cloud

### DIFF
--- a/en/TOC.md
+++ b/en/TOC.md
@@ -16,14 +16,14 @@
     - [Access a TiDB Cluster](access-tidb.md)
   - On Public Cloud Kubernetes
     - [Amazon EKS](deploy-on-aws-eks.md)
-    - [GCP GKE](deploy-on-gcp-gke.md)
+    - [Google Cloud GKE](deploy-on-gcp-gke.md)
     - [Azure AKS](deploy-on-azure-aks.md)
     - [Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
   - [Deploy TiDB on ARM64 Machines](deploy-cluster-on-arm64.md)
   - [Deploy TiFlash to Explore TiDB HTAP](deploy-tiflash.md)
   - Deploy TiDB Across Multiple Kubernetes Clusters
     - [Build Multiple Interconnected AWS EKS Clusters](build-multi-aws-eks.md)
-    - [Build Multiple Interconnected GCP GKE Clusters](build-multi-gcp-gke.md)
+    - [Build Multiple Interconnected GKE Clusters](build-multi-gcp-gke.md)
     - [Deploy TiDB Across Multiple Kubernetes Clusters](deploy-tidb-cluster-across-multiple-kubernetes.md)
   - [Deploy a Heterogeneous TiDB Cluster](deploy-heterogeneous-tidb-cluster.md)
   - [Deploy TiCDC](deploy-ticdc.md)

--- a/en/_index.md
+++ b/en/_index.md
@@ -24,7 +24,7 @@ hide_commit: true
 
 [On Amazon EKS](https://docs.pingcap.com/tidb-in-kubernetes/dev/deploy-on-aws-eks)
 
-[On GCP GKE](https://docs.pingcap.com/tidb-in-kubernetes/dev/deploy-on-gcp-gke)
+[On Google Cloud GKE](https://docs.pingcap.com/tidb-in-kubernetes/dev/deploy-on-gcp-gke)
 
 [On Azure AKS](https://docs.pingcap.com/tidb-in-kubernetes/dev/deploy-on-azure-aks)
 

--- a/en/access-tidb.md
+++ b/en/access-tidb.md
@@ -64,7 +64,7 @@ To check you can access TiDB services by using the IP of what nodes, see the fol
 
 ## LoadBalancer
 
-If the TiDB cluster runs in an environment with LoadBalancer, such as on GCP or AWS, it is recommended to use the LoadBalancer feature of these cloud platforms by setting `tidb.service.type=LoadBalancer`.
+If the TiDB cluster runs in an environment with LoadBalancer, such as on Google Cloud or AWS, it is recommended to use the LoadBalancer feature of these cloud platforms by setting `tidb.service.type=LoadBalancer`.
 
 To access TiDB Service through LoadBalancer, refer to [EKS](deploy-on-aws-eks.md#install-the-mysql-client-and-connect), [GKE](deploy-on-gcp-gke.md#install-the-mysql-client-and-connect) and [ACK](deploy-on-alibaba-cloud.md#access-the-database).
 

--- a/en/backup-restore-cr.md
+++ b/en/backup-restore-cr.md
@@ -135,7 +135,7 @@ This section introduces the fields in the `Backup` CR.
 * `.spec.br.rateLimit`: the speed limit, in MB/s. If set to `4`, the speed limit is 4 MB/s. The speed limit is not set by default.
 * `.spec.br.checksum`: whether to verify the files after the backup is completed. Defaults to `true`.
 * `.spec.br.timeAgo`: backs up the data before `timeAgo`. If the parameter value is not specified (empty by default), it means backing up the current data. It supports data formats such as `"1.5h"` and `"2h45m"`. See [ParseDuration](https://golang.org/pkg/time/#ParseDuration) for more information.
-* `.spec.br.sendCredToTikv`: whether the BR process passes its AWS, GCP, or Azure permissions to the TiKV process. Defaults to `true`.
+* `.spec.br.sendCredToTikv`: whether the BR process passes its AWS, Google Cloud, or Azure permissions to the TiKV process. Defaults to `true`.
 * `.spec.br.onLine`: whether to enable the [online restore](https://docs.pingcap.com/tidb/stable/use-br-command-line-tool#online-restore-experimental-feature) feature when restoring data.
 * `.spec.br.options`: the extra arguments that BR supports. This field is supported since TiDB Operator v1.1.6. It accepts an array of strings and can be used to specify the last backup timestamp `--lastbackupts` for incremental backup.
 
@@ -187,7 +187,7 @@ This section introduces the fields in the `Backup` CR.
 
 ### GCS fields
 
-* `.spec.gcs.projectId`: the unique identifier of the user project on GCP. To obtain the project ID, refer to [GCP documentation](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
+* `.spec.gcs.projectId`: the unique identifier of the user project on Google Cloud. To obtain the project ID, refer to [Google Cloud documentation](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 * `.spec.gcs.location`: the location of the GCS bucket. For example, `us-west2`.
 * `.spec.gcs.path`: the storage path of backup files on the remote storage. This field is valid only when the data is backed up using Dumpling or restored using TiDB Dumpling. For example, `gcs://test1-demo1/backup-2019-11-11T16:06:05Z.tgz`.
 * `.spec.gcs.secretName`: the name of the secret that stores the GCS account credential.

--- a/en/benchmark-sysbench.md
+++ b/en/benchmark-sysbench.md
@@ -84,7 +84,7 @@ For the test in single AZ (Available Zone), the following machine types are chos
 | TiDB     | c2-standard-16 | 3     |
 | Sysbench | c2-standard-30 | 1     |
 
-For the test (2019.08) where the result in multiple AZs is compared with that in a single AZ, the c2 machine is not simultaneously available in three AZs within the same GCP region, so the following machine types are chosen:
+For the test (2019.08) where the result in multiple AZs is compared with that in a single AZ, the c2 machine is not simultaneously available in three AZs within the same Google Cloud region, so the following machine types are chosen:
 
 | Component     | Instance type       | Count  |
 | :---     | :---------     | :---- |
@@ -97,7 +97,7 @@ Sysbench, the pressure test platform, has a high demand on CPU in the high concu
 
 > **Note:**
 >
-> The usable machine types vary among GCP regions. In the test, the disk also performs differently. Therefore, only the machines in us-central1 are applied for test.
+> The usable machine types vary among Google Cloud regions. In the test, the disk also performs differently. Therefore, only the machines in us-central1 are applied for test.
 
 #### Disk
 
@@ -114,7 +114,7 @@ GKE uses a more scalable and powerful [VPC-Native](https://cloud.google.com/kube
 #### CPU
 
 - In the test on a single AZ cluster, the c2-standard-16 machine mode is chosen for TiDB/TiKV.
-- In the comparison test on a single AZ cluster and on multiple AZs cluster, the c2-standard-16 machine type cannot be simultaneously adopted in three AZs within the same GCP region, so n1-standard-16 machine type is chosen.
+- In the comparison test on a single AZ cluster and on multiple AZs cluster, the c2-standard-16 machine type cannot be simultaneously adopted in three AZs within the same Google Cloud region, so n1-standard-16 machine type is chosen.
 
 ### Operation system and parameters
 
@@ -293,7 +293,7 @@ From the images above, TiDB performs better on Ubuntu than on COS in the Point S
 > - This test is conducted only for the single test case and indicates that the performance might be affected by different operating systems, different optimization, and default settings. Therefore, PingCAP makes no recommendation for the operating system.
 > - COS is officially recommended by GKE, because it is optimized for containers and improved substantially on security and disk performance.
 
-#### Kubernetes Service vs GCP LoadBalancer
+#### Kubernetes Service vs Google Cloud LoadBalancer
 
 After TiDB is deployed on Kubernetes, there are two ways of accessing TiDB: via Kubernetes Service inside the cluster, or via Load Balancer IP outside the cluster. TiDB is tested in both ways.
 
@@ -329,7 +329,7 @@ Latency comparison:
 
 ![Service vs Load Balancer](/media/service-vs-load-balancer-latency.png)
 
-From the images above, TiDB performs better when accessed via Kubernetes Service than accessed via GCP Load Balancer in the Point Select test.
+From the images above, TiDB performs better when accessed via Kubernetes Service than accessed via Google Cloud Load Balancer in the Point Select test.
 
 #### n1-standard-16 vs c2-standard-16
 
@@ -417,7 +417,7 @@ The Point Select test is conducted on different operating systems and in differe
 
 ### Performance comparison between single AZ and multiple AZs
 
-The network latency on communication across multiple AZs in GCP is slightly higher than that within the same zone. In this test, machines of the same configuration are used in different deployment plans under the same standard. The purpose is to learn how the latency across multiple AZs might affect the performance of TiDB.
+The network latency on communication across multiple AZs in Google Cloud is slightly higher than that within the same zone. In this test, machines of the same configuration are used in different deployment plans under the same standard. The purpose is to learn how the latency across multiple AZs might affect the performance of TiDB.
 
 Single AZ:
 
@@ -456,7 +456,7 @@ From the images above, the impact of network latency goes down as the concurrenc
 This is a test of TiDB using sysbench running on Kubernetes deployed on a typical public cloud platform. The purpose is to learn how different factors might affect the performance of TiDB. On the whole, these influencing factors include the following items:
 
 - In the VPC-Native mode, TiDB performs slightly better in Host network than in Pod network. (The difference, ~7%, is measured in QPS. Performance differences caused by the factors below are also measured by QPS.)
-- In Host network, TiDB performs better (~9%) in the read test on Ubuntu provided by GCP than on COS.
+- In Host network, TiDB performs better (~9%) in the read test on Ubuntu provided by Google Cloud than on COS.
 - The TiDB performance is slightly lower (~5%) if it is accessed outside the cluster via Load Balancer.
 - Increased latency among nodes in multiple AZs has a certain impact on the TiDB performance (30% ~ 6%; the impact diminishes as the concurrent number increases).
 - The QPS performance is greatly improved (50% ~ 60%) if the Point Select read test is conducted on machines of computing type (compared with general types), because the test mainly consumes CPU resources.

--- a/en/build-multi-gcp-gke.md
+++ b/en/build-multi-gcp-gke.md
@@ -1,30 +1,30 @@
 ---
-title: Build Multiple Interconnected GCP GKE Clusters
-summary: Learn how to build multiple interconnected GCP GKE clusters and prepare for deploying a TiDB cluster across multiple GKE clusters.
+title: Build Multiple Interconnected Google Cloud GKE Clusters
+summary: Learn how to build multiple interconnected Google Cloud GKE clusters and prepare for deploying a TiDB cluster across multiple GKE clusters.
 ---
 
-# Build Multiple Interconnected GCP GKE Clusters
+# Build Multiple Interconnected Google Cloud GKE Clusters
 
-This document describes how to create multiple GCP GKE clusters and configure network peering between these clusters. These interconnected clusters can be used for [deploying TiDB clusters across multiple Kubernetes clusters](deploy-tidb-cluster-across-multiple-kubernetes.md). The example in this document shows how to configure three-cluster network peering.
+This document describes how to create multiple Google Kubernetes Engine (GKE) clusters and configure network peering between these clusters. These interconnected clusters can be used for [deploying TiDB clusters across multiple Kubernetes clusters](deploy-tidb-cluster-across-multiple-kubernetes.md). The example in this document shows how to configure three-cluster network peering.
 
-If you need to deploy TiDB on a single GCP GKE cluster, refer to [Deploy TiDB on GCP GKE](deploy-on-gcp-gke.md).
+If you need to deploy TiDB on a single GKE cluster, refer to [Deploy TiDB on Google Cloud GKE](deploy-on-gcp-gke.md).
 
 ## Prerequisites
 
 Before you deploy GKE clusters, make sure you have completed the following preparations:
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/). You need to use Helm to install TiDB Operator.
-* Install [gcloud](https://cloud.google.com/sdk/gcloud): `gcloud` is the CLI for creating and managing GCP services
+* Install [gcloud](https://cloud.google.com/sdk/gcloud): `gcloud` is the CLI for creating and managing Google Cloud services
 * Complete the *Before you begin* section in [GKE Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart#before-you-begin).
 
-## Configure GCP service
+## Configure Google Cloud service
 
-Configure your GCP project by running the following command:
+Configure your Google Cloud project by running the following command:
 
 {{< copyable "shell-regular" >}}
 
 ```bash
-gcloud config set core/project <gcp-project>
+gcloud config set core/project <google-cloud-project>
 ```
 
 ## Step 1. Create a VPC network

--- a/en/configure-a-tidb-cluster.md
+++ b/en/configure-a-tidb-cluster.md
@@ -627,7 +627,7 @@ NodePort has two modes:
 
 #### LoadBalancer
 
-If the TiDB cluster runs in an environment with LoadBalancer, such as on GCP or AWS, it is recommended to use the LoadBalancer feature of these cloud platforms by setting `tidb.service.type=LoadBalancer`.
+If the TiDB cluster runs in an environment with LoadBalancer, such as on Google Cloud or AWS, it is recommended to use the LoadBalancer feature of these cloud platforms by setting `tidb.service.type=LoadBalancer`.
 
 ```yaml
 spec:

--- a/en/configure-storage-class.md
+++ b/en/configure-storage-class.md
@@ -26,9 +26,9 @@ PVs are created automatically by the system administrator or volume provisioner.
 
 TiKV uses the Raft protocol to replicate data. When a node fails, PD automatically schedules data to fill the missing data replicas; TiKV requires low read and write latency, so local SSD storage is strongly recommended in the production environment.
 
-PD also uses Raft to replicate data. PD is not an I/O-intensive application, but a database for storing cluster meta information, so a local SAS disk or network SSD storage such as EBS General Purpose SSD (gp2) volumes on AWS or SSD persistent disks on GCP can meet the requirements.
+PD also uses Raft to replicate data. PD is not an I/O-intensive application, but a database for storing cluster meta information, so a local SAS disk or network SSD storage such as EBS General Purpose SSD (gp2) volumes on AWS or SSD persistent disks on Google Cloud can meet the requirements.
 
-To ensure availability, it is recommended to use network storage for components such as TiDB monitoring, TiDB Binlog, and `tidb-backup` because they do not have redundant replicas. TiDB Binlog's Pump and Drainer components are I/O-intensive applications that require low read and write latency, so it is recommended to use high-performance network storage such as EBS Provisioned IOPS SSD (io1) volumes on AWS or SSD persistent disks on GCP.
+To ensure availability, it is recommended to use network storage for components such as TiDB monitoring, TiDB Binlog, and `tidb-backup` because they do not have redundant replicas. TiDB Binlog's Pump and Drainer components are I/O-intensive applications that require low read and write latency, so it is recommended to use high-performance network storage such as EBS Provisioned IOPS SSD (io1) volumes on AWS or SSD persistent disks on Google Cloud.
 
 When deploying TiDB clusters or `tidb-backup` with TiDB Operator, you can configure `StorageClass` for the components that require persistent storage via the corresponding `storageClassName` field in the `values.yaml` configuration file. The `StorageClassName` is set to `local-storage` by default.
 

--- a/en/deploy-on-gcp-gke.md
+++ b/en/deploy-on-gcp-gke.md
@@ -1,24 +1,24 @@
 ---
-title: Deploy TiDB on GCP GKE
-summary: Learn how to deploy a TiDB cluster on GCP GKE.
+title: Deploy TiDB on Google Cloud GKE
+summary: Learn how to deploy a TiDB cluster on Google Cloud GKE.
 aliases: ['/docs/tidb-in-kubernetes/dev/deploy-on-gcp-gke/']
 ---
 
-# Deploy TiDB on GCP GKE
+# Deploy TiDB on Google Cloud GKE
 
 <!-- markdownlint-disable MD029 -->
 <!-- markdownlint-disable MD037 -->
 
-This document describes how to deploy a GCP Google Kubernetes Engine (GKE) cluster and deploy a TiDB cluster on GCP GKE.
+This document describes how to deploy a Google Kubernetes Engine (GKE) cluster and deploy a TiDB cluster on GKE.
 
 To deploy TiDB Operator and the TiDB cluster in a self-managed Kubernetes environment, refer to [Deploy TiDB Operator](deploy-tidb-operator.md) and [Deploy TiDB on General Kubernetes](deploy-on-general-kubernetes.md).
 
 ## Prerequisites
 
-Before deploying a TiDB cluster on GCP GKE, make sure the following requirements are satisfied:
+Before deploying a TiDB cluster on GKE, make sure the following requirements are satisfied:
 
 * Install [Helm 3](https://helm.sh/docs/intro/install/): used for deploying TiDB Operator.
-* Install [gcloud](https://cloud.google.com/sdk/gcloud): a command-line tool used for creating and managing GCP services.
+* Install [gcloud](https://cloud.google.com/sdk/gcloud): a command-line tool used for creating and managing Google Cloud services.
 * Complete the operations in the **Before you begin** section of [GKE Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstart#before-you-begin).
 
     This guide includes the following contents:
@@ -34,15 +34,15 @@ Before deploying a TiDB cluster on GCP GKE, make sure the following requirements
     * TiKV or TiFlash nodes: `n2-standard-16`
 * Storage: For TiKV or TiFlash, it is recommended to use [pd-ssd](https://cloud.google.com/compute/docs/disks/performance#type_comparison) disk type.
 
-## Configure the GCP service
+## Configure the Google Cloud service
 
-Configure your GCP project and default region:
+Configure your Google Cloud project and default region:
 
 {{< copyable "shell-regular" >}}
 
 ```bash
-gcloud config set core/project <gcp-project>
-gcloud config set compute/region <gcp-region>
+gcloud config set core/project <google-cloud-project>
+gcloud config set compute/region <google-cloud-region>
 ```
 
 ## Create a GKE cluster and node pool
@@ -109,7 +109,7 @@ mountOptions:
 
 For the production environment, use [zonal persistent disks](https://cloud.google.com/compute/docs/disks#pdspecs).
 
-If you need to simulate bare-metal performance, some GCP instance types provide additional [local store volumes](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd). You can choose such instances for the TiKV node pool to achieve higher IOPS and lower latency.
+If you need to simulate bare-metal performance, some Google Cloud instance types provide additional [local store volumes](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd). You can choose such instances for the TiKV node pool to achieve higher IOPS and lower latency.
 
 > **Note:**
 >
@@ -150,7 +150,7 @@ To deploy TiDB Operator on GKE, refer to [deploy TiDB Operator](get-started.md#s
 
 ## Deploy a TiDB cluster and the monitoring component
 
-This section describes how to deploy a TiDB cluster and its monitoring component on GCP GKE.
+This section describes how to deploy a TiDB cluster and its monitoring component on GKE.
 
 ### Create namespace
 

--- a/en/deploy-tidb-cluster-across-multiple-kubernetes.md
+++ b/en/deploy-tidb-cluster-across-multiple-kubernetes.md
@@ -14,7 +14,7 @@ You need to configure the Kubernetes network and DNS so that the Kubernetes clus
 - The TiDB components on each Kubernetes cluster can access the Pod IP of all TiDB components in and between clusters.
 - The TiDB components on each Kubernetes cluster can look up the Pod FQDN of all TiDB components in and between clusters.
 
-To build multiple connected EKS or GKE clusters, refer to [Build Multiple Interconnected AWS EKS Clusters](build-multi-aws-eks.md) or [Build Multiple Interconnected GCP GKE Clusters](build-multi-gcp-gke.md).
+To build multiple connected EKS or GKE clusters, refer to [Build Multiple Interconnected AWS EKS Clusters](build-multi-aws-eks.md) or [Build Multiple Interconnected Google Cloud GKE Clusters](build-multi-gcp-gke.md).
 
 ## Supported scenarios
 

--- a/en/deploy-tidb-from-kubernetes-gke.md
+++ b/en/deploy-tidb-from-kubernetes-gke.md
@@ -22,7 +22,7 @@ It takes you through the following steps:
 
 > **Warning:**
 >
-> This document is for testing purposes only. **Do not** follow it in production environments. For production environments, see the instructions in [Deploy TiDB on GCP GKE](deploy-on-gcp-gke.md).
+> This document is for testing purposes only. **Do not** follow it in production environments. For production environments, see the instructions in [Deploy TiDB on Google Cloud GKE](deploy-on-gcp-gke.md).
 
 ## Select a project
 

--- a/en/deploy-tidb-operator.md
+++ b/en/deploy-tidb-operator.md
@@ -25,7 +25,7 @@ TiDB Operator runs in the Kubernetes cluster. You can refer to [the document of 
 For some public cloud environments, refer to the following documents:
 
 - [Deploy on AWS EKS](deploy-on-aws-eks.md)
-- [Deploy on GCP GKE](deploy-on-gcp-gke.md)
+- [Deploy on Google Cloud GKE](deploy-on-gcp-gke.md)
 - [Deploy on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
 
 TiDB Operator uses [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to persist the data of TiDB cluster (including the database, monitoring data, and backup data), so the Kubernetes cluster must provide at least one kind of persistent volumes.

--- a/en/get-started.md
+++ b/en/get-started.md
@@ -32,7 +32,7 @@ This section describes two ways to create a simple Kubernetes cluster. After cre
 - [Use kind](#method-1-create-a-kubernetes-cluster-using-kind) to deploy a Kubernetes cluster in Docker. It is a common and recommended way.
 - [Use minikube](#method-2-create-a-kubernetes-cluster-using-minikube) to deploy a Kubernetes cluster running locally in a VM.
 
-Alternatively, you can deploy a Kubernetes cluster on Google Kubernetes Engine on Google Cloud Platform using the [Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/pingcap/docs-tidb-operator&cloudshell_tutorial=en/deploy-tidb-from-kubernetes-gke.md).
+Alternatively, you can deploy a Kubernetes cluster on Google Kubernetes Engine on Google Cloud using the [Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/pingcap/docs-tidb-operator&cloudshell_tutorial=en/deploy-tidb-from-kubernetes-gke.md).
 
 ### Method 1: Create a Kubernetes cluster using kind
 
@@ -802,7 +802,7 @@ If you want to deploy a TiDB cluster in production environments, refer to the fo
 On public clouds:
 
 - [Deploy TiDB on AWS EKS](deploy-on-aws-eks.md)
-- [Deploy TiDB on GCP GKE](deploy-on-gcp-gke.md)
+- [Deploy TiDB on Google Cloud GKE](deploy-on-gcp-gke.md)
 - [Deploy TiDB on Azure AKS](deploy-on-azure-aks.md)
 - [Deploy TiDB on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
 

--- a/en/grant-permissions-to-remote-storage.md
+++ b/en/grant-permissions-to-remote-storage.md
@@ -152,7 +152,7 @@ When you use this method to grant permissions, you can [create the EKS cluster](
 
 ### Grant permissions by the service account
 
-Create the `gcs-secret` secret which stores the credential used to access GCS. The `google-credentials.json` file stores the service account key that you have downloaded from the GCP console. Refer to [GCP documentation](https://cloud.google.com/docs/authentication/getting-started) for details.
+Create the `gcs-secret` secret which stores the credential used to access GCS. The `google-credentials.json` file stores the service account key that you have downloaded from the Google Cloud console. Refer to [Google Cloud documentation](https://cloud.google.com/docs/authentication/getting-started) for details.
 
 {{< copyable "shell-regular" >}}
 

--- a/en/replace-nodes-for-cloud-disk.md
+++ b/en/replace-nodes-for-cloud-disk.md
@@ -9,7 +9,7 @@ This document describes a method for replacing and upgrading nodes without downt
 
 This document uses Amazon EKS as an example and describes how to create a new node group and migrate a TiDB cluster to the new node group using a rolling restart. You can use this method to replace a node group with more compute resources for TiKV or TiDB and upgrade EKS.
 
-For other cloud platforms, refer to [GCP GKE](deploy-on-gcp-gke.md), [Azure AKS](deploy-on-azure-aks.md), or [Alibaba Cloud ACK](deploy-on-alibaba-cloud.md) and operate on the node group.
+For other cloud platforms, refer to [Google Cloud GKE](deploy-on-gcp-gke.md), [Azure AKS](deploy-on-azure-aks.md), or [Alibaba Cloud ACK](deploy-on-alibaba-cloud.md) and operate on the node group.
 
 ## Prerequisites
 

--- a/en/tidb-operator-overview.md
+++ b/en/tidb-operator-overview.md
@@ -31,7 +31,7 @@ TiDB Operator provides several ways to deploy TiDB clusters on Kubernetes:
 
     + On public cloud:
         - [Deploy TiDB on AWS EKS](deploy-on-aws-eks.md)
-        - [Deploy TiDB on GCP GKE (beta)](deploy-on-gcp-gke.md)
+        - [Deploy TiDB on Google Cloud GKE (beta)](deploy-on-gcp-gke.md)
         - [Deploy TiDB on Azure AKS](deploy-on-azure-aks.md)
         - [Deploy TiDB on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
 

--- a/en/tidb-operator-overview.md
+++ b/en/tidb-operator-overview.md
@@ -31,7 +31,7 @@ TiDB Operator provides several ways to deploy TiDB clusters on Kubernetes:
 
     + On public cloud:
         - [Deploy TiDB on AWS EKS](deploy-on-aws-eks.md)
-        - [Deploy TiDB on Google Cloud GKE (beta)](deploy-on-gcp-gke.md)
+        - [Deploy TiDB on Google Cloud GKE](deploy-on-gcp-gke.md)
         - [Deploy TiDB on Azure AKS](deploy-on-azure-aks.md)
         - [Deploy TiDB on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
 

--- a/zh/TOC.md
+++ b/zh/TOC.md
@@ -16,14 +16,14 @@
     - [访问 TiDB 集群](access-tidb.md)
   - 公有云的 Kubernetes
     - [Amazon EKS](deploy-on-aws-eks.md)
-    - [GCP GKE](deploy-on-gcp-gke.md)
+    - [Google Cloud GKE](deploy-on-gcp-gke.md)
     - [Azure AKS](deploy-on-azure-aks.md)
     - [阿里云 ACK](deploy-on-alibaba-cloud.md)
   - [在 ARM64 机器上部署 TiDB 集群](deploy-cluster-on-arm64.md)
   - [部署 TiDB HTAP 存储引擎 TiFlash](deploy-tiflash.md)
   - 跨多个 Kubernetes 集群部署 TiDB 集群
     - [构建多个网络互通的 AWS EKS 集群](build-multi-aws-eks.md)
-    - [构建多个网络互通的 GCP GKE 集群](build-multi-gcp-gke.md)
+    - [构建多个网络互通的 GKE 集群](build-multi-gcp-gke.md)
     - [跨多个 Kubernetes 集群部署 TiDB 集群](deploy-tidb-cluster-across-multiple-kubernetes.md)
   - [部署 TiDB 异构集群](deploy-heterogeneous-tidb-cluster.md)
   - [部署增量数据同步工具 TiCDC](deploy-ticdc.md)

--- a/zh/_index.md
+++ b/zh/_index.md
@@ -24,7 +24,7 @@ hide_commit: true
 
 [部署到 Amazon EKS](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-on-aws-eks)
 
-[部署到 GCP GKE](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-on-gcp-gke)
+[部署到 Google Cloud GKE](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-on-gcp-gke)
 
 [部署到 Azure AKS](https://docs.pingcap.com/zh/tidb-in-kubernetes/dev/deploy-on-azure-aks)
 

--- a/zh/access-tidb.md
+++ b/zh/access-tidb.md
@@ -62,7 +62,7 @@ kubectl -n ${namespace} get svc ${cluster_name}-tidb -ojsonpath="{.spec.ports[?(
 
 ## LoadBalancer
 
-若运行在有 LoadBalancer 的环境，比如 GCP/AWS 平台，建议使用云平台的 LoadBalancer 特性。
+若运行在有 LoadBalancer 的环境，比如 Google Cloud、AWS 平台，建议使用云平台的 LoadBalancer 特性。
 
 参考 [EKS](deploy-on-aws-eks.md#安装-mysql-客户端并连接)、[GKE](deploy-on-gcp-gke.md#安装-mysql-客户端并连接) 和 [ACK](deploy-on-alibaba-cloud.md#连接数据库) 文档，通过 LoadBalancer 访问 TiDB 服务。
 

--- a/zh/backup-restore-cr.md
+++ b/zh/backup-restore-cr.md
@@ -124,7 +124,7 @@ summary: 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段�
 * `.spec.br.rateLimit`：是否对流量进行限制。单位为 MB/s，例如设置为 `4` 代表限速 4 MB/s，默认不限速。
 * `.spec.br.checksum`：是否在备份结束之后对文件进行验证。默认为 `true`。
 * `.spec.br.timeAgo`：备份 timeAgo 以前的数据，默认为空（备份当前数据），[支持](https://golang.org/pkg/time/#ParseDuration) "1.5h"，"2h45m" 等数据。
-* `.spec.br.sendCredToTikv`：BR 进程是否将自己的 AWS 权限、GCP 权限或者 Azure 权限传输给 TiKV 进程。默认为 `true`。
+* `.spec.br.sendCredToTikv`：BR 进程是否将自己的 AWS 权限、Google Cloud 权限或者 Azure 权限传输给 TiKV 进程。默认为 `true`。
 * `.spec.br.onLine`：restore 时是否启用[在线恢复功能](https://docs.pingcap.com/zh/tidb/stable/use-br-command-line-tool#在线恢复实验性功能)。
 * `.spec.br.options`：BR 工具支持的额外参数，需要以字符串数组的形式传入。自 v1.1.6 版本起支持该参数。可用于指定 `lastbackupts` 以进行增量备份。
 
@@ -178,7 +178,7 @@ summary: 介绍用于备份与恢复的 Custom Resource (CR) 资源的各字段�
 
 ### GCS 存储字段介绍
 
-* `.spec.gcs.projectId`：代表 GCP 上用户项目的唯一标识。具体获取该标识的方法可参考 [GCP 官方文档](https://cloud.google.com/resource-manager/docs/creating-managing-projects)。
+* `.spec.gcs.projectId`：代表 Google Cloud 上用户项目的唯一标识。具体获取该标识的方法可参考 [Google Cloud 官方文档](https://cloud.google.com/resource-manager/docs/creating-managing-projects)。
 * `.spec.gcs.location`：指定 GCS bucket 所在的区域，例如 `us-west2`。
 * `.spec.gcs.path`：指定备份文件在远端存储的存储路径，该字段仅在使用 Dumpling 备份或 Lightning 恢复时有效，例如 `gcs://test1-demo1/backup-2019-11-11T16:06:05Z.tgz`。
 * `.spec.gcs.secretName`：指定存储 GCS 用户账号认证信息的 Secret 名称。

--- a/zh/benchmark-sysbench.md
+++ b/zh/benchmark-sysbench.md
@@ -83,7 +83,7 @@ set global tidb_disable_txn_auto_retry=0;
 | TiDB     | c2-standard-16 | 3     |
 | Sysbench | c2-standard-30 | 1     |
 
-分别在多可用区和单可用区中对 TiDB 进行性能测试，并将结果相对比。在测试时 (2019.08)，一个 GCP 区域 (region) 下不存在三个能同时提供 c2 机器的可用区，所以我们选择了如下机器型号进行测试：
+分别在多可用区和单可用区中对 TiDB 进行性能测试，并将结果相对比。在测试时 (2019.08)，一个 Google Cloud 区域 (region) 下不存在三个能同时提供 c2 机器的可用区，所以我们选择了如下机器型号进行测试：
 
 | 组件     | 实例类型       | 数量  |
 | :---     | :---------     | :---- |
@@ -96,7 +96,7 @@ set global tidb_disable_txn_auto_retry=0;
 
 > **注意：**
 >
-> GCP 不同的区域可用机型不同。同时测试中发现磁盘性能表现也存在差异，我们统一在 us-central1 中申请机器测试。
+> Google Cloud 不同的区域可用机型不同。同时测试中发现磁盘性能表现也存在差异，我们统一在 us-central1 中申请机器测试。
 
 #### 磁盘
 
@@ -112,7 +112,7 @@ GKE 网络模式使用具备更好扩展性以及功能强大的 [VPC-Native](ht
 
 #### CPU
 
-在单可用集群测试中，我们为 TiDB/TiKV 选择 c2-standard-16 机型测试。在单可用与多可用集群的对比测试中，因为 GCP 区域 (region) 下不存在三个能同时申请 c2-standard-16 机型的可用区，所以我们选择了 n1-standard-16 机型测试。
+在单可用集群测试中，我们为 TiDB/TiKV 选择 c2-standard-16 机型测试。在单可用与多可用集群的对比测试中，因为 Google Cloud 区域 (region) 下不存在三个能同时申请 c2-standard-16 机型的可用区，所以我们选择了 n1-standard-16 机型测试。
 
 ### 操作系统及参数
 
@@ -280,7 +280,7 @@ Latency 对比：
 >
 > 此测试只针对单一测试集进行了测试，表明不同的操作系统、不同的优化与默认设置，都有可能影响性能，所以我们在此不对操作系统做推荐。COS 系统专为容器优化，在安全性、磁盘性能做了优化，在 GKE 是官方推荐系统。
 
-#### K8S Service vs GCP LoadBalancer
+#### K8S Service vs Google Cloud LoadBalancer
 
 通过 Kubernetes 部署 TiDB 集群后，有两种访问 TiDB 集群的场景：集群内通过 Service 访问或集群外通过 Load Balancer IP 访问。本次测试中分别对这两种情况进行了对比测试。
 
@@ -316,7 +316,7 @@ Latency 对比：
 
 ![Service vs Load Balancer](/media/service-vs-load-balancer-latency.png)
 
-从图中可以看到在单纯的 Point Select 测试中，使用 Kubernetes Service 访问 TiDB 时的表现比使用 GCP Load Balancer 访问时要好。
+从图中可以看到在单纯的 Point Select 测试中，使用 Kubernetes Service 访问 TiDB 时的表现比使用 Google Cloud Load Balancer 访问时要好。
 
 #### n1-standard-16 vs c2-standard-16
 
@@ -402,7 +402,7 @@ Latency 对比：
 
 ### 单可用区与多可用区对比
 
-GCP 多可用区涉及跨 Zone 通信，网络延迟相比同 Zone 会少许增加。我们使用同样机器配置，对两种部署方案进行同一标准下的性能测试，了解多可用区延迟增加带来的影响。
+Google Cloud 多可用区涉及跨 Zone 通信，网络延迟相比同 Zone 会少许增加。我们使用同样机器配置，对两种部署方案进行同一标准下的性能测试，了解多可用区延迟增加带来的影响。
 
 单可用区：
 
@@ -441,7 +441,7 @@ Latency 对比：
 此次测试主要将典型公有云部署 Kubernetes 运行 TiDB 集群的几种场景使用 sysbench 做了测试，了解不同因素可能带来的影响。从整体看，主要有以下几点：
 
 - VPC-Native 模式下 Host 网络性能略好于 Pod 网络（~7%，以 QPS 差异估算，下同）
-- GCP 的 Ubuntu 系统 Host 网络下单纯的读测试中性能略好于 COS (~9%)
+- Google Cloud 的 Ubuntu 系统 Host 网络下单纯的读测试中性能略好于 COS (~9%)
 - 使用 Load Balancer 在集群外访问，会略损失性能 (~5%)
 - 多可用区下节点之间延迟增加，会对 TiDB 性能产生一定的影响（30% ~ 6%，随并发数增加而下降）
 - Point Select 读测试主要消耗 CPU ，计算型机型相对普通型机器带来了很大 QPS 提升 (50% ~ 60%)

--- a/zh/build-multi-gcp-gke.md
+++ b/zh/build-multi-gcp-gke.md
@@ -1,13 +1,13 @@
 ---
-title: 构建多个网络互通的 GCP GKE 集群
-summary: 介绍如何构建多个 GCP GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
+title: 构建多个网络互通的 Google Cloud GKE 集群
+summary: 介绍如何构建多个 Google Cloud GKE 集群互通网络，为跨 Kubernetes 集群部署 TiDB 集群作准备
 ---
 
-# 构建多个网络互通的 GCP GKE 集群
+# 构建多个网络互通的 Google Cloud GKE 集群
 
-本文介绍了如何构建多个 GCP GKE 集群，并配置集群之间的网络互通，为跨 Kubernetes 集群部署 TiDB 集群作准备。
+本文介绍了如何构建多个 Google Kubernetes Engine (GKE) 集群，并配置集群之间的网络互通，为跨 Kubernetes 集群部署 TiDB 集群作准备。
 
-如果仅需要部署一个 TiDB 集群到一个 GCP GKE 集群，请参考[在 GCP GKE 上部署 TiDB 集群](deploy-on-gcp-gke.md)文档。
+如果仅需要部署一个 TiDB 集群到一个 GKE 集群，请参考[在 Google Cloud GKE 上部署 TiDB 集群](deploy-on-gcp-gke.md)文档。
 
 ## 环境准备
 
@@ -17,14 +17,14 @@ summary: 介绍如何构建多个 GCP GKE 集群互通网络，为跨 Kubernetes
 * [gcloud](https://cloud.google.com/sdk/gcloud)：用于创建和管理 GCP 服务的命令行工具
 * 完成 [GKE 快速入门](https://cloud.google.com/kubernetes-engine/docs/quickstart#before-you-begin) 中的**准备工作** (Before you begin)
 
-## 配置 GCP 服务
+## 配置 Google Cloud 服务
 
-使用以下命令，设置好你的 GCP 项目：
+使用以下命令，设置好你的 Google Cloud 项目：
 
 {{< copyable "shell-regular" >}}
 
 ```bash
-gcloud config set core/project <gcp-project>
+gcloud config set core/project <google-cloud-project>
 ```
 
 ## 第 1 步：创建网络

--- a/zh/configure-a-tidb-cluster.md
+++ b/zh/configure-a-tidb-cluster.md
@@ -603,7 +603,7 @@ NodePort 有两种模式：
 
 #### LoadBalancer
 
-若运行在有 LoadBalancer 的环境，比如 GCP/AWS 平台，建议使用云平台的 LoadBalancer 特性。
+若运行在有 LoadBalancer 的环境，比如 Google Cloud、AWS 平台，建议使用云平台的 LoadBalancer 特性。
 
 ```yaml
 spec:

--- a/zh/configure-storage-class.md
+++ b/zh/configure-storage-class.md
@@ -26,9 +26,9 @@ PV 一般由系统管理员或 volume provisioner 自动创建，PV 与 Pod 是�
 
 TiKV 自身借助 Raft 实现了数据复制，出现节点故障后，PD 会自动进行数据调度补齐缺失的数据副本，同时 TiKV 要求存储有较低的读写延迟，所以生产环境强烈推荐使用本地 SSD 存储。
 
-PD 同样借助 Raft 实现了数据复制，但作为存储集群元信息的数据库，并不是 IO 密集型应用，所以一般本地普通 SAS 盘或网络 SSD 存储（例如 AWS 上 gp2 类型的 EBS 存储卷，GCP 上的持久化 SSD 盘）就可以满足要求。
+PD 同样借助 Raft 实现了数据复制，但作为存储集群元信息的数据库，并不是 IO 密集型应用，所以一般本地普通 SAS 盘或网络 SSD 存储（例如 AWS 上 gp2 类型的 EBS 存储卷，Google Cloud 上的持久化 SSD 盘）就可以满足要求。
 
-监控组件以及 TiDB Binlog、备份等工具，由于自身没有做多副本冗余，所以为保证可用性，推荐用网络存储。其中 TiDB Binlog 的 pump 和 drainer 组件属于 IO 密集型应用，需要较低的读写延迟，所以推荐用高性能的网络存储（例如 AWS 上的 io1 类型的 EBS 存储卷，GCP 上的持久化 SSD 盘）。
+监控组件以及 TiDB Binlog、备份等工具，由于自身没有做多副本冗余，所以为保证可用性，推荐用网络存储。其中 TiDB Binlog 的 pump 和 drainer 组件属于 IO 密集型应用，需要较低的读写延迟，所以推荐用高性能的网络存储（例如 AWS 上的 io1 类型的 EBS 存储卷，Google Cloud 上的持久化 SSD 盘）。
 
 在利用 TiDB Operator 部署 TiDB 集群或者备份工具的时候，需要持久化存储的组件都可以通过 values.yaml 配置文件中对应的 `storageClassName` 设置存储类型。不设置时默认都使用 `local-storage`。
 

--- a/zh/deploy-on-gcp-gke.md
+++ b/zh/deploy-on-gcp-gke.md
@@ -1,14 +1,14 @@
 ---
-title: 在 GCP GKE 上部署 TiDB 集群
-summary: 了解如何在 GCP GKE 上部署 TiDB 集群。
+title: 在 Google Cloud GKE 上部署 TiDB 集群
+summary: 了解如何在 Google Cloud GKE 上部署 TiDB 集群。
 aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-on-gcp-gke/']
 ---
 
-# 在 GCP GKE 上部署 TiDB 集群
+# 在 Google Cloud GKE 上部署 TiDB 集群
 
 <!-- markdownlint-disable MD029 -->
 
-本文介绍了如何部署 GCP Google Kubernetes Engine (GKE) 集群，并在其中部署 TiDB 集群。
+本文介绍了如何部署 Google Kubernetes Engine (GKE) 集群，并在其中部署 TiDB 集群。
 
 如果需要部署 TiDB Operator 及 TiDB 集群到自托管 Kubernetes 环境，请参考[部署 TiDB Operator](deploy-tidb-operator.md)及[部署 TiDB 集群](deploy-on-general-kubernetes.md)等文档。
 
@@ -17,7 +17,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-on-gcp-gke/']
 部署前，请确认已完成以下环境准备：
 
 * [Helm 3](https://helm.sh/docs/intro/install/)：用于安装 TiDB Operator
-* [gcloud](https://cloud.google.com/sdk/gcloud)：用于创建和管理 GCP 服务的命令行工具
+* [gcloud](https://cloud.google.com/sdk/gcloud)：用于创建和管理 Google Cloud 服务的命令行工具
 * 完成 [GKE 快速入门](https://cloud.google.com/kubernetes-engine/docs/quickstart#before-you-begin) 中的**准备工作** (Before you begin)
 
     该教程包含以下内容：
@@ -33,16 +33,16 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-on-gcp-gke/']
     * TiKV 或 TiFlash 所在节点：`n2-standard-16`
 * 推荐存储：推荐 TiKV 与 TiFlash 使用 [pd-ssd](https://cloud.google.com/compute/docs/disks/performance#type_comparison) 类型的存储。
 
-## 配置 GCP 服务
+## 配置 Google Cloud 服务
 
 {{< copyable "shell-regular" >}}
 
 ```shell
-gcloud config set core/project <gcp-project>
-gcloud config set compute/region <gcp-region>
+gcloud config set core/project <google-cloud-project>
+gcloud config set compute/region <google-cloud-region>
 ```
 
-使用以上命令，设置好你的 GCP 项目和默认的区域。
+使用以上命令，设置好你的 Google Cloud 项目和默认的区域。
 
 ## 创建 GKE 集群和节点池
 
@@ -105,7 +105,7 @@ mountOptions:
 
 ### 使用本地存储
 
-请使用[区域永久性磁盘](https://cloud.google.com/compute/docs/disks#pdspecs)作为生产环境的存储类型。如果需要模拟测试裸机部署的性能，可以使用 GCP 部分实例类型提供的[本地存储卷](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd)。可以为 TiKV 节点池选择这一类型的实例，以便提供更高的 IOPS 和低延迟。
+请使用[区域永久性磁盘](https://cloud.google.com/compute/docs/disks#pdspecs)作为生产环境的存储类型。如果需要模拟测试裸机部署的性能，可以使用 Google Cloud 部分实例类型提供的[本地存储卷](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd)。可以为 TiKV 节点池选择这一类型的实例，以便提供更高的 IOPS 和低延迟。
 
 > **注意：**
 >
@@ -143,7 +143,7 @@ mountOptions:
 
 ## 部署 TiDB 集群和监控
 
-下面介绍如何在 GCP GKE 上部署 TiDB 集群和监控组件。
+下面介绍如何在 GKE 上部署 TiDB 集群和监控组件。
 
 ### 创建 namespace
 

--- a/zh/deploy-tidb-cluster-across-multiple-kubernetes.md
+++ b/zh/deploy-tidb-cluster-across-multiple-kubernetes.md
@@ -14,7 +14,7 @@ summary: 本文档介绍如何实现跨多个 Kubernetes 集群部署 TiDB 集�
 - 各 Kubernetes 集群上的 TiDB 组件有能力访问集群内和集群间所有 TiDB 组件的 Pod IP。
 - 各 Kubernetes 集群上的 TiDB 组件有能力解析集群内和集群间所有 TiDB 组件的 Pod FQDN。
 
-多个 EKS 或者 GKE 集群网络互通可以参考 [构建多个网络互通的 AWS EKS 集群](build-multi-aws-eks.md) 与 [构建多个网络互通的 GCP GKE 集群](build-multi-gcp-gke.md)。
+多个 EKS 或者 GKE 集群网络互通可以参考 [构建多个网络互通的 AWS EKS 集群](build-multi-aws-eks.md) 与 [构建多个网络互通的 Google Cloud GKE 集群](build-multi-gcp-gke.md)。
 
 ## 支持场景
 

--- a/zh/deploy-tidb-from-kubernetes-gke.md
+++ b/zh/deploy-tidb-from-kubernetes-gke.md
@@ -1,12 +1,12 @@
 ---
-title: 在 GCP 上通过 Kubernetes 部署 TiDB 集群
-summary: 在 GCP 上通过 Kubernetes 部署 TiDB 集群教程。
+title: 在 Google Cloud 上通过 Kubernetes 部署 TiDB 集群
+summary: 在 Google Cloud 上通过 Kubernetes 部署 TiDB 集群教程。
 aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-tidb-from-kubernetes-gke/']
 ---
 
-# 在 GCP 上通过 Kubernetes 部署 TiDB 集群
+# 在 Google Cloud 上通过 Kubernetes 部署 TiDB 集群
 
-本文介绍如何使用 [TiDB Operator](https://github.com/pingcap/tidb-operator) 在 GCP 上部署 TiDB 集群。本教程需要在 [Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/docs-tidb-operator&tutorial=zh/deploy-tidb-from-kubernetes-gke.md) 上运行。
+本文介绍如何使用 [TiDB Operator](https://github.com/pingcap/tidb-operator) 在 Google Cloud 上部署 TiDB 集群。本教程需要在 [Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/pingcap/docs-tidb-operator&tutorial=zh/deploy-tidb-from-kubernetes-gke.md) 上运行。
 
 <a href="https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/pingcap/docs-tidb-operator&cloudshell_tutorial=zh/deploy-tidb-from-kubernetes-gke.md"><img src="https://gstatic.com/cloudssh/images/open-btn.png"/></a>
 
@@ -22,7 +22,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-tidb-from-kubernetes-gke/']
 
 > **警告：**
 >
-> 本文中的部署说明仅用于测试目的，**不要**直接用于生产环境。如果要在生产环境部署，请参阅[在 GCP 上通过 Kubernetes 部署 TiDB 集群](deploy-on-gcp-gke.md)。
+> 本文中的部署说明仅用于测试目的，**不要**直接用于生产环境。如果要在生产环境部署，请参阅[在 Google Cloud 上通过 Kubernetes 部署 TiDB 集群](deploy-on-gcp-gke.md)。
 
 ## 选择一个项目
 

--- a/zh/deploy-tidb-operator.md
+++ b/zh/deploy-tidb-operator.md
@@ -25,7 +25,7 @@ TiDB Operator 运行在 Kubernetes 集群，你可以使用 [Getting started 页
 对于部分公有云环境，可以参考如下文档部署 TiDB Operator 及 TiDB 集群：
 
 - [部署到 AWS EKS](deploy-on-aws-eks.md)
-- [部署到 GCP GKE](deploy-on-gcp-gke.md)
+- [部署到 Google Cloud GKE](deploy-on-gcp-gke.md)
 - [部署到阿里云 ACK](deploy-on-alibaba-cloud.md)
 
 TiDB Operator 使用[持久化卷](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)持久化存储 TiDB 集群数据（包括数据库，监控和备份数据），所以 Kubernetes 集群必须提供至少一种持久化卷。

--- a/zh/get-started.md
+++ b/zh/get-started.md
@@ -32,7 +32,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/get-started/','/docs-cn/dev/tidb-in-k
 - [使用 kind](#方法一使用-kind-创建-kubernetes-集群) 创建在 Docker 中运行的 Kubernetes，这是目前比较通用的部署方式。
 - [使用 minikube](#方法二使用-minikube-创建-kubernetes-集群) 创建在虚拟机中运行的 Kubernetes
 
-你也可以使用 [Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/pingcap/docs-tidb-operator&cloudshell_tutorial=zh/deploy-tidb-from-kubernetes-gke.md) 在 Google Cloud Platform 的 Google Kubernetes Engine 中部署 Kubernetes 集群。
+你也可以使用 [Google Cloud Shell](https://console.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/pingcap/docs-tidb-operator&cloudshell_tutorial=zh/deploy-tidb-from-kubernetes-gke.md) 在 Google Cloud 的 Google Kubernetes Engine 中部署 Kubernetes 集群。
 
 ### 方法一：使用 kind 创建 Kubernetes 集群
 
@@ -841,7 +841,7 @@ minikube delete
 在公有云上部署：
 
 - [在 AWS EKS 上部署 TiDB 集群](deploy-on-aws-eks.md)
-- [在 GCP GKE 上部署 TiDB 集群](deploy-on-gcp-gke.md)
+- [在 Google Cloud GKE 上部署 TiDB 集群](deploy-on-gcp-gke.md)
 - [在 Azure AKS 上部署 TiDB 集群](deploy-on-azure-aks.md)
 - [在阿里云 ACK 上部署 TiDB 集群](deploy-on-alibaba-cloud.md)
 

--- a/zh/grant-permissions-to-remote-storage.md
+++ b/zh/grant-permissions-to-remote-storage.md
@@ -150,7 +150,7 @@ kubectl create secret generic s3-secret --from-literal=access_key=xxx --from-lit
 
 ### 通过服务账号密钥授权
 
-创建 `gcs-secret` secret。该 secret 存放用于访问 GCS 的凭证。`google-credentials.json` 文件存放用户从 GCP console 上下载的 service account key。具体操作参考 [GCP 官方文档](https://cloud.google.com/docs/authentication/getting-started)。
+创建 `gcs-secret` secret。该 secret 存放用于访问 GCS 的凭证。`google-credentials.json` 文件存放用户从 Google Cloud console 上下载的 service account key。具体操作参考 [Google Cloud 官方文档](https://cloud.google.com/docs/authentication/getting-started)。
 
 {{< copyable "shell-regular" >}}
 

--- a/zh/replace-nodes-for-cloud-disk.md
+++ b/zh/replace-nodes-for-cloud-disk.md
@@ -11,7 +11,7 @@ summary: 介绍如何为使用云存储的 TiDB 集群更换节点。
 
 > **注意：**
 >
-> 其它公有云环境请参考[GCP GKE](deploy-on-gcp-gke.md)、[Azure AKS](deploy-on-azure-aks.md)、[阿里云 ACK](deploy-on-alibaba-cloud.md) 操作节点组。
+> 其它公有云环境请参考 [Google Cloud GKE](deploy-on-gcp-gke.md)、[Azure AKS](deploy-on-azure-aks.md)、[阿里云 ACK](deploy-on-alibaba-cloud.md) 操作节点组。
 
 ## 前置条件
 

--- a/zh/replace-nodes-for-cloud-disk.md
+++ b/zh/replace-nodes-for-cloud-disk.md
@@ -11,7 +11,7 @@ summary: 介绍如何为使用云存储的 TiDB 集群更换节点。
 
 > **注意：**
 >
-> 其它公有云环境请参考 [Google Cloud GKE](deploy-on-gcp-gke.md)、[Azure AKS](deploy-on-azure-aks.md)、[阿里云 ACK](deploy-on-alibaba-cloud.md) 操作节点组。
+> 其它公有云环境请参考 [Google Cloud GKE](deploy-on-gcp-gke.md)、[Azure AKS](deploy-on-azure-aks.md) 或[阿里云 ACK](deploy-on-alibaba-cloud.md) 操作节点组。
 
 ## 前置条件
 

--- a/zh/tidb-operator-overview.md
+++ b/zh/tidb-operator-overview.md
@@ -34,9 +34,9 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
     - 在公有云上部署生产可用的 TiDB 集群并进行后续的运维管理；
 
         - [在 AWS EKS 上部署 TiDB 集群](deploy-on-aws-eks.md)
-        - [Deploy TiDB on Google Cloud GKE (beta)](deploy-on-gcp-gke.md)
-        - [Deploy TiDB on Azure AKS](deploy-on-azure-aks.md)
-        - [Deploy TiDB on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
+        - [在 Google Cloud GKE 上部署 TiDB 集群 (beta)](deploy-on-gcp-gke.md)
+        - [在 Azure AKS 上部署 TiDB 集群](deploy-on-azure-aks.md)
+        - [在阿里云 ACK 上部署 TiDB 集群](deploy-on-alibaba-cloud.md)
 
     - 在自托管的 Kubernetes 集群中部署 TiDB 集群：
 

--- a/zh/tidb-operator-overview.md
+++ b/zh/tidb-operator-overview.md
@@ -34,7 +34,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
     - 在公有云上部署生产可用的 TiDB 集群并进行后续的运维管理；
 
         - [在 AWS EKS 上部署 TiDB 集群](deploy-on-aws-eks.md)
-        - [在 Google Cloud GKE 上部署 TiDB 集群 (beta)](deploy-on-gcp-gke.md)
+        - [在 Google Cloud GKE 上部署 TiDB 集群](deploy-on-gcp-gke.md)
         - [在 Azure AKS 上部署 TiDB 集群](deploy-on-azure-aks.md)
         - [在阿里云 ACK 上部署 TiDB 集群](deploy-on-alibaba-cloud.md)
 

--- a/zh/tidb-operator-overview.md
+++ b/zh/tidb-operator-overview.md
@@ -33,7 +33,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
 
     - 在公有云上部署生产可用的 TiDB 集群并进行后续的运维管理；
 
-        - [Deploy TiDB on AWS EKS](deploy-on-aws-eks.md)
+        - [在 AWS EKS 上部署 TiDB 集群](deploy-on-aws-eks.md)
         - [Deploy TiDB on Google Cloud GKE (beta)](deploy-on-gcp-gke.md)
         - [Deploy TiDB on Azure AKS](deploy-on-azure-aks.md)
         - [Deploy TiDB on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)

--- a/zh/tidb-operator-overview.md
+++ b/zh/tidb-operator-overview.md
@@ -34,7 +34,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
     - 在公有云上部署生产可用的 TiDB 集群并进行后续的运维管理；
 
         - [Deploy TiDB on AWS EKS](deploy-on-aws-eks.md)
-        - [Deploy TiDB on GCP GKE (beta)](deploy-on-gcp-gke.md)
+        - [Deploy TiDB on Google Cloud GKE (beta)](deploy-on-gcp-gke.md)
         - [Deploy TiDB on Azure AKS](deploy-on-azure-aks.md)
         - [Deploy TiDB on Alibaba Cloud ACK](deploy-on-alibaba-cloud.md)
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->


### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
- Update outdated term "GCP" to "Google Cloud" because "[Google Cloud Platform is now called Google Cloud](https://cloud.google.com/blog/topics/developers-practitioners/introducing-new-homepage-google-cloud)"
- Update related descriptions

Note: I searched "GCP" and "Google Cloud Platform" in the whole main branch of this repo.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here--> https://github.com/pingcap/docs-cn/pull/14041
