### PR TITLE
security: add docs for reloading certs in `TLS between TiDB components` doc

### DIFF
--- a/en/enable-tls-between-components.md
+++ b/en/enable-tls-between-components.md
@@ -1750,7 +1750,7 @@ This section describes how to enable TLS encrypted communication for an existing
 
 ## Reload certificates
 
-- If you generate the certificate and key files manually using `cfssl`, you must update the corresponding `Secret` manually.
-- If you generate the certificate and key files using `cert-manager`, the `Secret` is updated automatically whenever a new certificate is issued.
+- If you generate the certificate and key files manually using `cfssl`, you must update the corresponding Secret manually.
+- If you generate the certificate and key files using `cert-manager`, the Secret is updated automatically whenever a new certificate is issued.
 
-TiDB, PD, TiKV, TiFlash, TiCDC, TiProxy, and client components automatically reload the current certificates and key files on every new connection. This means the TiDB cluster does not need to be restarted. Once the `Secret` is updated, the certs and keys are reloaded automatically.
+TiDB, PD, TiKV, TiFlash, TiCDC, TiProxy, and client components automatically reload the current certificates and key files for every new connection. This means the TiDB cluster does not require a restart. Once the Secret is updated, the certificates and keys are reloaded automatically.

--- a/zh/enable-tls-between-components.md
+++ b/zh/enable-tls-between-components.md
@@ -1736,7 +1736,7 @@ aliases: ['/docs-cn/tidb-in-kubernetes/dev/enable-tls-between-components/']
 
 ## 重新加载证书
 
-- 如果你使用 `cfssl` 手动生成证书和密钥文件，则必须手动更新相应的 `Secret`。
-- 如果你使用 `cert-manager` 生成证书和密钥文件，那么每次颁发新证书时，`Secret` 会自动更新。
+- 如果你使用 `cfssl` 手动生成证书和密钥文件，则必须手动更新相应的 Secret。
+- 如果你使用 `cert-manager` 生成证书和密钥文件，那么每次颁发新证书时，Secret 会自动更新。
 
-TiDB、PD、TiKV、TiFlash、TiCDC、TiProxy 以及客户端组件会在每次建立新连接时自动重新加载当前的证书和密钥文件，因此无需重启 TiDB 集群。一旦 `Secret` 更新，证书和密钥会自动生效。
+TiDB、PD、TiKV、TiFlash、TiCDC、TiProxy 以及客户端组件会在每次建立新连接时自动重新加载当前的证书和密钥文件，因此无需重启 TiDB 集群。一旦 Secret 更新，证书和密钥会自动生效。


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Add a description that TiDB components can automatically reload the certificates / keys. The users don't need to restart the whole cluster to reload certs/keys.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s):