### PR TITLE
Fix kubectl exec syntax

### DIFF
--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -1631,7 +1631,7 @@ In this step, you need to perform the following operations:
     {{< copyable "shell-regular" >}}
 
     ``` shell
-    kubectl exec -it ${cluster_name}-pd-0 -n ${namespace} sh
+    kubectl exec -it ${cluster_name}-pd-0 -n ${namespace} -- sh
     ```
 
     Use `pd-ctl`:
@@ -1650,7 +1650,7 @@ In this step, you need to perform the following operations:
     {{< copyable "shell-regular" >}}
 
     ``` shell
-    kubectl exec -it ${cluster_name}-tikv-0 -n ${namespace} sh
+    kubectl exec -it ${cluster_name}-tikv-0 -n ${namespace} -- sh
     ```
 
     Use `tikv-ctl`:

--- a/en/enable-tls-for-dm.md
+++ b/en/enable-tls-for-dm.md
@@ -548,7 +548,7 @@ Get into the DM-master Pod:
 {{< copyable "shell-regular" >}}
 
 ``` shell
-kubectl exec -it ${cluster_name}-dm-master-0 -n ${namespace} sh
+kubectl exec -it ${cluster_name}-dm-master-0 -n ${namespace} -- sh
 ```
 
 Use `dmctl`:

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -1617,7 +1617,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
     {{< copyable "shell-regular" >}}
 
     ``` shell
-    kubectl exec -it ${cluster_name}-pd-0 -n ${namespace} sh
+    kubectl exec -it ${cluster_name}-pd-0 -n ${namespace} -- sh
     ```
 
     使用 `pd-ctl`：
@@ -1636,7 +1636,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
     {{< copyable "shell-regular" >}}
 
     ``` shell
-    kubectl exec -it ${cluster_name}-tikv-0 -n ${namespace} sh
+    kubectl exec -it ${cluster_name}-tikv-0 -n ${namespace} -- sh
     ```
 
     使用 `tikv-ctl`：

--- a/zh/enable-tls-for-dm.md
+++ b/zh/enable-tls-for-dm.md
@@ -521,7 +521,7 @@ spec:
 {{< copyable "shell-regular" >}}
 
 ``` shell
-kubectl exec -it ${cluster_name}-dm-master-0 -n ${namespace} sh
+kubectl exec -it ${cluster_name}-dm-master-0 -n ${namespace} -- sh
 ```
 
 使用 `dmctl`：


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

```
dvaneeden@dve-carbon:~$ kubectl version
Client Version: v1.33.1
Kustomize Version: v5.6.0
Server Version: v1.33.1
dvaneeden@dve-carbon:~$ kubectl exec -it basic-pd-0 -n tidb-cluster sh
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
See 'kubectl exec -h' for help and examples
dvaneeden@dve-carbon:~$ kubectl exec -it basic-pd-0 -n tidb-cluster -- sh
sh-5.1# /pd-ctl --version
Release Version: v8.5.2
Edition: Community
Git Commit Hash: 4cd009c4db3c15215341a96521dd53e53c55e5bd
Git Branch: HEAD
UTC Build Time:  2025-05-14 02:44:50
sh-5.1# 
exit
```

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
