### PR TITLE
zh,en: remove spec.from for Backup and spec.to for Restore

### DIFF
--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -110,12 +110,6 @@ Depending on which method you choose to grant permissions to the remote storage 
         # sendCredToTikv: true
         # options:
         # - --lastbackupts=420134118382108673
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         secretName: s3-secret
@@ -159,12 +153,6 @@ Depending on which method you choose to grant permissions to the remote storage 
         # checksum: true
         # options:
         # - --lastbackupts=420134118382108673
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -206,12 +194,6 @@ Depending on which method you choose to grant permissions to the remote storage 
         # checksum: true
         # options:
         # - --lastbackupts=420134118382108673
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -459,12 +441,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -495,12 +471,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -531,12 +501,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -569,12 +533,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -634,12 +592,6 @@ Depending on which method you choose to grant permissions to the remote storage,
           # timeAgo: ${time}
           # checksum: true
           # sendCredToTikv: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           secretName: s3-secret
@@ -688,12 +640,6 @@ Depending on which method you choose to grant permissions to the remote storage,
           # rateLimit: 0
           # timeAgo: ${time}
           # checksum: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1
@@ -740,12 +686,6 @@ Depending on which method you choose to grant permissions to the remote storage,
           # rateLimit: 0
           # timeAgo: ${time}
           # checksum: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1

--- a/en/backup-to-azblob-using-br.md
+++ b/en/backup-to-azblob-using-br.md
@@ -104,12 +104,6 @@ spec:
     # sendCredToTikv: true
     # options:
     # - --lastbackupts=420134118382108673
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  from:
-    host: ${tidb_host}
-    port: ${tidb_port}
-    user: ${tidb_user}
-    secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret
     container: my-container
@@ -355,12 +349,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -390,12 +378,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -425,12 +407,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -462,12 +438,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -525,12 +495,6 @@ Depending on which method you choose to grant permissions to the remote storage,
           # timeAgo: ${time}
           # checksum: true
           # sendCredToTikv: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         azblob:
           secretName: azblob-secret-ad
           container: my-container
@@ -573,12 +537,6 @@ Depending on which method you choose to grant permissions to the remote storage,
           # rateLimit: 0
           # timeAgo: ${time}
           # checksum: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         azblob:
           secretName: azblob-secret-ad
           container: my-container

--- a/en/backup-to-gcs-using-br.md
+++ b/en/backup-to-gcs-using-br.md
@@ -88,12 +88,6 @@ This document provides an example about how to back up the data of the `demo1` T
       namespace: backup-test
     spec:
       # backupType: full
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb-host}
-        port: ${tidb-port}
-        user: ${tidb-user}
-        secretName: backup-demo1-tidb-secret
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -355,12 +349,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   br:
     cluster: demo1
     clusterNamespace: test1
@@ -390,12 +378,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.*"
   br:
