### PR TITLE
en, zh: add required PVC cleanup step after TiKV scale-in

### DIFF
--- a/en/scale-a-tidb-cluster.md
+++ b/en/scale-a-tidb-cluster.md
@@ -57,6 +57,17 @@ To scale PD, TiKV, TiDB, or TiProxy horizontally, use kubectl to modify `spec.pd
 
     For the TiKV component, it might take 3-5 minutes to scale in or out because the process involves data migration.
 
+4. Delete the PVC for the scaled-in TiKV node.
+
+    After TiKV scales in, TiDB Operator does not automatically delete the corresponding PVC. To avoid issues during future scale-out operations, you must manually delete the PVC.
+
+    To find and delete the PVC for the scaled-in Pod, run the following commands:
+
+    ```shell
+    kubectl get pvc -n ${namespace}
+    kubectl delete pvc -n ${namespace} ${pvc_name}
+    ```
+
 ### Horizontally scale TiFlash
 
 This section describes how to horizontally scale out or scale in TiFlash if you have deployed TiFlash in the cluster.

--- a/zh/scale-a-tidb-cluster.md
+++ b/zh/scale-a-tidb-cluster.md
@@ -56,6 +56,17 @@ TiDB 水平扩缩容操作指的是通过增加或减少 Pod 的数量，来达�
 
     TiKV 组件由于涉及到数据搬迁，通常需要 3 到 5 分钟来进行扩容或者缩容。
 
+4. 删除缩容 TiKV 节点对应的 PVC。
+
+    TiKV 缩容完成后，TiDB Operator 不会自动删除对应的 PVC。为避免后续扩容失败，必须手动删除该 PVC。
+
+    执行以下命令查找并删除缩容 Pod 对应的 PVC：
+
+    ```shell
+    kubectl get pvc -n ${namespace}
+    kubectl delete pvc -n ${namespace} ${pvc_name}
+    ```
+
 ### 水平扩缩容 TiFlash
 
 如果你部署了 TiFlash，想对 TiFlash 进行水平扩缩容，请参照本小节的步骤进行操作。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

add required PVC cleanup step after TiKV scale-in

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] main (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [x] release-1.x (the latest development version for v1.x)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [x] v1.5 (TiDB Operator 1.5 versions)
- [x] v1.4 (TiDB Operator 1.4 versions)
- [x] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): <!--Give links here-->
