### PR TITLE
DM: Revise wrong syntax for command example on get into the pod in eng doc

### DIFF
--- a/en/use-tidb-dm.md
+++ b/en/use-tidb-dm.md
@@ -35,7 +35,7 @@ Attach to the DM-master Pod by executing the following command:
 {{< copyable "shell-regular" >}}
 
 ```shell
-kubectl exec -ti ${dm_cluster_name}-dm-master-0 -n ${namespace} - /bin/sh
+kubectl exec -ti ${dm_cluster_name}-dm-master-0 -n ${namespace} -- /bin/sh
 ```
 
 ### Create data source


### PR DESCRIPTION
[#2586](https://github.com/pingcap/docs-tidb-operator/issues/2586) Example syntax error in eng doc.

### What is changed, added, or deleted? (Required)

Add a hyphen on kubectl command:  from kubectl exec -it - to kubectl exec -it --
because - is not valid syntax, and will throw an error message. Detail inside the #2586 

### Which TiDB Operator version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)
- [x] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?
NA
- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