@@ -427,12 +409,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   br:
@@ -464,12 +440,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   - "db1.table2"
@@ -525,12 +495,6 @@ The steps to prepare for a scheduled snapshot backup are the same as that of [Pr
       backupTemplate:
         # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/en/backup-to-pv-using-br.md
+++ b/en/backup-to-pv-using-br.md
@@ -97,12 +97,6 @@ This document provides an example about how to back up the data of the `demo1` T
       namespace: test1
     spec:
       # # backupType: full
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # from:
-      #   host: ${tidb-host}
-      #   port: ${tidb-port}
-      #   user: ${tidb-user}
-      #   secretName: backup-demo1-tidb-secret
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -159,12 +153,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   br:
     cluster: demo1
     clusterNamespace: test1
@@ -196,12 +184,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.*"
   br:
@@ -235,12 +217,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   br:
@@ -274,12 +250,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   - "db1.table2"
@@ -335,12 +305,6 @@ The steps to prepare for a scheduled snapshot backup are the same as that of [Pr
       maxReservedTime: "3h"
       schedule: "*/2 * * * *"
       backupTemplate:
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        # from:
-        #   host: ${tidb_host}
-        #   port: ${tidb_port}
-        #   user: ${tidb_user}
-        #   secretName: backup-demo1-tidb-secret
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/en/backup-to-pv-using-br.md
+++ b/en/backup-to-pv-using-br.md
@@ -96,7 +96,7 @@ This document provides an example about how to back up the data of the `demo1` T
       name: demo1-backup-nfs
       namespace: test1
     spec:
-      # # backupType: full
+      # backupType: full
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -152,7 +152,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   br:
     cluster: demo1
     clusterNamespace: test1
@@ -183,7 +183,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   tableFilter:
   - "db1.*"
   br:
@@ -216,7 +216,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   tableFilter:
   - "db1.table1"
   br:
@@ -249,7 +249,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   tableFilter:
   - "db1.table1"
   - "db1.table2"

--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -1560,11 +1560,6 @@ In this step, you need to perform the following operations:
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}
@@ -1595,11 +1590,6 @@ In this step, you need to perform the following operations:
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -396,8 +396,8 @@ You can generate multiple sets of client-side certificates. At least one set of 
 
     - TidbInitializer
     - PD Dashboard
-    - Backup
-    - Restore
+    - Backup (when using Dumpling)
+    - Restore (when using Lightning)
 
     If you need to [restore data using TiDB Lightning](restore-data-using-tidb-lightning.md), you need to generate a server-side certificate for the TiDB Lightning component.
 
@@ -608,15 +608,9 @@ In this step, you create a TiDB cluster and perform the following operations:
         spec:
           backupType: full
           br:
-          cluster: ${cluster_name}
-          clusterNamespace: ${namespace}
-          sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-backup-client-secret
+            cluster: ${cluster_name}
+            clusterNamespace: ${namespace}
+            sendCredToTikv: true
           s3:
             provider: aws
             region: ${my_region}
@@ -639,12 +633,6 @@ In this step, you create a TiDB cluster and perform the following operations:
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-restore-client-secret
           s3:
             provider: aws
             region: ${my_region}

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -397,7 +397,7 @@ You can generate multiple sets of client-side certificates. At least one set of 
     - TidbInitializer
     - PD Dashboard
     - Backup (when using Dumpling)
-    - Restore (when using Lightning)
+    - Restore (when using TiDB Lightning)
 
     If you need to [restore data using TiDB Lightning](restore-data-using-tidb-lightning.md), you need to generate a server-side certificate for the TiDB Lightning component.
 

--- a/en/restore-from-aws-s3-using-br.md
+++ b/en/restore-from-aws-s3-using-br.md
@@ -97,12 +97,6 @@ Depending on which method you choose to grant permissions to the remote storage 
         # timeAgo: ${time}
         # checksum: true
         # sendCredToTikv: true
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # to:
-      #   host: ${tidb_host}
-      #   port: ${tidb_port}
-      #   user: ${tidb_user}
-      #   secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         secretName: s3-secret
@@ -141,12 +135,6 @@ Depending on which method you choose to grant permissions to the remote storage 
         # rateLimit: 0
         # timeAgo: ${time}
         # checksum: true
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -183,12 +171,6 @@ Depending on which method you choose to grant permissions to the remote storage 
         # rateLimit: 0
         # timeAgo: ${time}
         # checksum: true
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1

--- a/en/restore-from-azblob-using-br.md
+++ b/en/restore-from-azblob-using-br.md
@@ -92,12 +92,6 @@ spec:
     # timeAgo: ${time}
     # checksum: true
     # sendCredToTikv: true
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # to:
-  #   host: ${tidb_host}
-  #   port: ${tidb_port}
-  #   user: ${tidb_user}
-  #   secretName: restore-demo2-tidb-secret
   azblob:
     secretName: azblob-secret
     container: my-container

--- a/en/restore-from-gcs-using-br.md
+++ b/en/restore-from-gcs-using-br.md
@@ -92,12 +92,6 @@ Before restoring backup data on GCS to TiDB using BR, take the following steps t
         # rateLimit: 0
         # checksum: true
         # sendCredToTikv: true
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # to:
-      #   host: ${tidb_host}
-      #   port: ${tidb_port}
-      #   user: ${tidb_user}
-      #   secretName: restore-demo2-tidb-secret
       gcs:
         projectId: ${project_id}
         secretName: gcs-secret

--- a/en/restore-from-pv-using-br.md
+++ b/en/restore-from-pv-using-br.md
@@ -75,12 +75,6 @@ Before restoring backup data on PVs to TiDB using BR, take the following steps t
         # concurrency: 4
         # rateLimit: 0
         # checksum: true
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # to:
-      #   host: ${tidb_host}
-      #   port: ${tidb_port}
-      #   user: ${tidb_user}
-      #   secretName: restore-demo2-tidb-secret
       local:
         prefix: backup-nfs
         volume:

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -111,12 +111,6 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
         # sendCredToTikv: true
         # options:
         # - --lastbackupts=420134118382108673
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         secretName: s3-secret
@@ -158,12 +152,6 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
         # checksum: true
         # options:
         # - --lastbackupts=420134118382108673
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -203,12 +191,6 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
         # checksum: true
         # options:
         # - --lastbackupts=420134118382108673
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -456,12 +438,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -492,12 +468,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -528,12 +498,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -566,12 +530,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   s3:
     provider: aws
     region: us-west-1
@@ -629,12 +587,6 @@ spec:
           # timeAgo: ${time}
           # checksum: true
           # sendCredToTikv: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           secretName: s3-secret
@@ -681,12 +633,6 @@ spec:
           # rateLimit: 0
           # timeAgo: ${time}
           # checksum: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1
@@ -731,12 +677,6 @@ spec:
           # rateLimit: 0
           # timeAgo: ${time}
           # checksum: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1

--- a/zh/backup-to-azblob-using-br.md
+++ b/zh/backup-to-azblob-using-br.md
@@ -105,12 +105,6 @@ spec:
     # sendCredToTikv: true
     # options:
     # - --lastbackupts=420134118382108673
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  from:
-    host: ${tidb_host}
-    port: ${tidb_port}
-    user: ${tidb_user}
-    secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret
     container: my-container
@@ -356,12 +350,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -391,12 +379,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -426,12 +408,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -463,12 +439,6 @@ spec:
     cluster: demo1
     sendCredToTikv: false
     clusterNamespace: test1
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb_host}
-    # port: ${tidb_port}
-    # user: ${tidb_user}
-    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret-ad
     container: my-container
