### PR TITLE
docs: document container security context in v1.6.6

### DIFF
--- a/en/containers-run-as-non-root-user.md
+++ b/en/containers-run-as-non-root-user.md
@@ -23,11 +23,15 @@ controllerManager:
 
 ## Configure containers controlled by CR
 
-For the containers controlled by Custom Resource (CR), you can configure security context in any CRs (`TidbCluster`/`DmCluster`/`TidbInitializer`/`TidbMonitor`/`Backup`/`BackupSchedule`/`Restore`) to make the containers run as a non-root user.
+For containers controlled by Custom Resources (CRs), you can configure the security context at the Pod or container level. The supported fields vary by CR.
 
-You can use either of the following two types of configuration. If you configure both the cluster level and the component level for a component, only the configuration of the component level takes effect.
+### Configure the Pod-level security context
 
-- Configure `podSecurityContext` at the cluster level (`spec.podSecurityContext`) for all components. The following is an example configuration:
+`podSecurityContext` applies to all containers in the generated Pod and controls Pod-level settings such as volume ownership.
+
+For `TidbCluster` and `DMCluster`, you can configure `podSecurityContext` at the following levels:
+
+- Cluster level: configure `spec.podSecurityContext` to apply the settings to all components:
 
     ```yaml
     spec:
@@ -37,7 +41,7 @@ You can use either of the following two types of configuration. If you configure
         fsGroup: 2000
     ```
 
-- Configure at the component level for a specific component. For example, configuring  `spec.tidb.podSecurityContext` for `TidbCluster`, `spec.master.podSecurityContext` for `DMCluster`. The following is an example configuration:
+- Component level: configure `spec.<component>.podSecurityContext` to apply the settings to a specific component. For example, use `spec.tidb.podSecurityContext` for the TiDB component of a `TidbCluster`, or `spec.master.podSecurityContext` for the master component of a `DMCluster`:
 
     ```yaml
     spec:
@@ -53,13 +57,29 @@ You can use either of the following two types of configuration. If you configure
           fsGroup: 2000
     ```
 
