### PR TITLE
Fix Grafana dashboard script links

### DIFF
--- a/en/monitor-a-tidb-cluster.md
+++ b/en/monitor-a-tidb-cluster.md
@@ -250,7 +250,7 @@ To configure the monitoring dashboard, perform the following steps:
     - For Prometheus, set the URL to `http://prometheus-operated.monitoring.svc:9090`.
     - For VictoriaMetrics, set the URL to `http://vmsingle-demo.monitoring.svc:8429`.
 
-5. Download Grafana dashboards for TiDB components using the [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/{{{ .tidb_operator_release_branch }}}/hack/get-grafana-dashboards.sh>) script and import them manually into Grafana.
+5. Download Grafana dashboards for TiDB components using the [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/main/hack/get-grafana-dashboards.sh>) script and import them manually into Grafana.
 
 ## Configure alerts
 

--- a/zh/monitor-a-tidb-cluster.md
+++ b/zh/monitor-a-tidb-cluster.md
@@ -250,7 +250,7 @@ TiDB 集群的监控包括两部分：[监控数据采集](#监控数据采集)�
     - 如果使用 Prometheus 采集监控指标，设置 URL 为 `http://prometheus-operated.monitoring.svc:9090`。
     - 如果使用 VictoriaMetrics 采集监控指标，设置 URL 为 `http://vmsingle-demo.monitoring.svc:8429`。
 
-5. 可以使用 [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/{{{ .tidb_operator_release_branch }}}/hack/get-grafana-dashboards.sh>) 脚本下载各组件的监控面板，然后手动导入到 Grafana 中。
+5. 可以使用 [`get-grafana-dashboards.sh`](<https://raw.githubusercontent.com/pingcap/tidb-operator/main/hack/get-grafana-dashboards.sh>) 脚本下载各组件的监控面板，然后手动导入到 Grafana 中。
 
 ## 告警配置
 


### PR DESCRIPTION
Fixes #3157.

This replaces the templated raw GitHub branch URL used for `get-grafana-dashboards.sh` in both English and Chinese monitor docs with the current `main` branch URL, so the link checker can resolve it.

Validation:
- Verified `https://raw.githubusercontent.com/pingcap/tidb-operator/main/hack/get-grafana-dashboards.sh` returns HTTP 200.