@@ -523,12 +493,6 @@ spec:
           # timeAgo: ${time}
           # checksum: true
           # sendCredToTikv: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
        azblob:
           secretName: azblob-secret-ad
           container: my-container
@@ -569,12 +533,6 @@ spec:
           # rateLimit: 0
           # timeAgo: ${time}
           # checksum: true
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         azblob:
           secretName: azblob-secret-ad
           container: my-container

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -96,12 +96,6 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
       namespace: backup-test
     spec:
       # backupType: full
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb-host}
-        port: ${tidb-port}
-        user: ${tidb-user}
-        secretName: backup-demo1-tidb-secret
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -355,12 +349,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   br:
     cluster: demo1
     clusterNamespace: test1
@@ -390,12 +378,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.*"
   br:
@@ -427,12 +409,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   br:
@@ -464,12 +440,6 @@ metadata:
   namespace: backup-test
 spec:
   # backupType: full
-  # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-    # host: ${tidb-host}
-    # port: ${tidb-port}
-    # user: ${tidb-user}
-    # secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   - "db1.table2"
@@ -523,12 +493,6 @@ spec:
       backupTemplate:
         # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/zh/backup-to-pv-using-br.md
+++ b/zh/backup-to-pv-using-br.md
@@ -92,7 +92,7 @@ Ad-hoc 备份支持快照备份与增量备份。Ad-hoc 备份通过创建一个
       name: demo1-backup-nfs
       namespace: test1
     spec:
-      # # backupType: full
+      # backupType: full
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -148,7 +148,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   br:
     cluster: demo1
     clusterNamespace: test1
@@ -179,7 +179,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   tableFilter:
   - "db1.*"
   br:
@@ -212,7 +212,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   tableFilter:
   - "db1.table1"
   br:
@@ -245,7 +245,7 @@ metadata:
   name: demo1-backup-nfs
   namespace: test1
 spec:
-  # # backupType: full
+  # backupType: full
   tableFilter:
   - "db1.table1"
   - "db1.table2"

--- a/zh/backup-to-pv-using-br.md
+++ b/zh/backup-to-pv-using-br.md
@@ -93,12 +93,6 @@ Ad-hoc 备份支持快照备份与增量备份。Ad-hoc 备份通过创建一个
       namespace: test1
     spec:
       # # backupType: full
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # from:
-      #   host: ${tidb-host}
-      #   port: ${tidb-port}
-      #   user: ${tidb-user}
-      #   secretName: backup-demo1-tidb-secret
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -155,12 +149,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   br:
     cluster: demo1
     clusterNamespace: test1
@@ -192,12 +180,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.*"
   br:
@@ -231,12 +213,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   br:
@@ -270,12 +246,6 @@ metadata:
   namespace: test1
 spec:
   # # backupType: full
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # from:
-  #   host: ${tidb-host}
-  #   port: ${tidb-port}
-  #   user: ${tidb-user}
-  #   secretName: backup-demo1-tidb-secret
   tableFilter:
   - "db1.table1"
   - "db1.table2"
