### PR TITLE
replace a link for TiDB Operator 1.0 GA

### DIFF
--- a/zh/benchmark-sysbench.md
+++ b/zh/benchmark-sysbench.md
@@ -6,7 +6,7 @@ summary: TiDB Operator GA 发布后，我们在 GKE 平台进行了全面的性�
 
 # TiDB on Kubernetes Sysbench 性能测试
 
-随着 [TiDB Operator GA 发布](https://cn.pingcap.com/blog/tidb-operator-1.0-ga)，越来越多用户开始使用 TiDB Operator 在 Kubernetes 中部署管理 TiDB 集群。在本次测试中，我们选择 GKE 平台做了一次深入、全方位的测试，方便大家了解 TiDB 在 Kubernetes 中性能影响因素。
+随着 [TiDB Operator GA 发布](https://tidb.net/blog/0124c886)，越来越多用户开始使用 TiDB Operator 在 Kubernetes 中部署管理 TiDB 集群。在本次测试中，我们选择 GKE 平台做了一次深入、全方位的测试，方便大家了解 TiDB 在 Kubernetes 中性能影响因素。
 
 ## 目的
 


### PR DESCRIPTION

### What is changed, added, or deleted? (Required)

This PR updates [cn.pingcap.com](https://cn.pingcap.com/) links to [pingkai.cn](https://pingkai.cn/) links.

Reason: [pingkai.cn](https://pingkai.cn/) will gradually replace [cn.pingcap.com](https://cn.pingcap.com/).

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] master (the latest development version for v1.x)
- [ ] feature/v2 (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [ ] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
