### PR TITLE
fix a broken link of eksctl

### DIFF
--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -581,7 +581,7 @@ eksctl scale nodegroup --cluster ${clusterName} --name tikv-1c --nodes 2 --nodes
 eksctl scale nodegroup --cluster ${clusterName} --name tikv-1d --nodes 2 --nodes-min 2 --nodes-max 2
 ```
 
-For more information on managing node groups, refer to [`eksctl` documentation](https://eksctl.io/usage/managing-nodegroups/).
+For more information on managing node groups, refer to [`eksctl` documentation](https://eksctl.io/usage/nodegroups/).
 
 ### Scale out TiDB components
 

--- a/zh/deploy-on-aws-eks.md
+++ b/zh/deploy-on-aws-eks.md
@@ -563,7 +563,7 @@ eksctl scale nodegroup --cluster ${clusterName} --name tikv-1c --nodes 2 --nodes
 eksctl scale nodegroup --cluster ${clusterName} --name tikv-1d --nodes 2 --nodes-min 2 --nodes-max 2
 ```
 
-更多节点组管理可参考 [eksctl 文档](https://eksctl.io/usage/managing-nodegroups/)。
+更多节点组管理可参考 [eksctl 文档](https://eksctl.io/usage/nodegroups/)。
 
 ### 扩容 TiDB 组件
 


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Close #2509 #2508 #2507 #2506 

The documentation page previous found at `https://eksctl.io/usage/managing-nodegroups/` has been updated to a new URL `https://eksctl.io/usage/nodegroups/`. This change was made in https://github.com/eksctl-io/eksctl/commit/aec56df90f29feeead74d1eb5cd643cda907229f
### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