@@ -329,12 +299,6 @@ spec:
       maxReservedTime: "3h"
       schedule: "*/2 * * * *"
       backupTemplate:
-        # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        # from:
-        #   host: ${tidb_host}
-        #   port: ${tidb_port}
-        #   user: ${tidb_user}
-        #   secretName: backup-demo1-tidb-secret
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -1545,11 +1545,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}
@@ -1580,11 +1575,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -392,8 +392,8 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
 
     - TidbInitializer
     - PD Dashboard
-    - Backup
-    - Restore
+    - Backup (使用 Dumpling 时)
+    - Restore (使用 Lightning 时)
 
     如需要[使用 TiDB Lightning 恢复 Kubernetes 上的集群数据](restore-data-using-tidb-lightning.md)，则也可以为其中的 TiDB Lightning 组件生成 Client 端证书。
 
@@ -607,12 +607,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-backup-client-secret
           s3:
             provider: aws
             region: ${my_region}
@@ -635,12 +629,6 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-restore-client-secret
           s3:
             provider: aws
             region: ${my_region}

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -392,8 +392,8 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
 
     - TidbInitializer
     - PD Dashboard
-    - Backup (使用 Dumpling 时)
-    - Restore (使用 Lightning 时)
+    - Backup（使用 Dumpling 时）
+    - Restore（使用 TiDB Lightning 时）
 
     如需要[使用 TiDB Lightning 恢复 Kubernetes 上的集群数据](restore-data-using-tidb-lightning.md)，则也可以为其中的 TiDB Lightning 组件生成 Client 端证书。
 

--- a/zh/restore-from-aws-s3-using-br.md
+++ b/zh/restore-from-aws-s3-using-br.md
@@ -96,12 +96,6 @@ PITR 全称为 Point-in-time recovery，该功能可以让你在新集群上恢�
         # timeAgo: ${time}
         # checksum: true
         # sendCredToTikv: true
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # to:
-      #   host: ${tidb_host}
-      #   port: ${tidb_port}
-      #   user: ${tidb_user}
-      #   secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         secretName: s3-secret
@@ -140,12 +134,6 @@ PITR 全称为 Point-in-time recovery，该功能可以让你在新集群上恢�
         # rateLimit: 0
         # timeAgo: ${time}
         # checksum: true
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -182,12 +170,6 @@ PITR 全称为 Point-in-time recovery，该功能可以让你在新集群上恢�
         # rateLimit: 0
         # timeAgo: ${time}
         # checksum: true
-      # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1

--- a/zh/restore-from-azblob-using-br.md
+++ b/zh/restore-from-azblob-using-br.md
@@ -92,12 +92,6 @@ spec:
     # timeAgo: ${time}
     # checksum: true
     # sendCredToTikv: true
-  # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  # to:
-  #   host: ${tidb_host}
-  #   port: ${tidb_port}
-  #   user: ${tidb_user}
-  #   secretName: restore-demo2-tidb-secret
   azblob:
     secretName: azblob-secret
     container: my-container

--- a/zh/restore-from-gcs-using-br.md
+++ b/zh/restore-from-gcs-using-br.md
@@ -93,12 +93,6 @@ PITR 全称为 Point-in-time recovery，该功能可以让你在新集群上恢�
         # rateLimit: 0
         # checksum: true
         # sendCredToTikv: true
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # to:
-      #   host: ${tidb_host}
-      #   port: ${tidb_port}
-      #   user: ${tidb_user}
-      #   secretName: restore-demo2-tidb-secret
       gcs:
         projectId: ${project_id}
         secretName: gcs-secret

--- a/zh/restore-from-pv-using-br.md
+++ b/zh/restore-from-pv-using-br.md
@@ -75,12 +75,6 @@ summary: 介绍如何将存储在持久卷上的备份数据恢复到 TiDB 集�
         # concurrency: 4
         # rateLimit: 0
         # checksum: true
-      # # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      # to:
-      #   host: ${tidb_host}
-      #   port: ${tidb_port}
-      #   user: ${tidb_user}
-      #   secretName: restore-demo2-tidb-secret
       local:
         prefix: backup-nfs
         volume:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

remove `spec.from` for `Backup` using BR and `spec.to` for `Restore` using BR.

not remove these for Dumpling & Lightning

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)


**for v1.4**, I'll open another PR to comment these out (instead of remove them)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
