### PR TITLE
Add GitHub Actions workflow to trigger docs-staging nextgen update

### DIFF
--- a/.github/workflows/dispatch-nextgen.yml
+++ b/.github/workflows/dispatch-nextgen.yml
@@ -1,0 +1,31 @@
+name: Trigger docs-staging nextgen update
+
+on:
+  push:
+    paths-ignore:
+      - ".github/**"
+    branches:
+      - feature/preview-top-navigation
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: trigger docs-staging update-nextgen workflow
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DOCS_STAGING }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'pingcap',
+              repo: 'docs-staging',
+              workflow_id: 'update-nextgen.yml',
+              ref: 'nextgen',
+              inputs: {
+                repo: 'pingcap/docs-tidb-operator',
+                branch: 'feature/preview-top-navigation'
+              }
+            })


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB Operator documentation. See [CONTRIBUTING](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-tidb-operator) that's required for repo owners to accept my contribution.

### What is changed, added, or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB Operator version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB Operator version(s) that your changes apply to.-->

- [ ] main (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [ ] release-1.x (the latest development version for v1.x)
- [ ] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from: <!--Give links here-->
- Other reference link(s): https://github.com/pingcap/docs/pull/22342
