### PR TITLE
Change docs link for cert manager

### DIFF
--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -706,7 +706,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
 
 1. Install `cert-manager`.
 
-    Refer to [cert-manager installation on Kubernetes](https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html) for details.
+    Refer to [cert-manager installation on Kubernetes](https://cert-manager.io/docs/installation/) for details.
 
 2. Create an Issuer to issue certificates to the TiDB cluster.
 

--- a/en/enable-tls-for-dm.md
+++ b/en/enable-tls-for-dm.md
@@ -274,7 +274,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
 
 1. Install `cert-manager`.
 
-    Refer to [cert-manager installation on Kubernetes](https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html) for details.
+    Refer to [cert-manager installation on Kubernetes](https://cert-manager.io/docs/installation/) for details.
 
 2. Create an Issuer to issue certificates to the DM cluster.
 

--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -210,7 +210,7 @@ You can generate multiple sets of client-side certificates. At least one set of 
 
 1. Install `cert-manager`.
 
-    Refer to [cert-manager installation on Kubernetes](https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html).
+    Refer to [cert-manager installation on Kubernetes](https://cert-manager.io/docs/installation/).
 
 2. Create an Issuer to issue certificates for the TiDB cluster.
 

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -705,7 +705,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
 
 1. 安装 cert-manager。
 
-    请参考官网安装：[cert-manager installation on Kubernetes](https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html)。
+    请参考官网安装：[cert-manager installation on Kubernetes](https://cert-manager.io/docs/installation/)。
 
 2. 创建一个 Issuer 用于给 TiDB 集群颁发证书。
 

--- a/zh/enable-tls-for-dm.md
+++ b/zh/enable-tls-for-dm.md
@@ -265,7 +265,7 @@ TiDB Operator 从 v1.2 开始已经支持为 Kubernetes 上 DM 集群组件间�
 
 1. 安装 cert-manager。
 
-   请参考官网安装：[cert-manager installation on Kubernetes](https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html)。
+   请参考官网安装：[cert-manager installation on Kubernetes](https://cert-manager.io/docs/installation/)。
 
 2. 创建一个 Issuer 用于给 DM 集群颁发证书。
 

--- a/zh/enable-tls-for-mysql-client.md
+++ b/zh/enable-tls-for-mysql-client.md
@@ -206,7 +206,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-for-mysql-client/']
 
 1. 安装 cert-manager。
 
-    请参考官网安装：[cert-manager installation on Kubernetes](https://docs.cert-manager.io/en/release-0.11/getting-started/install/kubernetes.html)。
+    请参考官网安装：[cert-manager installation on Kubernetes](https://cert-manager.io/docs/installation/)。
 
 2. 创建一个 Issuer 用于给 TiDB 集群颁发证书。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

The docs link points to the v0.11 docs which now link to the release notes, which isn't what we want.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
