### PR TITLE
fix: update Prometheus source label

### DIFF
--- a/en/monitor-a-tidb-cluster.md
+++ b/en/monitor-a-tidb-cluster.md
@@ -66,7 +66,7 @@ To collect monitoring data using Prometheus, perform the following steps:
               regex: "true"
             - sourceLabels:
                 - __meta_kubernetes_pod_name
-                - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+                - __meta_kubernetes_pod_label_pingcap_com_group
                 - __meta_kubernetes_pod_label_app_kubernetes_io_component
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_pod_annotation_prometheus_io_port

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -66,7 +66,7 @@ TiDB 集群的监控包括两部分：[监控数据采集](#监控数据采集)�
               regex: "true"
             - sourceLabels:
                 - __meta_kubernetes_pod_name
-                - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+                - __meta_kubernetes_pod_label_pingcap_com_group
                 - __meta_kubernetes_pod_label_app_kubernetes_io_component
                 - __meta_kubernetes_namespace
                 - __meta_kubernetes_pod_annotation_prometheus_io_port


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->
Update Prometheus source label from `app_kubernetes_io_instance` to `pingcap_com_group`

Since according to [this](https://github.com/pingcap/tidb-operator/blob/7b359cbe9c757b1d795f1f9991bd745d8514444d/pkg/apiutil/core/v1alpha1/group.go#L225), it uses the group name as the service name prefix.

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [x] main (the latest development version for v2.x)
- [x] v2.0 (TiDB Operator 2.0 versions)
- [ ] release-1.x (the latest development version for v1.x)
- [ ] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
