### PR TITLE
ci: skip website deployment for release-1.x branch

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release-*
+      - '!release-1.x'
 
 jobs:
   trigger:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added, or deleted? (Required)

The `release-1.x` branch is used for v1.x development and should not trigger website publication. This PR adds a branch filter to prevent unnecessary deployments.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] master (the latest development version for v1.x)
- [x] feature/v2 (the latest development version for v2.x)
- [x] v2.0 (TiDB Operator 2.0 versions)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): https://github.com/pingcap/docs-tidb-operator/pull/2978
