### PR TITLE
zh,en: remove deprecated Helm charts

### DIFF
--- a/en/tidb-toolkit.md
+++ b/en/tidb-toolkit.md
@@ -177,10 +177,7 @@ version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9b
 Kubernetes applications are packed as charts in Helm. PingCAP provides the following Helm charts for TiDB on Kubernetes:
 
 * `tidb-operator`: used to deploy TiDB Operator;
-* `tidb-cluster`: used to deploy TiDB clusters;
-* `tidb-backup`: used to back up or restore TiDB clusters;
 * `tidb-lightning`: used to import data into a TiDB cluster;
-* `tidb-drainer`: used to deploy TiDB Drainer;
 
 These charts are hosted in the Helm chart repository `https://charts.pingcap.org/` maintained by PingCAP. You can add this repository to your local server or computer using the following command:
 
@@ -200,9 +197,6 @@ helm search repo pingcap
 
 ```
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-pingcap/tidb-backup     v1.6.1                          A Helm chart for TiDB Backup or Restore
-pingcap/tidb-cluster    v1.6.1                          A Helm chart for TiDB Cluster
-pingcap/tidb-drainer    v1.6.1                          A Helm chart for TiDB Binlog drainer.
 pingcap/tidb-lightning  v1.6.1                          A Helm chart for TiDB Lightning
 pingcap/tidb-operator   v1.6.1          v1.6.1          tidb-operator Helm chart for Kubernetes
 ```
@@ -267,7 +261,6 @@ Use the following command to download the chart file required for cluster instal
 
 ```shell
 wget http://charts.pingcap.org/tidb-operator-v1.6.1.tgz
-wget http://charts.pingcap.org/tidb-drainer-v1.6.1.tgz
 wget http://charts.pingcap.org/tidb-lightning-v1.6.1.tgz
 ```
 

--- a/zh/tidb-toolkit.md
+++ b/zh/tidb-toolkit.md
@@ -177,10 +177,7 @@ version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9b
 Kubernetes 应用在 Helm 中被打包为 chart。PingCAP 针对 Kubernetes 上的 TiDB 部署运维提供了多个 Helm chart：
 
 * `tidb-operator`：用于部署 TiDB Operator；
-* `tidb-cluster`：用于部署 TiDB 集群；
-* `tidb-backup`：用于 TiDB 集群备份恢复；
 * `tidb-lightning`：用于 TiDB 集群导入数据；
-* `tidb-drainer`：用于部署 TiDB Drainer；
 
 这些 chart 都托管在 PingCAP 维护的 helm chart 仓库 `https://charts.pingcap.org/` 中，你可以通过下面的命令添加该仓库：
 
@@ -200,9 +197,6 @@ helm search repo pingcap
 
 ```
 NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-pingcap/tidb-backup     v1.6.1                          A Helm chart for TiDB Backup or Restore
-pingcap/tidb-cluster    v1.6.1                          A Helm chart for TiDB Cluster
-pingcap/tidb-drainer    v1.6.1                          A Helm chart for TiDB Binlog drainer.
 pingcap/tidb-lightning  v1.6.1                          A Helm chart for TiDB Lightning
 pingcap/tidb-operator   v1.6.1          v1.6.1          tidb-operator Helm chart for Kubernetes
 ```
@@ -265,7 +259,6 @@ helm uninstall ${release_name} -n ${namespace}
 
 ```shell
 wget http://charts.pingcap.org/tidb-operator-v1.6.1.tgz
-wget http://charts.pingcap.org/tidb-drainer-v1.6.1.tgz
 wget http://charts.pingcap.org/tidb-lightning-v1.6.1.tgz
 ```
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
