### PR TITLE
variables: bump TiDB Operator to v1.6.6 and TiDB to v8.5.7

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -1,4 +1,4 @@
 {
-  "tidb_operator_version": "v1.6.5",
-  "tidb_version": "v8.5.5"
+  "tidb_operator_version": "v1.6.6",
+  "tidb_version": "v8.5.7"
 }


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Bump the version variables on `release-1.x` for the TiDB Operator v1.6.6 release:

- `tidb_operator_version`: `v1.6.5` -> `v1.6.6`
- `tidb_version`: `v8.5.5` -> `v8.5.7`

This is the `release-1.x` counterpart of the v1.6.6 release. The release notes themselves are added on `main` (#3163) and cherry-picked to `release-1.x`; `variables.json` is bumped here directly because on `main` it tracks v2 (`v2.0.0`).

### Which TiDB Operator version(s) do your changes apply to? (Required)

- [ ] main (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [ ] release-1.x (the latest development version for v1.x)
- [x] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

- Companion release notes PR on `main`: https://github.com/pingcap/docs-tidb-operator/pull/3163
- TiDB Operator v1.6.6 release commits on `release-1.6`: https://github.com/pingcap/tidb-operator/compare/v1.6.5...release-1.6
