### PR TITLE
enable-tls-for-mysql-client: Add info about TLS without client certs

### DIFF
--- a/en/enable-tls-for-mysql-client.md
+++ b/en/enable-tls-for-mysql-client.md
@@ -43,8 +43,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 
 1. Download `cfssl` and initialize the certificate issuer:
 
-    {{< copyable "shell-regular" >}}
-
     ```shell
     mkdir -p ~/bin
     curl -s -L -o ~/bin/cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
@@ -114,8 +112,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 
 4. Generate CA by the configured option:
 
-    {{< copyable "shell-regular" >}}
-
     ```shell
     cfssl gencert -initca ca-csr.json | cfssljson -bare ca -
     ```
@@ -123,8 +119,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 5. Generate the server-side certificate:
 
     First, create the default `server.json` file:
-
-    {{< copyable "shell-regular" >}}
 
     ``` shell
     cfssl print-defaults csr > server.json
@@ -155,8 +149,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 
     Finally, generate the server-side certificate:
 
-    {{< copyable "shell-regular" >}}
-
     ``` shell
     cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=server server.json | cfssljson -bare server
     ```
@@ -164,8 +156,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 6. Generate the client-side certificate:
 
     First, create the default `client.json` file:
-
-    {{< copyable "shell-regular" >}}
 
     ``` shell
     cfssl print-defaults csr > client.json
@@ -182,8 +172,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 
     Finally, generate the client-side certificate:
 
-    {{< copyable "shell-regular" >}}
-
     ``` shell
     cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client client.json | cfssljson -bare client
     ```
@@ -191,8 +179,6 @@ This section describes how to issue certificates for the TiDB cluster using two 
 7. Create the Kubernetes Secret object.
 
     If you have already generated two sets of certificates as described in the above steps, create the Secret object for the TiDB cluster by the following command:
-
-    {{< copyable "shell-regular" >}}
 
     ```shell
     kubectl create secret generic ${cluster_name}-tidb-server-secret --namespace=${namespace} --from-file=tls.crt=server.pem --from-file=tls.key=server-key.pem --from-file=ca.crt=ca.pem
@@ -217,8 +203,6 @@ You can generate multiple sets of client-side certificates. At least one set of 
     To configure `cert-manager`, create the Issuer resources.
 
     First, create a directory which saves the files that `cert-manager` needs to create certificates:
-
-    {{< copyable "shell-regular" >}}
 
     ``` shell
     mkdir -p cert-manager
@@ -268,8 +252,6 @@ You can generate multiple sets of client-side certificates. At least one set of 
     - An Issuer, used to issue TLS certificates for the TiDB server
 
     Finally, execute the following command to create an Issuer:
-
-    {{< copyable "shell-regular" >}}
 
     ``` shell
     kubectl apply -f tidb-server-issuer.yaml
@@ -338,8 +320,6 @@ You can generate multiple sets of client-side certificates. At least one set of 
 
     Execute the following command to generate the certificate:
 
-    {{< copyable "shell-regular" >}}
-
     ``` shell
     kubectl apply -f tidb-server-cert.yaml
     ```
@@ -381,8 +361,6 @@ You can generate multiple sets of client-side certificates. At least one set of 
     - For other attributes, refer to [cert-manager API](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec)
 
     Execute the following command to generate the certificate:
-
-    {{< copyable "shell-regular" >}}
 
     ``` shell
     kubectl apply -f tidb-client-cert.yaml
@@ -521,8 +499,6 @@ You can generate multiple sets of client-side certificates. At least one set of 
 
     2. Create the certificate by running the following command:
 
-        {{< copyable "shell-regular" >}}
-
         ``` shell
         kubectl apply -f tidb-components-client-cert.yaml
         ```
@@ -645,15 +621,11 @@ In this step, you create a TiDB cluster and perform the following operations:
 
 2. Deploy the TiDB cluster:
 
-    {{< copyable "shell-regular" >}}
-
     ``` shell
     kubectl apply -f tidb-cluster.yaml
     ```
 
 3. Back up the cluster:
-
-    {{< copyable "shell-regular" >}}
 
     ``` shell
     kubectl apply -f backup.yaml
@@ -661,30 +633,34 @@ In this step, you create a TiDB cluster and perform the following operations:
 
 4. Restore the cluster:
 
-    {{< copyable "shell-regular" >}}
-
     ``` shell
     kubectl apply -f restore.yaml
     ```
 
-## Configure the MySQL client to use an encrypted connection
+## Configure the MySQL client to use a TLS connection
 
 To connect the MySQL client with the TiDB cluster, use the client-side certificate created above and take the following methods. For details, refer to [Configure the MySQL client to use encrypted connections](https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers#configure-the-mysql-client-to-use-encrypted-connections).
 
 Execute the following command to acquire the client-side certificate and connect to the TiDB server:
 
-{{< copyable "shell-regular" >}}
-
 ``` shell
-kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret  -ojsonpath='{.data.tls\.crt}' | base64 --decode > client-tls.crt
-kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret  -ojsonpath='{.data.tls\.key}' | base64 --decode > client-tls.key
-kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret  -ojsonpath='{.data.ca\.crt}'  | base64 --decode > client-ca.crt
+kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret -ojsonpath='{.data.tls\.crt}' | base64 --decode > client-tls.crt
+kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret -ojsonpath='{.data.tls\.key}' | base64 --decode > client-tls.key
+kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret -ojsonpath='{.data.ca\.crt}'  | base64 --decode > client-ca.crt
 ```
-
-{{< copyable "shell-regular" >}}
 
 ``` shell
 mysql --comments -uroot -p -P 4000 -h ${tidb_host} --ssl-cert=client-tls.crt --ssl-key=client-tls.key --ssl-ca=client-ca.crt
 ```
 
 Finally, to verify whether TLS is successfully enabled, refer to [checking the current connection](https://docs.pingcap.com/tidb/stable/enable-tls-between-clients-and-servers#check-whether-the-current-connection-uses-encryption).
+
+When not relying on client certificates the following is sufficient:
+
+``` shell
+kubectl get secret -n ${namespace} ${cluster_name}-tidb-client-secret  -ojsonpath='{.data.ca\.crt}'  | base64 --decode > client-ca.crt
+```
+
+``` shell
+mysql --comments -uroot -p -P 4000 -h ${tidb_host} --ssl-ca=client-ca.crt
+```


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
