### PR TITLE
ci: update the git diff command in the prevent deletion workflow to improve accuracy

### DIFF
--- a/.github/workflows/prevent-deletion.yaml
+++ b/.github/workflows/prevent-deletion.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Find changes
         run: |
           git rev-parse '${{ github.event.pull_request.head.sha }}'
-          if git diff --name-only --diff-filter 'D' HEAD '${{ github.event.pull_request.head.sha }}' | grep -E '^media/.*\.(jpg|png|jpeg|gif)$' >/tmp/changed_files; then
+          if git diff --merge-base --name-only --diff-filter 'D' HEAD '${{ github.event.pull_request.head.sha }}' | grep -E '^media/.*\.(jpg|png|jpeg|gif)$' >/tmp/changed_files; then
             cat /tmp/changed_files
             echo '{"name":"Image Deletion Check","head_sha":"${{ github.event.pull_request.head.sha }}","status":"completed","conclusion":"failure"}' > /tmp/body.json
             jq \


### PR DESCRIPTION

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

Fix an issue that the `prevent-deletion.yaml` workflow mistakenly detects image deletions when images are added or removed in the PR's base branch. The root cause of this issue is that the workflow directly compares the latest commit of the PR base branch with the latest commit of the PR.

This PR improves the accuracy of the image deletion detection script by adding the `--merge-base` option to the `git diff` command. This change ensures that git calculates the changes from the shared starting point of the HEAD and the PR head SHA.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
