### PR TITLE
docs: fix broken links in v2-vs-v1 and monitor-a-tidb-cluster

### DIFF
--- a/en/monitor-a-tidb-cluster.md
+++ b/en/monitor-a-tidb-cluster.md
@@ -250,7 +250,7 @@ To configure the monitoring dashboard, perform the following steps:
     - For Prometheus, set the URL to `http://prometheus-operated.monitoring.svc:9090`.
     - For VictoriaMetrics, set the URL to `http://vmsingle-demo.monitoring.svc:8429`.
 
-5. Download Grafana dashboards for TiDB components using the [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/{{{ .tidb_operator_release_branch }}}/hack/get-grafana-dashboards.sh>) script and import them manually into Grafana.
+5. Download Grafana dashboards for TiDB components using the [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/main/hack/get-grafana-dashboards.sh>) script and import them manually into Grafana.
 
 ## Configure alerts
 

--- a/en/v2-vs-v1.md
+++ b/en/v2-vs-v1.md
@@ -70,7 +70,7 @@ TiDB Operator v2 supports configuring the evenly spread policy to distribute com
 
 #### `Binlog` (Pump + Drainer)
 
-This component is deprecated. For more information, see [TiDB Binlog Overview](https://docs.pingcap.com/tidb/v8.3/tidb-binlog-overview/).
+This component is deprecated. For more information, see [TiDB Binlog Overview](https://docs.pingcap.com/tidb/v8.1/tidb-binlog-overview/).
 
 #### Dumpling + TiDB Lightning
 

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -250,7 +250,7 @@ TiDB 集群的监控包括两部分：[监控数据采集](#监控数据采集)�
     - 如果使用 Prometheus 采集监控指标，设置 URL 为 `http://prometheus-operated.monitoring.svc:9090`。
     - 如果使用 VictoriaMetrics 采集监控指标，设置 URL 为 `http://vmsingle-demo.monitoring.svc:8429`。
 
-5. 可以使用 [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/{{{ .tidb_operator_release_branch }}}/hack/get-grafana-dashboards.sh>) 脚本下载各组件的监控面板，然后手动导入到 Grafana 中。
+5. 可以使用 [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/main/hack/get-grafana-dashboards.sh>) 脚本下载各组件的监控面板，然后手动导入到 Grafana 中。
 
 ## 告警配置
 

--- a/zh/v2-vs-v1.md
+++ b/zh/v2-vs-v1.md
@@ -70,7 +70,7 @@ TiDB Operator v2 支持配置 Evenly Spread Policy 来将组件按需均匀分�
 
 #### `Binlog` (Pump + Drainer)
 
-`Binlog` 组件已经废弃，详见 [TiDB Binlog 简介](https://docs.pingcap.com/zh/tidb/v8.3/tidb-binlog-overview/)。
+`Binlog` 组件已经废弃，详见 [TiDB Binlog 简介](https://docs.pingcap.com/zh/tidb/v8.1/tidb-binlog-overview/)。
 
 #### Dumpling + TiDB Lightning
 


### PR DESCRIPTION
## Broken links

Two classes of broken links reported by the link checker (issue #3126):

**1. TiDB Binlog docs (404)**
`v2-vs-v1.md` (en + zh) links to `docs.pingcap.com/tidb/v8.3/tidb-binlog-overview/` which returns 404 — the binlog docs were removed after v8.1. Updated to point to `v8.1` where the page exists.

**2. Unrendered Hugo template in URL**
`monitor-a-tidb-cluster.md` (en + zh) contains `{{{ .tidb_operator_release_branch }}}` in the raw GitHub URL, which never renders and produces a 404. Replaced with the actual `main` branch.

4 files changed, 4 lines — one link fix per file.

Closes #3126