### PR TITLE
zh, en: comment out spec.from for Backup and spec.to for Restore in v1.4

### DIFF
--- a/en/backup-to-aws-s3-using-br.md
+++ b/en/backup-to-aws-s3-using-br.md
@@ -110,11 +110,11 @@ Depending on which method you choose to grant permissions to the remote storage 
         # options:
         # - --lastbackupts=420134118382108673
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         secretName: s3-secret
@@ -159,11 +159,11 @@ Depending on which method you choose to grant permissions to the remote storage 
         # options:
         # - --lastbackupts=420134118382108673
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -206,11 +206,11 @@ Depending on which method you choose to grant permissions to the remote storage 
         # options:
         # - --lastbackupts=420134118382108673
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -634,11 +634,11 @@ Depending on which method you choose to grant permissions to the remote storage,
           # checksum: true
           # sendCredToTikv: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           secretName: s3-secret
@@ -688,11 +688,11 @@ Depending on which method you choose to grant permissions to the remote storage,
           # timeAgo: ${time}
           # checksum: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1
@@ -740,11 +740,11 @@ Depending on which method you choose to grant permissions to the remote storage,
           # timeAgo: ${time}
           # checksum: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1

--- a/en/backup-to-azblob-using-br.md
+++ b/en/backup-to-azblob-using-br.md
@@ -105,11 +105,11 @@ spec:
     # options:
     # - --lastbackupts=420134118382108673
   # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  from:
-    host: ${tidb_host}
-    port: ${tidb_port}
-    user: ${tidb_user}
-    secretName: backup-demo1-tidb-secret
+  # from:
+    # host: ${tidb_host}
+    # port: ${tidb_port}
+    # user: ${tidb_user}
+    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret
     container: my-container
@@ -526,11 +526,11 @@ Depending on which method you choose to grant permissions to the remote storage,
           # checksum: true
           # sendCredToTikv: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         azblob:
           secretName: azblob-secret-ad
           container: my-container
@@ -574,11 +574,11 @@ Depending on which method you choose to grant permissions to the remote storage,
           # timeAgo: ${time}
           # checksum: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         azblob:
           secretName: azblob-secret-ad
           container: my-container

--- a/en/backup-to-gcs-using-br.md
+++ b/en/backup-to-gcs-using-br.md
@@ -89,11 +89,11 @@ This document provides an example about how to back up the data of the `demo1` T
     spec:
       # backupType: full
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb-host}
-        port: ${tidb-port}
-        user: ${tidb-user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb-host}
+        # port: ${tidb-port}
+        # user: ${tidb-user}
+        # secretName: backup-demo1-tidb-secret
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -526,11 +526,11 @@ The steps to prepare for a scheduled snapshot backup are the same as that of [Pr
         # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -1470,11 +1470,6 @@ In this step, you need to perform the following operations:
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}
@@ -1505,11 +1500,6 @@ In this step, you need to perform the following operations:
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -395,8 +395,8 @@ You can generate multiple sets of client-side certificates. At least one set of 
 
     - TidbInitializer
     - PD Dashboard
-    - Backup
-    - Restore
+    - Backup (when using Dumpling)
+    - Restore (when using Lightning)
 
     If you need to [restore data using TiDB Lightning](restore-data-using-tidb-lightning.md), you need to generate a server-side certificate for the TiDB Lightning component.
 
@@ -607,15 +607,9 @@ In this step, you create a TiDB cluster and perform the following operations:
         spec:
           backupType: full
           br:
-          cluster: ${cluster_name}
-          clusterNamespace: ${namespace}
-          sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-backup-client-secret
+            cluster: ${cluster_name}
+            clusterNamespace: ${namespace}
+            sendCredToTikv: true
           s3:
             provider: aws
             region: ${my_region}
@@ -638,12 +632,6 @@ In this step, you create a TiDB cluster and perform the following operations:
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-restore-client-secret
           s3:
             provider: aws
             region: ${my_region}

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -396,7 +396,7 @@ You can generate multiple sets of client-side certificates. At least one set of 
     - TidbInitializer
     - PD Dashboard
     - Backup (when using Dumpling)
-    - Restore (when using Lightning)
+    - Restore (when using TiDB Lightning)
 
     If you need to [restore data using TiDB Lightning](restore-data-using-tidb-lightning.md), you need to generate a server-side certificate for the TiDB Lightning component.
 

--- a/en/restore-from-aws-s3-using-br.md
+++ b/en/restore-from-aws-s3-using-br.md
@@ -141,11 +141,11 @@ Depending on which method you choose to grant permissions to the remote storage 
         # timeAgo: ${time}
         # checksum: true
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
+      # to:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -183,11 +183,11 @@ Depending on which method you choose to grant permissions to the remote storage 
         # timeAgo: ${time}
         # checksum: true
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
+      # to:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1

--- a/zh/backup-to-aws-s3-using-br.md
+++ b/zh/backup-to-aws-s3-using-br.md
@@ -111,11 +111,11 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
         # options:
         # - --lastbackupts=420134118382108673
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         secretName: s3-secret
@@ -158,11 +158,11 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
         # options:
         # - --lastbackupts=420134118382108673
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -203,11 +203,11 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
         # options:
         # - --lastbackupts=420134118382108673
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: backup-demo1-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -629,11 +629,11 @@ spec:
           # checksum: true
           # sendCredToTikv: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           secretName: s3-secret
