### PR TITLE
enable-tls-between-components: add TiProxy for cert-manager

### DIFF
--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -1169,7 +1169,7 @@ This section describes how to issue certificates using two methods: `cfssl` and 
 
     - TiProxy
 
-        ``` yaml
+        ```yaml
         apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -1160,7 +1160,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
 
     - TiProxy 组件的 Server 端证书。
 
-        ``` yaml
+        ```yaml
         apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:
@@ -1216,9 +1216,9 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
             - `127.0.0.1`
             - `::1`
         - `issuerRef` 请填写上面创建的 Issuer；
-        - 其他属性请参阅 cert-manager API（https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec）。
+        - 其他属性请参考 [cert-manager API](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec)。
 
-      创建该对象后，`cert-manager` 会生成名为 `${cluster_name}-tiproxy-cluster-secret` 的 Secret，供 TiProxy 组件使用。
+      创建这个对象以后，`cert-manager` 会生成一个名字为 `${cluster_name}-tiproxy-cluster-secret` 的 Secret 对象供 TiDB 集群的 TiProxy 组件使用。
 
     - TiFlash 组件的 Server 端证书。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added, or deleted? (Required)

For cert-manager the description for the TiProxy certificate/secret was missing.
<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
