### PR TITLE
operator: changed the default PORT value from 10261 to 10262

### DIFF
--- a/en/access-dashboard.md
+++ b/en/access-dashboard.md
@@ -49,7 +49,7 @@ In this deployment method, the `service`, `port`, and `HTTP` paths of TiDB Dashb
 
 ```shell
 export SERVICE_NAME=${cluster_name}-discovery && \
-export PORT=10261 && \
+export PORT=10262 && \
 export HTTP_PATH=/dashboard
 ```
 

--- a/zh/access-dashboard.md
+++ b/zh/access-dashboard.md
@@ -47,7 +47,7 @@ spec:
 
 ```shell
 export SERVICE_NAME=${cluster_name}-discovery && \
-export PORT=10261 && \
+export PORT=10262 && \
 export HTTP_PATH=/dashboard
 ```
 


### PR DESCRIPTION
Changed the default PORT value from 10261 to 10262 in both English and Chinese access-dashboard documentation to reflect the correct configuration.

<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [x] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