-Starting from TiDB Operator v1.6.6, you can also configure the [container-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the main container of a component using `spec.<component>.securityContext`. Container-level settings apply only to that container. If the same field is set at both the container and Pod levels, the container-level setting takes precedence.
+If both levels are configured, the component-level `podSecurityContext` replaces the cluster-level `podSecurityContext` for that component.
 
-For example, the following configuration runs the main PD container as a non-root user and prevents its processes from gaining additional privileges:
+Other CRs, including `TidbInitializer`, `TidbMonitor`, `Backup`, `BackupSchedule`, and `Restore`, also support Pod-level security context settings. For the supported fields and paths, refer to the [API documentation](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md>).
+
+### Configure the container-level security context
+
+Starting from TiDB Operator v1.6.6, the following CRs support [container-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container):
+
+- For `TidbCluster` and `DMCluster`, configure `spec.<component>.securityContext`, such as `spec.pd.securityContext`, `spec.tidb.securityContext`, `spec.master.securityContext`, or `spec.worker.securityContext`. These CRs do not support cluster-level `spec.securityContext`.
+- For `TidbDashboard` and `TidbNGMonitoring`, configure `spec.securityContext`.
+- For `TidbMonitor`, configure `securityContext` for each generated container. The supported paths include `spec.initializer.securityContext`, `spec.prometheus.securityContext`, `spec.grafana.securityContext`, `spec.reloader.securityContext`, `spec.prometheusReloader.securityContext`, `spec.thanos.securityContext`, and `spec.dm.initializer.securityContext`.
+
+`TidbInitializer`, `Backup`, `BackupSchedule`, and `Restore` do not support container-level `securityContext`.
+
+For the complete `ComponentSpec.securityContext` schema, refer to the [`ComponentSpec` API documentation](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md#componentspec>).
+
+For example, the following configuration runs the PD container as a non-root user, sets the group ownership of its volumes, and prevents container processes from gaining more privileges than their parent processes:
 
 ```yaml
 spec:
   pd:
+    podSecurityContext:
+      fsGroup: 2000
     securityContext:
       runAsNonRoot: true
       runAsUser: 1000
@@ -69,6 +89,11 @@ spec:
 
 > **Note:**
 >
+> - Container-level settings apply only to the corresponding container and override overlapping fields in the effective `podSecurityContext`.
 > - Fields that affect Pod volumes, such as `fsGroup`, can only be configured in `podSecurityContext`.
-> - To configure a security context separately for a sidecar or init container, set `securityContext` in the corresponding container configuration.
-> - `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. Use `securityContext.privileged` for the corresponding component instead. If `securityContext` is configured, TiDB Operator ignores the legacy `privileged` field.
+> - Updating `securityContext` for a deployed component changes its Pod template and triggers a rolling update of the affected Pods.
+> - To configure the TiDB slow-log tailer, TiKV log tailer, TiFlash log tailer, or TiFlash initializer separately, use `spec.tidb.slowLogTailer.securityContext`, `spec.tikv.logTailer.securityContext`, `spec.tiflash.logTailer.securityContext`, or `spec.tiflash.initializer.securityContext`.
+
+> **Warning:**
+>
+> `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. When you configure any field in the corresponding component's `securityContext`, TiDB Operator ignores the legacy `privileged` field. If the container still needs privileged mode, explicitly configure `securityContext.privileged: true`; otherwise, the component might fail to start.

--- a/en/containers-run-as-non-root-user.md
+++ b/en/containers-run-as-non-root-user.md
@@ -27,7 +27,7 @@ For containers controlled by Custom Resources (CRs), you can configure the secur
 
 ### Configure the Pod-level security context
 
-`podSecurityContext` applies to all containers in the generated Pod and controls Pod-level settings such as volume ownership.
+`podSecurityContext` defines Pod-level security settings, such as volume ownership, and provides default security settings for all containers in the generated Pod.
 
 For `TidbCluster` and `DMCluster`, you can configure `podSecurityContext` at the following levels:
 
@@ -97,4 +97,4 @@ spec:
 
 > **Warning:**
 >
-> `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. Once you configure the corresponding component's `securityContext` object, even as an empty object, TiDB Operator ignores the legacy `privileged` field. If the container still needs privileged mode, explicitly configure `securityContext.privileged: true`; otherwise, the component might fail to start.
+> `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. Once you configure the corresponding component's `securityContext` object, even as an empty object, TiDB Operator ignores the legacy `privileged` field. If the TiKV or TiFlash container still requires privileged mode, explicitly configure `spec.tikv.securityContext.privileged: true` or `spec.tiflash.securityContext.privileged: true`; otherwise, the component might fail to start.

--- a/en/containers-run-as-non-root-user.md
+++ b/en/containers-run-as-non-root-user.md
@@ -52,3 +52,23 @@ You can use either of the following two types of configuration. If you configure
           runAsGroup: 2000
           fsGroup: 2000
     ```
+
+Starting from TiDB Operator v1.6.6, you can also configure the [container-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container) for the main container of a component using `spec.<component>.securityContext`. Container-level settings apply only to that container. If the same field is set at both the container and Pod levels, the container-level setting takes precedence.
+
+For example, the following configuration runs the main PD container as a non-root user and prevents its processes from gaining additional privileges:
+
+```yaml
+spec:
+  pd:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 2000
+      allowPrivilegeEscalation: false
+```
+
+> **Note:**
+>
+> - Fields that affect Pod volumes, such as `fsGroup`, can only be configured in `podSecurityContext`.
+> - To configure a security context separately for a sidecar or init container, set `securityContext` in the corresponding container configuration.
+> - `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. Use `securityContext.privileged` for the corresponding component instead. If `securityContext` is configured, TiDB Operator ignores the legacy `privileged` field.

--- a/en/containers-run-as-non-root-user.md
+++ b/en/containers-run-as-non-root-user.md
@@ -97,4 +97,4 @@ spec:
 
 > **Warning:**
 >
-> `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. When you configure any field in the corresponding component's `securityContext`, TiDB Operator ignores the legacy `privileged` field. If the container still needs privileged mode, explicitly configure `securityContext.privileged: true`; otherwise, the component might fail to start.
+> `spec.tikv.privileged` and `spec.tiflash.privileged` are deprecated. Once you configure the corresponding component's `securityContext` object, even as an empty object, TiDB Operator ignores the legacy `privileged` field. If the container still needs privileged mode, explicitly configure `securityContext.privileged: true`; otherwise, the component might fail to start.

--- a/en/containers-run-as-non-root-user.md
+++ b/en/containers-run-as-non-root-user.md
@@ -59,14 +59,15 @@ For `TidbCluster` and `DMCluster`, you can configure `podSecurityContext` at the
 
 If both levels are configured, the component-level `podSecurityContext` replaces the cluster-level `podSecurityContext` for that component.
 
-Other CRs, including `TidbInitializer`, `TidbMonitor`, `Backup`, `BackupSchedule`, and `Restore`, also support Pod-level security context settings. For the supported fields and paths, refer to the [API documentation](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md>).
+Other CRs, including `TidbDashboard`, `TidbNGMonitoring`, `TidbInitializer`, `TidbMonitor`, `Backup`, `BackupSchedule`, and `Restore`, also support Pod-level security context settings. For the supported fields and paths, refer to the [API documentation](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md>).
 
 ### Configure the container-level security context
 
 Starting from TiDB Operator v1.6.6, the following CRs support [container-level security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container):
 
 - For `TidbCluster` and `DMCluster`, configure `spec.<component>.securityContext`, such as `spec.pd.securityContext`, `spec.tidb.securityContext`, `spec.master.securityContext`, or `spec.worker.securityContext`. These CRs do not support cluster-level `spec.securityContext`.
-- For `TidbDashboard` and `TidbNGMonitoring`, configure `spec.securityContext`.
+- For `TidbDashboard`, configure `spec.securityContext`.
+- For `TidbNGMonitoring`, configure `spec.ngMonitoring.securityContext`. Configuring top-level `spec.securityContext` has no effect on the generated container.
 - For `TidbMonitor`, configure `securityContext` for each generated container. The supported paths include `spec.initializer.securityContext`, `spec.prometheus.securityContext`, `spec.grafana.securityContext`, `spec.reloader.securityContext`, `spec.prometheusReloader.securityContext`, `spec.thanos.securityContext`, and `spec.dm.initializer.securityContext`.
 
 `TidbInitializer`, `Backup`, `BackupSchedule`, and `Restore` do not support container-level `securityContext`.
@@ -89,7 +90,7 @@ spec:
 
 > **Note:**
 >
-> - Container-level settings apply only to the corresponding container and override overlapping fields in the effective `podSecurityContext`.
+> - Container-level settings apply only to container definitions generated from the corresponding field and override overlapping fields in the effective `podSecurityContext`.
 > - Fields that affect Pod volumes, such as `fsGroup`, can only be configured in `podSecurityContext`.
 > - Updating `securityContext` for a deployed component changes its Pod template and triggers a rolling update of the affected Pods.
 > - To configure the TiDB slow-log tailer, TiKV log tailer, TiFlash log tailer, or TiFlash initializer separately, use `spec.tidb.slowLogTailer.securityContext`, `spec.tikv.logTailer.securityContext`, `spec.tiflash.logTailer.securityContext`, or `spec.tiflash.initializer.securityContext`.

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -27,7 +27,7 @@ controllerManager:
 
 ### 配置 Pod 级别的安全上下文
 
-`podSecurityContext` 对生成的 Pod 中的所有容器生效，并控制卷所有权等 Pod 级别的设置。
+`podSecurityContext` 用于定义 Pod 级别的安全设置，例如卷的所有权，同时也会为 Pod 中所有容器提供默认的安全设置。
 
 对于 `TidbCluster` 和 `DMCluster`，你可以在以下级别配置 `podSecurityContext`：
 

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -52,3 +52,23 @@ controllerManager:
           runAsGroup: 2000
           fsGroup: 2000
     ```
+
+从 TiDB Operator v1.6.6 起，你还可以通过 `spec.<component>.securityContext` 为组件的主容器配置[容器级别的安全上下文](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)。容器级别的配置仅对该容器生效。当容器级别和 Pod 级别配置了相同字段时，容器级别的配置优先生效。
+
+例如，以下配置让 PD 主容器以非 root 用户运行，并禁止进程获取更多权限：
+
+```yaml
+spec:
+  pd:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 2000
+      allowPrivilegeEscalation: false
+```
+
+> **注意：**
+>
+> - `fsGroup` 等影响 Pod 卷的字段只能配置在 `podSecurityContext` 中。
+> - 如果需要为 sidecar 容器或 init container 单独配置安全上下文，请在对应容器的配置中设置 `securityContext`。
+> - `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。请改用对应组件的 `securityContext.privileged`。如果配置了 `securityContext`，TiDB Operator 会忽略原有的 `privileged` 字段。

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -97,4 +97,4 @@ spec:
 
 > **警告：**
 >
-> `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。一旦配置了对应组件的 `securityContext` 对象，即使对象为空，TiDB Operator 也会忽略原有的 `privileged` 字段。如果容器仍需以 privileged 模式运行，请显式配置 `securityContext.privileged: true`，否则组件可能无法启动。
+> `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。一旦配置了对应组件的 `securityContext` 对象，即使对象为空，TiDB Operator 也会忽略原有的 `privileged` 字段。如果 TiKV 或 TiFlash 容器仍需以 privileged 模式运行，请分别显式配置 `spec.tikv.securityContext.privileged: true` 或 `spec.tiflash.securityContext.privileged: true`，否则组件可能无法启动。

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -97,4 +97,4 @@ spec:
 
 > **警告：**
 >
-> `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。如果你在对应组件的 `securityContext` 中配置了任意字段，TiDB Operator 会忽略原有的 `privileged` 字段。如果容器仍需以 privileged 模式运行，请显式配置 `securityContext.privileged: true`，否则组件可能无法启动。
+> `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。一旦配置了对应组件的 `securityContext` 对象，即使对象为空，TiDB Operator 也会忽略原有的 `privileged` 字段。如果容器仍需以 privileged 模式运行，请显式配置 `securityContext.privileged: true`，否则组件可能无法启动。

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -59,14 +59,15 @@ controllerManager:
 
 如果同时配置了这两个级别，该组件将使用组件级别的 `podSecurityContext` 替代集群级别的 `podSecurityContext`。
 
-`TidbInitializer`、`TidbMonitor`、`Backup`、`BackupSchedule` 和 `Restore` 等其他 CR 也支持 Pod 级别的安全上下文设置。有关支持的字段和路径，请参考 [API 文档](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md>)。
+`TidbDashboard`、`TidbNGMonitoring`、`TidbInitializer`、`TidbMonitor`、`Backup`、`BackupSchedule` 和 `Restore` 等其他 CR 也支持 Pod 级别的安全上下文设置。有关支持的字段和路径，请参考 [API 文档](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md>)。
 
 ### 配置容器级别的安全上下文
 
 从 TiDB Operator v1.6.6 起，以下 CR 支持[容器级别的安全上下文](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)：
 
 - 对于 `TidbCluster` 和 `DMCluster`，配置 `spec.<component>.securityContext`，例如 `spec.pd.securityContext`、`spec.tidb.securityContext`、`spec.master.securityContext` 或 `spec.worker.securityContext`。这些 CR 不支持集群级别的 `spec.securityContext`。
-- 对于 `TidbDashboard` 和 `TidbNGMonitoring`，配置 `spec.securityContext`。
+- 对于 `TidbDashboard`，配置 `spec.securityContext`。
+- 对于 `TidbNGMonitoring`，配置 `spec.ngMonitoring.securityContext`。在顶层配置 `spec.securityContext` 不会对生成的容器生效。
 - 对于 `TidbMonitor`，分别为生成的容器配置 `securityContext`。支持的路径包括 `spec.initializer.securityContext`、`spec.prometheus.securityContext`、`spec.grafana.securityContext`、`spec.reloader.securityContext`、`spec.prometheusReloader.securityContext`、`spec.thanos.securityContext` 和 `spec.dm.initializer.securityContext`。
 
 `TidbInitializer`、`Backup`、`BackupSchedule` 和 `Restore` 不支持容器级别的 `securityContext`。
@@ -89,7 +90,7 @@ spec:
 
 > **注意：**
 >
-> - 容器级别的配置仅对相应容器生效，并覆盖有效 `podSecurityContext` 中的同名字段。
+> - 容器级别的配置仅应用于对应字段所生成的容器定义，并覆盖有效 `podSecurityContext` 中的同名字段。
 > - `fsGroup` 等影响 Pod 卷的字段只能配置在 `podSecurityContext` 中。
 > - 更新已部署组件的 `securityContext` 会修改其 Pod 模板，并触发受影响 Pod 的滚动更新。
 > - 如需单独配置 TiDB 慢日志 sidecar、TiKV 日志 sidecar、TiFlash 日志 sidecar 或 TiFlash init container，请分别使用 `spec.tidb.slowLogTailer.securityContext`、`spec.tikv.logTailer.securityContext`、`spec.tiflash.logTailer.securityContext` 或 `spec.tiflash.initializer.securityContext`。

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -93,7 +93,7 @@ spec:
 > - 容器级别的配置仅应用于对应字段所生成的容器定义，并覆盖有效 `podSecurityContext` 中的同名字段。
 > - `fsGroup` 等影响 Pod 卷的字段只能配置在 `podSecurityContext` 中。
 > - 更新已部署组件的 `securityContext` 会修改其 Pod 模板，并触发受影响 Pod 的滚动更新。
-> - 如需单独配置 TiDB 慢日志 sidecar、TiKV 日志 sidecar、TiFlash 日志 sidecar 或 TiFlash init container，请分别使用 `spec.tidb.slowLogTailer.securityContext`、`spec.tikv.logTailer.securityContext`、`spec.tiflash.logTailer.securityContext` 或 `spec.tiflash.initializer.securityContext`。
+> - 如需单独配置 TiDB 慢日志 tailer 容器、TiKV 日志 tailer 容器、TiFlash 日志 tailer 容器或 TiFlash initializer 容器，请分别使用 `spec.tidb.slowLogTailer.securityContext`、`spec.tikv.logTailer.securityContext`、`spec.tiflash.logTailer.securityContext` 或 `spec.tiflash.initializer.securityContext`。
 
 > **警告：**
 >

--- a/zh/containers-run-as-non-root-user.md
+++ b/zh/containers-run-as-non-root-user.md
@@ -23,11 +23,15 @@ controllerManager:
 
 ## 配置按照 CR 生成的容器
 
-对于按照 Custom Resource (CR) 生成的容器，你同样可以在任意一种 CR (`TidbCluster`/`DmCluster`/`TidbInitializer`/`TidbMonitor`/`Backup`/`BackupSchedule`/`Restore`) 中配置安全上下文 (security context)。
+对于按照 Custom Resource (CR) 生成的容器，你可以配置 Pod 级别或容器级别的安全上下文。不同 CR 支持的字段有所不同。
 
-你可以采用以下两种 `podSecurityContext` 配置。如果同时配置了集群级别和组件级别，则该组件以组件级别的配置为准。
+### 配置 Pod 级别的安全上下文
 
-- 配置在集群级别 (`spec.podSecurityContext`)，对所有组件生效。配置示例如下：
+`podSecurityContext` 对生成的 Pod 中的所有容器生效，并控制卷所有权等 Pod 级别的设置。
+
+对于 `TidbCluster` 和 `DMCluster`，你可以在以下级别配置 `podSecurityContext`：
+
+- 集群级别：配置 `spec.podSecurityContext`，对所有组件生效：
 
     ```yaml
     spec:
@@ -37,7 +41,7 @@ controllerManager:
         fsGroup: 2000
     ```
 
-- 配置在组件级别，仅对该组件生效。例如，为 PD 组件配置 `spec.pd.podSecurityContext`，为 TiDB 组件配置 `spec.tidb.podSecurityContext`。配置示例如下：
+- 组件级别：配置 `spec.<component>.podSecurityContext`，仅对指定组件生效。例如，为 `TidbCluster` 的 TiDB 组件配置 `spec.tidb.podSecurityContext`，或为 `DMCluster` 的 master 组件配置 `spec.master.podSecurityContext`：
 
     ```yaml
     spec:
@@ -53,13 +57,29 @@ controllerManager:
           fsGroup: 2000
     ```
 
-从 TiDB Operator v1.6.6 起，你还可以通过 `spec.<component>.securityContext` 为组件的主容器配置[容器级别的安全上下文](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)。容器级别的配置仅对该容器生效。当容器级别和 Pod 级别配置了相同字段时，容器级别的配置优先生效。
+如果同时配置了这两个级别，该组件将使用组件级别的 `podSecurityContext` 替代集群级别的 `podSecurityContext`。
 
-例如，以下配置让 PD 主容器以非 root 用户运行，并禁止进程获取更多权限：
+`TidbInitializer`、`TidbMonitor`、`Backup`、`BackupSchedule` 和 `Restore` 等其他 CR 也支持 Pod 级别的安全上下文设置。有关支持的字段和路径，请参考 [API 文档](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md>)。
+
+### 配置容器级别的安全上下文
+
+从 TiDB Operator v1.6.6 起，以下 CR 支持[容器级别的安全上下文](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)：
+
+- 对于 `TidbCluster` 和 `DMCluster`，配置 `spec.<component>.securityContext`，例如 `spec.pd.securityContext`、`spec.tidb.securityContext`、`spec.master.securityContext` 或 `spec.worker.securityContext`。这些 CR 不支持集群级别的 `spec.securityContext`。
+- 对于 `TidbDashboard` 和 `TidbNGMonitoring`，配置 `spec.securityContext`。
+- 对于 `TidbMonitor`，分别为生成的容器配置 `securityContext`。支持的路径包括 `spec.initializer.securityContext`、`spec.prometheus.securityContext`、`spec.grafana.securityContext`、`spec.reloader.securityContext`、`spec.prometheusReloader.securityContext`、`spec.thanos.securityContext` 和 `spec.dm.initializer.securityContext`。
+
+`TidbInitializer`、`Backup`、`BackupSchedule` 和 `Restore` 不支持容器级别的 `securityContext`。
+
+有关 `ComponentSpec.securityContext` 的完整字段说明，请参考 [`ComponentSpec` API 文档](<https://github.com/pingcap/tidb-operator/blob/{{{ .tidb_operator_version }}}/docs/api-references/docs.md#componentspec>)。
+
+例如，以下配置让 PD 容器以非 root 用户运行，设置其卷的组所有权，并禁止容器进程获得超出其父进程的特权：
 
 ```yaml
 spec:
   pd:
+    podSecurityContext:
+      fsGroup: 2000
     securityContext:
       runAsNonRoot: true
       runAsUser: 1000
@@ -69,6 +89,11 @@ spec:
 
 > **注意：**
 >
+> - 容器级别的配置仅对相应容器生效，并覆盖有效 `podSecurityContext` 中的同名字段。
 > - `fsGroup` 等影响 Pod 卷的字段只能配置在 `podSecurityContext` 中。
-> - 如果需要为 sidecar 容器或 init container 单独配置安全上下文，请在对应容器的配置中设置 `securityContext`。
-> - `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。请改用对应组件的 `securityContext.privileged`。如果配置了 `securityContext`，TiDB Operator 会忽略原有的 `privileged` 字段。
+> - 更新已部署组件的 `securityContext` 会修改其 Pod 模板，并触发受影响 Pod 的滚动更新。
+> - 如需单独配置 TiDB 慢日志 sidecar、TiKV 日志 sidecar、TiFlash 日志 sidecar 或 TiFlash init container，请分别使用 `spec.tidb.slowLogTailer.securityContext`、`spec.tikv.logTailer.securityContext`、`spec.tiflash.logTailer.securityContext` 或 `spec.tiflash.initializer.securityContext`。
+
+> **警告：**
+>
+> `spec.tikv.privileged` 和 `spec.tiflash.privileged` 已弃用。如果你在对应组件的 `securityContext` 中配置了任意字段，TiDB Operator 会忽略原有的 `privileged` 字段。如果容器仍需以 privileged 模式运行，请显式配置 `securityContext.privileged: true`，否则组件可能无法启动。


### PR DESCRIPTION
## Summary

- Document Pod-level and container-level security context configuration for CR-generated containers starting from TiDB Operator v1.6.6.
- Add a copyable PD example that combines container identity settings with Pod-level `fsGroup`.
- Clarify supported CRs and container paths, configuration precedence, rolling updates, and migration from deprecated TiKV/TiFlash `privileged` fields.

## Why

The existing guide only documents Pod-level `podSecurityContext`. The feature introduced by [pingcap/tidb-operator#6404](https://github.com/pingcap/tidb-operator/pull/6404) and cherry-picked to `release-1.6` by [pingcap/tidb-operator#6858](https://github.com/pingcap/tidb-operator/pull/6858) also lets users configure generated containers directly. Without precise scope and precedence guidance, users can select unsupported fields or create containers that cannot write to their volumes.

## How

- Separate Pod-level and container-level configuration into dedicated sections.
- Distinguish `TidbCluster` and `DMCluster` component paths from `TidbDashboard`, `TidbNGMonitoring`, and `TidbMonitor` paths, and identify CRs that only support Pod-level settings.
- Explain Pod/container precedence, enumerate supported auxiliary-container fields, and warn that adding `securityContext` disables the legacy TiKV/TiFlash `privileged` fallback.

## Testing

- [x] `npx --yes markdownlint-cli@0.47.0 en/containers-run-as-non-root-user.md zh/containers-run-as-non-root-user.md`
- [x] `npx --yes markdown-link-check@3.13.7` for both changed files using the repository link-check configuration
- [x] `git diff --check`

## Risks and Reviewer Focus

- The documentation is based on the current `release-1.6` implementation. The public v1.6.6 tag has not been published yet, so the version statement should remain aligned with the release schedule.
- Updating `securityContext` on a deployed component changes its Pod template and triggers a rolling update.
