### PR TITLE
zh, en: update some instance type for AWS Graviton

### DIFF
--- a/en/deploy-cluster-on-arm64.md
+++ b/en/deploy-cluster-on-arm64.md
@@ -5,7 +5,7 @@ summary: Learn how to deploy a TiDB cluster on ARM64 machines.
 
 # Deploy a TiDB Cluster on ARM64 Machines
 
-This document describes how to deploy a TiDB cluster on ARM64 machines.
+This document describes how to deploy a TiDB cluster on ARM64 machines (including AWS Graviton instances).
 
 ## Prerequisites
 

--- a/en/deploy-on-aws-eks.md
+++ b/en/deploy-on-aws-eks.md
@@ -32,9 +32,9 @@ To verify whether AWS CLI is configured correctly, run the `aws configure list` 
 ## Recommended instance types and storage
 
 - Instance types: to gain better performance, the following is recommended:
-    - PD nodes: `c5.xlarge`
-    - TiDB nodes: `c5.4xlarge`
-    - TiKV or TiFlash nodes: `m5.4xlarge`
+    - PD nodes: `c7g.xlarge`
+    - TiDB nodes: `c7g.4xlarge`
+    - TiKV or TiFlash nodes: `m7g.4xlarge`
 - Storage: Because AWS supports the [EBS `gp3`](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp3-ebs-volume-type) volume type, it is recommended to use EBS `gp3`. For `gp3` provisioning, the following is recommended:
     - TiKV: 400 MiB/s, 4000 IOPS
     - TiFlash: 625 MiB/s, 6000 IOPS
@@ -106,7 +106,7 @@ nodeGroups:
     desiredCapacity: 1
     privateNetworking: true
     availabilityZones: ["ap-northeast-1a"]
-    instanceType: c5.xlarge
+    instanceType: c7g.xlarge
     labels:
       dedicated: pd
     taints:
@@ -118,7 +118,7 @@ nodeGroups:
     desiredCapacity: 1
     privateNetworking: true
     availabilityZones: ["ap-northeast-1d"]
-    instanceType: c5.xlarge
+    instanceType: c7g.xlarge
     labels:
       dedicated: pd
     taints:
@@ -130,7 +130,7 @@ nodeGroups:
     desiredCapacity: 1
     privateNetworking: true
     availabilityZones: ["ap-northeast-1c"]
-    instanceType: c5.xlarge
+    instanceType: c7g.xlarge
     labels:
       dedicated: pd
     taints:

--- a/zh/deploy-cluster-on-arm64.md
+++ b/zh/deploy-cluster-on-arm64.md
@@ -5,7 +5,7 @@ summary: 本文档介绍如何在 ARM64 机器上部署 TiDB 集群
 
 # 在 ARM64 机器上部署 TiDB 集群
 
-本文档介绍如何在 ARM64 机器上部署 TiDB 集群。
+本文档介绍如何在 ARM64 机器（包括 AWS 的 Graviton 实例）上部署 TiDB 集群。
 
 ## 前置条件
 

--- a/zh/deploy-on-aws-eks.md
+++ b/zh/deploy-on-aws-eks.md
@@ -33,9 +33,9 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-on-aws-eks/']
 ## 推荐机型及存储
 
 - 推荐机型：出于性能考虑，推荐：
-    - PD 所在节点：`c5.xlarge`
-    - TiDB 所在节点：`c5.4xlarge`
-    - TiKV 或 TiFlash 所在节点：`m5.4xlarge`
+    - PD 所在节点：`c7g.xlarge`
+    - TiDB 所在节点：`c7g.4xlarge`
+    - TiKV 或 TiFlash 所在节点：`m7g.4xlarge`
 - 推荐存储：因为 AWS 目前已经支持 [EBS gp3](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/general-purpose.html#gp3-ebs-volume-type) 卷类型，建议使用 EBS gp3 卷类型。对于 gp3 配置，推荐：
     - TiKV：400 MiB/s 与 4000 IOPS
     - TiFlash：625 MiB/s 与 6000 IOPS
@@ -107,7 +107,7 @@ nodeGroups:
     desiredCapacity: 1
     privateNetworking: true
     availabilityZones: ["ap-northeast-1a"]
-    instanceType: c5.xlarge
+    instanceType: c7g.xlarge
     labels:
       dedicated: pd
     taints:
@@ -119,7 +119,7 @@ nodeGroups:
     desiredCapacity: 1
     privateNetworking: true
     availabilityZones: ["ap-northeast-1d"]
-    instanceType: c5.xlarge
+    instanceType: c7g.xlarge
     labels:
       dedicated: pd
     taints:
@@ -131,7 +131,7 @@ nodeGroups:
     desiredCapacity: 1
     privateNetworking: true
     availabilityZones: ["ap-northeast-1c"]
-    instanceType: c5.xlarge
+    instanceType: c7g.xlarge
     labels:
       dedicated: pd
     taints:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

We can use Graviton instances in AWS

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