@@ -681,11 +681,11 @@ spec:
           # timeAgo: ${time}
           # checksum: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1
@@ -731,11 +731,11 @@ spec:
           # timeAgo: ${time}
           # checksum: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         s3:
           provider: aws
           region: us-west-1

--- a/zh/backup-to-azblob-using-br.md
+++ b/zh/backup-to-azblob-using-br.md
@@ -106,11 +106,11 @@ spec:
     # options:
     # - --lastbackupts=420134118382108673
   # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-  from:
-    host: ${tidb_host}
-    port: ${tidb_port}
-    user: ${tidb_user}
-    secretName: backup-demo1-tidb-secret
+  # from:
+    # host: ${tidb_host}
+    # port: ${tidb_port}
+    # user: ${tidb_user}
+    # secretName: backup-demo1-tidb-secret
   azblob:
     secretName: azblob-secret
     container: my-container
@@ -524,11 +524,11 @@ spec:
           # checksum: true
           # sendCredToTikv: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
        azblob:
           secretName: azblob-secret-ad
           container: my-container
@@ -570,11 +570,11 @@ spec:
           # timeAgo: ${time}
           # checksum: true
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         azblob:
           secretName: azblob-secret-ad
           container: my-container

--- a/zh/backup-to-gcs-using-br.md
+++ b/zh/backup-to-gcs-using-br.md
@@ -96,11 +96,11 @@ Ad-hoc 备份支持快照备份，也支持[启动](#启动日志备份)和[停�
     spec:
       # backupType: full
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      from:
-        host: ${tidb-host}
-        port: ${tidb-port}
-        user: ${tidb-user}
-        secretName: backup-demo1-tidb-secret
+      # from:
+        # host: ${tidb-host}
+        # port: ${tidb-port}
+        # user: ${tidb-user}
+        # secretName: backup-demo1-tidb-secret
       br:
         cluster: demo1
         clusterNamespace: test1
@@ -523,11 +523,11 @@ spec:
         # Clean outdated backup data based on maxBackups or maxReservedTime. If not configured, the default policy is Retain
         # cleanPolicy: Delete
         # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-        from:
-          host: ${tidb_host}
-          port: ${tidb_port}
-          user: ${tidb_user}
-          secretName: backup-demo1-tidb-secret
+        # from:
+          # host: ${tidb_host}
+          # port: ${tidb_port}
+          # user: ${tidb_user}
+          # secretName: backup-demo1-tidb-secret
         br:
           cluster: demo1
           clusterNamespace: test1

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -1445,11 +1445,6 @@ summary: 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}
@@ -1480,11 +1475,6 @@ summary: 在 Kubernetes 上如何为 TiDB 集群组件间开启 TLS。
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
           s3:
             provider: aws
             region: ${my_region}

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -391,8 +391,8 @@ summary: 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
 
     - TidbInitializer
     - PD Dashboard
-    - Backup
-    - Restore
+    - Backup（使用 Dumpling 时）
+    - Restore（使用 TiDB Lightning 时）
 
     如需要[使用 TiDB Lightning 恢复 Kubernetes 上的集群数据](restore-data-using-tidb-lightning.md)，则也可以为其中的 TiDB Lightning 组件生成 Client 端证书。
 

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -606,12 +606,6 @@ summary: 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          from:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-backup-client-secret
           s3:
             provider: aws
             region: ${my_region}
@@ -634,12 +628,6 @@ summary: 在 Kubernetes 上如何为 TiDB 集群的 MySQL 客户端开启 TLS。
             cluster: ${cluster_name}
             clusterNamespace: ${namespace}
             sendCredToTikv: true
-          to:
-            host: ${host}
-            secretName: ${tidb_secret}
-            port: 4000
-            user: root
-            tlsClientSecretName: ${cluster_name}-restore-client-secret
           s3:
             provider: aws
             region: ${my_region}

--- a/zh/restore-from-aws-s3-using-br.md
+++ b/zh/restore-from-aws-s3-using-br.md
@@ -140,11 +140,11 @@ PITR 全称为 Point-in-time recovery，该功能可以让你在新集群上恢�
         # timeAgo: ${time}
         # checksum: true
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
+      # to:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1
@@ -182,11 +182,11 @@ PITR 全称为 Point-in-time recovery，该功能可以让你在新集群上恢�
         # timeAgo: ${time}
         # checksum: true
       # Only needed for TiDB Operator < v1.1.10 or TiDB < v4.0.8
-      to:
-        host: ${tidb_host}
-        port: ${tidb_port}
-        user: ${tidb_user}
-        secretName: restore-demo2-tidb-secret
+      # to:
+        # host: ${tidb_host}
+        # port: ${tidb_port}
+        # user: ${tidb_user}
+        # secretName: restore-demo2-tidb-secret
       s3:
         provider: aws
         region: us-west-1


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

comment out `spec.from` for Backup using BR and `spec.to` for Restore using BR.

not comment out these for Dumpling & Lightning

ref #2614

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] master (the latest development version)
- [ ] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)
- [ ] v1.2 (TiDB Operator 1.2 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
