### PR TITLE
ci: ignore templated release branch links

### DIFF
--- a/.github/workflows/link-fail-fast.yaml
+++ b/.github/workflows/link-fail-fast.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Download Exclude Path
         run: |
           curl https://raw.githubusercontent.com/pingcap/docs/master/.lycheeignore -O
+          echo 'https://.*github.*/%7B%7B%7B%20.tidb_operator_release_branch%20%7D%7D%7D' >> .lycheeignore
 
       - name: Link Checker
         if: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Download Exclude Path
         run: |
           curl https://raw.githubusercontent.com/pingcap/docs/master/.lycheeignore --output .lycheeignore
+          echo 'https://.*github.*/%7B%7B%7B%20.tidb_operator_release_branch%20%7D%7D%7D' >> .lycheeignore
 
       - name: Check Links
         uses: lycheeverse/lychee-action@v1.6.1


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Fixes #3157.

The link workflows download the shared PingCAP `.lycheeignore`, which already excludes encoded `tidb_operator_version` template URLs. This PR appends the matching encoded `tidb_operator_release_branch` template URL pattern before running lychee in both the scheduled full link check and the pull-request fail-fast link check.

This keeps the documentation source using the release-branch variable while preventing lychee from treating the unrendered template placeholder as a real raw GitHub branch.

Source proof:

- Current `variables.json` sets `tidb_operator_release_branch` to `release-2.0`.
- The rendered target `https://raw.githubusercontent.com/pingcap/tidb-operator/refs/heads/release-2.0/hack/get-grafana-dashboards.sh` returns HTTP 200.
- The unrendered encoded placeholder URL reported by #3157 returns HTTP 404 before the new ignore pattern.
- Duplicate PR search before work and before PR creation returned no open PRs for #3157 / `get-grafana-dashboards.sh` / `tidb_operator_release_branch`.

### Which TiDB Operator version(s) do your changes apply to? (Required)

- [x] main (the latest development version for v2.x)
- [x] v2.0 (TiDB Operator 2.0 versions)
- [ ] release-1.x (the latest development version for v1.x)
- [ ] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

- Other reference link(s): #3157

### Verification

- RED: `lychee -E -i -n -t 45 --root-dir "$PWD" -- en/monitor-a-tidb-cluster.md zh/monitor-a-tidb-cluster.md` failed with the two `tidb_operator_release_branch` raw URL 404s from #3157.
- GREEN: same focused lychee command after simulating the workflow append returned `0 Errors`, `8 Excluded`.
- `python3` + PyYAML parsed `.github/workflows/link.yml` and `.github/workflows/link-fail-fast.yaml` successfully.
- `git diff --check`
