### PR TITLE
en, zh: add descriptions for TiDB Binlog deprecation

### DIFF
--- a/en/configure-tidb-binlog-drainer.md
+++ b/en/configure-tidb-binlog-drainer.md
@@ -10,7 +10,7 @@ This document introduces the configuration parameters for a [TiDB Binlog](deploy
 
 > **Warning:**
 >
-> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. For incremental data replication, use [TiCDC](deploy-ticdc.md) instead. For point-in-time recovery (PITR), use PITR.
+> Starting from TiDB v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. For incremental data replication, use [TiCDC](deploy-ticdc.md) instead. For point-in-time recovery (PITR), use PITR.
 
 ## Configuration parameters
 

--- a/en/configure-tidb-binlog-drainer.md
+++ b/en/configure-tidb-binlog-drainer.md
@@ -6,7 +6,11 @@ aliases: ['/docs/tidb-in-kubernetes/dev/configure-tidb-binlog-drainer/']
 
 # TiDB Binlog Drainer Configurations on Kubernetes
 
-This document introduces the configuration parameters for a [TiDB Binlog](deploy-tidb-binlog.md) drainer on Kubernetes. Note that TiDB Binlog is deprecated starting from TiDB v8.3.0.
+This document introduces the configuration parameters for a [TiDB Binlog](deploy-tidb-binlog.md) drainer on Kubernetes.
+
+> **Warning:**
+>
+> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. Use [TiCDC](deploy-ticdc.md) instead for incremental data replication as an alternative.
 
 ## Configuration parameters
 

--- a/en/configure-tidb-binlog-drainer.md
+++ b/en/configure-tidb-binlog-drainer.md
@@ -6,7 +6,7 @@ aliases: ['/docs/tidb-in-kubernetes/dev/configure-tidb-binlog-drainer/']
 
 # TiDB Binlog Drainer Configurations on Kubernetes
 
-This document introduces the configuration parameters for a TiDB Binlog drainer on Kubernetes.
+This document introduces the configuration parameters for a [TiDB Binlog](deploy-tidb-binlog.md) drainer on Kubernetes. Note that TiDB Binlog is deprecated starting from TiDB v8.3.0.
 
 ## Configuration parameters
 

--- a/en/configure-tidb-binlog-drainer.md
+++ b/en/configure-tidb-binlog-drainer.md
@@ -10,7 +10,7 @@ This document introduces the configuration parameters for a [TiDB Binlog](deploy
 
 > **Warning:**
 >
-> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. Use [TiCDC](deploy-ticdc.md) instead for incremental data replication as an alternative.
+> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. For incremental data replication, use [TiCDC](deploy-ticdc.md) instead. For point-in-time recovery (PITR), use PITR.
 
 ## Configuration parameters
 

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -8,6 +8,10 @@ aliases: ['/docs/tidb-in-kubernetes/dev/deploy-tidb-binlog/']
 
 This document describes how to maintain [TiDB Binlog](https://docs.pingcap.com/tidb/stable/tidb-binlog-overview) of a TiDB cluster on Kubernetes.
 
+> **Warning:**
+>
+> Starting from TiDB v8.3.0, TiDB Binlog is deprecated, and is planned to be removed in a future release. Use [TiCDC](deploy-ticdc.md) instead for incremental data replication as an alternative.
+
 ## Prerequisites
 
 - [Deploy TiDB Operator](deploy-tidb-operator.md);

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -10,7 +10,7 @@ This document describes how to maintain [TiDB Binlog](https://docs.pingcap.com/t
 
 > **Warning:**
 >
-> Starting from TiDB v8.3.0, TiDB Binlog is deprecated, and is planned to be removed in a future release. Use [TiCDC](deploy-ticdc.md) instead for incremental data replication as an alternative.
+> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. Use [TiCDC](deploy-ticdc.md) instead for incremental data replication as an alternative.
 
 ## Prerequisites
 

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -10,7 +10,7 @@ This document describes how to maintain [TiDB Binlog](https://docs.pingcap.com/t
 
 > **Warning:**
 >
-> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. For incremental data replication, use [TiCDC](deploy-ticdc.md) instead. For point-in-time recovery (PITR), use PITR.
+> Starting from TiDB v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. For incremental data replication, use [TiCDC](deploy-ticdc.md) instead. For point-in-time recovery (PITR), use PITR.
 
 ## Prerequisites
 

--- a/en/deploy-tidb-binlog.md
+++ b/en/deploy-tidb-binlog.md
@@ -10,7 +10,7 @@ This document describes how to maintain [TiDB Binlog](https://docs.pingcap.com/t
 
 > **Warning:**
 >
-> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. Use [TiCDC](deploy-ticdc.md) instead for incremental data replication as an alternative.
+> Starting from v7.5.0, TiDB Binlog replication is deprecated. Starting from v8.3.0, TiDB Binlog is fully deprecated, with removal planned for a future release. For incremental data replication, use [TiCDC](deploy-ticdc.md) instead. For point-in-time recovery (PITR), use PITR.
 
 ## Prerequisites
 

--- a/zh/configure-tidb-binlog-drainer.md
+++ b/zh/configure-tidb-binlog-drainer.md
@@ -6,7 +6,11 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/configure-tidb-binlog-drainer/']
 
 # Kubernetes 上的 TiDB Binlog Drainer 配置
 
-本文档介绍 Kubernetes 上 [TiDB Binlog](deploy-tidb-binlog.md) drainer 的配置参数。注意 TiDB Binlog 从 TiDB v8.3.0 开始被废弃。
+本文档介绍 Kubernetes 上 [TiDB Binlog](deploy-tidb-binlog.md) drainer 的配置参数。
+
+> **警告：**
+>
+> 从 TiDB v7.5.0 开始，TiDB Binlog 的数据同步功能被废弃。从 v8.3.0 开始，TiDB Binlog 被完全废弃，并计划在未来版本中移除。请使用 [TiCDC](deploy-ticdc.md) 作为增量数据同步的替代方案。
 
 ## 配置参数
 

--- a/zh/configure-tidb-binlog-drainer.md
+++ b/zh/configure-tidb-binlog-drainer.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/configure-tidb-binlog-drainer/']
 
 # Kubernetes 上的 TiDB Binlog Drainer 配置
 
-本文档介绍 Kubernetes 上 TiDB Binlog drainer 的配置参数。
+本文档介绍 Kubernetes 上 [TiDB Binlog](deploy-tidb-binlog.md) drainer 的配置参数。注意 TiDB Binlog 从 TiDB v8.3.0 开始被废弃。
 
 ## 配置参数
 

--- a/zh/configure-tidb-binlog-drainer.md
+++ b/zh/configure-tidb-binlog-drainer.md
@@ -10,7 +10,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/configure-tidb-binlog-drainer/']
 
 > **警告：**
 >
-> 从 TiDB v7.5.0 开始，TiDB Binlog 的数据同步功能被废弃。从 v8.3.0 开始，TiDB Binlog 被完全废弃，并计划在未来版本中移除。请使用 [TiCDC](deploy-ticdc.md) 作为增量数据同步的替代方案。
+> 从 TiDB v7.5.0 开始，TiDB Binlog 的数据同步功能被废弃。从 v8.3.0 开始，TiDB Binlog 被完全废弃，并计划在未来版本中移除。如需进行增量数据同步，请使用 [TiCDC](deploy-ticdc.md)。如需按时间点恢复，请使用 Point-in-Time Recovery (PITR)。
 
 ## 配置参数
 

--- a/zh/deploy-tidb-binlog.md
+++ b/zh/deploy-tidb-binlog.md
@@ -10,7 +10,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-tidb-binlog/']
 
 > **警告：**
 >
-> 从 TiDB v8.3.0 开始，TiDB Binlog 被废弃，并计划在未来版本中移除。请使用 [TiCDC](deploy-ticdc.md) 作为增量数据同步的替代方案。
+> 从 TiDB v7.5.0 开始，TiDB Binlog 的数据同步功能被废弃。从 v8.3.0 开始，TiDB Binlog 被完全废弃，并计划在未来版本中移除。请使用 [TiCDC](deploy-ticdc.md) 作为增量数据同步的替代方案。
 
 ## 部署准备
 

--- a/zh/deploy-tidb-binlog.md
+++ b/zh/deploy-tidb-binlog.md
@@ -8,6 +8,10 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-tidb-binlog/']
 
 本文档介绍如何在 Kubernetes 上部署 TiDB 集群的 [TiDB Binlog](https://docs.pingcap.com/zh/tidb/stable/tidb-binlog-overview)。
 
+> **警告：**
+>
+> 从 TiDB v8.3.0 开始，TiDB Binlog 被废弃，并计划在未来版本中移除。请使用 [TiCDC](deploy-ticdc.md) 作为增量数据同步的替代方案。
+
 ## 部署准备
 
 - [部署 TiDB Operator](deploy-tidb-operator.md)；

--- a/zh/deploy-tidb-binlog.md
+++ b/zh/deploy-tidb-binlog.md
@@ -10,7 +10,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/deploy-tidb-binlog/']
 
 > **警告：**
 >
-> 从 TiDB v7.5.0 开始，TiDB Binlog 的数据同步功能被废弃。从 v8.3.0 开始，TiDB Binlog 被完全废弃，并计划在未来版本中移除。请使用 [TiCDC](deploy-ticdc.md) 作为增量数据同步的替代方案。
+> 从 TiDB v7.5.0 开始，TiDB Binlog 的数据同步功能被废弃。从 v8.3.0 开始，TiDB Binlog 被完全废弃，并计划在未来版本中移除。如需进行增量数据同步，请使用 [TiCDC](deploy-ticdc.md)。如需按时间点恢复，请使用 Point-in-Time Recovery (PITR)。
 
 ## 部署准备
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->


### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
TiDB Binlog will be deprecated starting from TiDB v8.3.0. This PR adds necessary warning and note.

Ref: https://docs.pingcap.com/tidb/v7.5/release-7.5.0#deprecated-features 

![image](https://github.com/user-attachments/assets/7468b54d-f9ec-4b3d-8936-593ebe02b7c7)


### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
