### PR TITLE
en, zh: add aliases for release notes

### DIFF
--- a/en/releases/release-0.1.0.md
+++ b/en/releases/release-0.1.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.1.0 Release Notes
 summary: TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
+aliases: ['/tidb-in-kubernetes/dev/release-0.1.0/','/tidb-in-kubernetes/v1.3/release-0.1.0/','/tidb-in-kubernetes/v1.4/release-0.1.0/','/tidb-in-kubernetes/v1.5/release-0.1.0/','/tidb-in-kubernetes/v1.6/release-0.1.0/','/tidb-in-kubernetes/v2.0/release-0.1.0/']
 ---
 
 # TiDB Operator 0.1.0 Release Notes

--- a/en/releases/release-0.2.0.md
+++ b/en/releases/release-0.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.2.0 Release Notes
 summary: TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script to set up DinD environment easily was added, and code was linted and formatted in CI.
+aliases: ['/tidb-in-kubernetes/dev/release-0.2.0/','/tidb-in-kubernetes/v1.3/release-0.2.0/','/tidb-in-kubernetes/v1.4/release-0.2.0/','/tidb-in-kubernetes/v1.5/release-0.2.0/','/tidb-in-kubernetes/v1.6/release-0.2.0/','/tidb-in-kubernetes/v2.0/release-0.2.0/']
 ---
 
 # TiDB Operator 0.2.0 Release Notes

--- a/en/releases/release-0.2.1.md
+++ b/en/releases/release-0.2.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.2.1 Release Notes
 summary: TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
+aliases: ['/tidb-in-kubernetes/dev/release-0.2.1/','/tidb-in-kubernetes/v1.3/release-0.2.1/','/tidb-in-kubernetes/v1.4/release-0.2.1/','/tidb-in-kubernetes/v1.5/release-0.2.1/','/tidb-in-kubernetes/v1.6/release-0.2.1/','/tidb-in-kubernetes/v2.0/release-0.2.1/']
 ---
 
 # TiDB Operator 0.2.1 Release Notes

--- a/en/releases/release-0.3.0.md
+++ b/en/releases/release-0.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.3.0 Release Notes
 summary: TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
+aliases: ['/tidb-in-kubernetes/dev/release-0.3.0/','/tidb-in-kubernetes/v1.3/release-0.3.0/','/tidb-in-kubernetes/v1.4/release-0.3.0/','/tidb-in-kubernetes/v1.5/release-0.3.0/','/tidb-in-kubernetes/v1.6/release-0.3.0/','/tidb-in-kubernetes/v2.0/release-0.3.0/']
 ---
 
 # TiDB Operator 0.3.0 Release Notes

--- a/en/releases/release-0.3.1.md
+++ b/en/releases/release-0.3.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.3.1 Release Notes
 summary: TiDB Operator 0.3.1 was released on October 31, 2018. Minor changes include parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes address issues such as parallel upgrade bugs and recovery after a failed upgrade.
+aliases: ['/tidb-in-kubernetes/dev/release-0.3.1/','/tidb-in-kubernetes/v1.3/release-0.3.1/','/tidb-in-kubernetes/v1.4/release-0.3.1/','/tidb-in-kubernetes/v1.5/release-0.3.1/','/tidb-in-kubernetes/v1.6/release-0.3.1/','/tidb-in-kubernetes/v2.0/release-0.3.1/']
 ---
 
 # TiDB Operator 0.3.1 Release Notes

--- a/en/releases/release-0.4.0.md
+++ b/en/releases/release-0.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.4 Release Notes
 summary: TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
+aliases: ['/tidb-in-kubernetes/dev/release-0.4.0/','/tidb-in-kubernetes/v1.3/release-0.4.0/','/tidb-in-kubernetes/v1.4/release-0.4.0/','/tidb-in-kubernetes/v1.5/release-0.4.0/','/tidb-in-kubernetes/v1.6/release-0.4.0/','/tidb-in-kubernetes/v2.0/release-0.4.0/']
 ---
 
 # TiDB Operator 0.4 Release Notes

--- a/en/releases/release-1.0-ga.md
+++ b/en/releases/release-1.0-ga.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 GA Release Notes
 summary: TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. The release includes stability test cases, improvements in GKE SSD setup, AWS Terraform scripts, and bug fixes for sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The release also includes changes in configuration for TiDB, TiKV, and PD in charts, and an increase in default storage size for Pump.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0-ga/','/tidb-in-kubernetes/v1.3/release-1.0-ga/','/tidb-in-kubernetes/v1.4/release-1.0-ga/','/tidb-in-kubernetes/v1.5/release-1.0-ga/','/tidb-in-kubernetes/v1.6/release-1.0-ga/','/tidb-in-kubernetes/v2.0/release-1.0-ga/']
 ---
 
 # TiDB Operator 1.0 GA Release Notes

--- a/en/releases/release-1.0.0-beta.0.md
+++ b/en/releases/release-1.0.0-beta.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.0 Release Notes
 summary: TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-beta.0/','/tidb-in-kubernetes/v1.3/release-1.0.0-beta.0/','/tidb-in-kubernetes/v1.4/release-1.0.0-beta.0/','/tidb-in-kubernetes/v1.5/release-1.0.0-beta.0/','/tidb-in-kubernetes/v1.6/release-1.0.0-beta.0/','/tidb-in-kubernetes/v2.0/release-1.0.0-beta.0/']
 ---
 
 # TiDB Operator 1.0 Beta.0 Release Notes

--- a/en/releases/release-1.0.0-beta.1-p1.md
+++ b/en/releases/release-1.0.0-beta.1-p1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.1 P1 Release Notes
 summary: TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates propose adding multiple statefulsets support to TiDB Operator and updating the roadmap.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-beta.1-p1/','/tidb-in-kubernetes/v1.3/release-1.0.0-beta.1-p1/','/tidb-in-kubernetes/v1.4/release-1.0.0-beta.1-p1/','/tidb-in-kubernetes/v1.5/release-1.0.0-beta.1-p1/','/tidb-in-kubernetes/v1.6/release-1.0.0-beta.1-p1/','/tidb-in-kubernetes/v2.0/release-1.0.0-beta.1-p1/']
 ---
 
 # TiDB Operator 1.0 Beta.1 P1 Release Notes

--- a/en/releases/release-1.0.0-beta.1-p2.md
+++ b/en/releases/release-1.0.0-beta.1-p2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.1 P2 Release Notes
 summary: TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-beta.1-p2/','/tidb-in-kubernetes/v1.3/release-1.0.0-beta.1-p2/','/tidb-in-kubernetes/v1.4/release-1.0.0-beta.1-p2/','/tidb-in-kubernetes/v1.5/release-1.0.0-beta.1-p2/','/tidb-in-kubernetes/v1.6/release-1.0.0-beta.1-p2/','/tidb-in-kubernetes/v2.0/release-1.0.0-beta.1-p2/']
 ---
 
 # TiDB Operator 1.0 Beta.1 P2 Release Notes

--- a/en/releases/release-1.0.0-beta.1.md
+++ b/en/releases/release-1.0.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.1 Release Notes
 summary: TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and more.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.0.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.0.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.0.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.0.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.0.0-beta.1/']
 ---
 
 # TiDB Operator 1.0 Beta.1 Release Notes

--- a/en/releases/release-1.0.0-beta.2.md
+++ b/en/releases/release-1.0.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.2 Release Notes
 summary: TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-beta.2/','/tidb-in-kubernetes/v1.3/release-1.0.0-beta.2/','/tidb-in-kubernetes/v1.4/release-1.0.0-beta.2/','/tidb-in-kubernetes/v1.5/release-1.0.0-beta.2/','/tidb-in-kubernetes/v1.6/release-1.0.0-beta.2/','/tidb-in-kubernetes/v2.0/release-1.0.0-beta.2/']
 ---
 
 # TiDB Operator 1.0 Beta.2 Release Notes

--- a/en/releases/release-1.0.0-beta.3.md
+++ b/en/releases/release-1.0.0-beta.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.3 Release Notes
 summary: TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented. Overall, the release focuses on stability, new features, and documentation improvements.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-beta.3/','/tidb-in-kubernetes/v1.3/release-1.0.0-beta.3/','/tidb-in-kubernetes/v1.4/release-1.0.0-beta.3/','/tidb-in-kubernetes/v1.5/release-1.0.0-beta.3/','/tidb-in-kubernetes/v1.6/release-1.0.0-beta.3/','/tidb-in-kubernetes/v2.0/release-1.0.0-beta.3/']
 ---
 
 # TiDB Operator 1.0 Beta.3 Release Notes

--- a/en/releases/release-1.0.0-rc.1.md
+++ b/en/releases/release-1.0.0-rc.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 RC.1 Release Notes
 summary: TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. The release notes also detail various bug fixes and changes made in the new version.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.0-rc.1/','/tidb-in-kubernetes/v1.3/release-1.0.0-rc.1/','/tidb-in-kubernetes/v1.4/release-1.0.0-rc.1/','/tidb-in-kubernetes/v1.5/release-1.0.0-rc.1/','/tidb-in-kubernetes/v1.6/release-1.0.0-rc.1/','/tidb-in-kubernetes/v2.0/release-1.0.0-rc.1/']
 ---
 
 # TiDB Operator 1.0 RC.1 Release Notes

--- a/en/releases/release-1.0.1.md
+++ b/en/releases/release-1.0.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.1 Release Notes
 summary: TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid serious bugs that could cause service outage. The release also includes modularization of GCP Terraform, support for expanding cloud storage PV dynamically, and improvements to backup tool image. Additionally, several bug fixes were made to address issues such as TiKV scale-in failure and orphaned pods cleaner bugs.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.1/','/tidb-in-kubernetes/v1.3/release-1.0.1/','/tidb-in-kubernetes/v1.4/release-1.0.1/','/tidb-in-kubernetes/v1.5/release-1.0.1/','/tidb-in-kubernetes/v1.6/release-1.0.1/','/tidb-in-kubernetes/v2.0/release-1.0.1/']
 ---
 
 # TiDB Operator 1.0.1 Release Notes

--- a/en/releases/release-1.0.2.md
+++ b/en/releases/release-1.0.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.2 Release Notes
 summary: TiDB Operator version 1.0.2 has made several improvements and bug fixes. The AWS Terraform script now suspends the replacing behavior for TiKV auto-scaling-group to prevent data loss. It also adds a new VM manager, sets default externalTrafficPolicy to be Local for TiDB service, and fixes various compatibility issues. The release also includes bug fixes for tkctl version, Terraform script, statefulsets apiVersion, TiDB Loadbalancer, and more. Overall, the release aims to enhance stability and compatibility for TiDB Operator on AWS, GCP, and Aliyun.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.2/','/tidb-in-kubernetes/v1.3/release-1.0.2/','/tidb-in-kubernetes/v1.4/release-1.0.2/','/tidb-in-kubernetes/v1.5/release-1.0.2/','/tidb-in-kubernetes/v1.6/release-1.0.2/','/tidb-in-kubernetes/v2.0/release-1.0.2/']
 ---
 
 # TiDB Operator 1.0.2 Release Notes

--- a/en/releases/release-1.0.3.md
+++ b/en/releases/release-1.0.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.3 Release Notes
 summary: TiDB Operator 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.3/','/tidb-in-kubernetes/v1.3/release-1.0.3/','/tidb-in-kubernetes/v1.4/release-1.0.3/','/tidb-in-kubernetes/v1.5/release-1.0.3/','/tidb-in-kubernetes/v1.6/release-1.0.3/','/tidb-in-kubernetes/v2.0/release-1.0.3/']
 ---
 
 # TiDB Operator 1.0.3 Release Notes

--- a/en/releases/release-1.0.4.md
+++ b/en/releases/release-1.0.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.4 Release Notes
 summary: TiDB Operator version 1.0.4 was released on November 23, 2019. The new features include HostNetwork support, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. There are also bug fixes and changes, and a recommendation to upgrade to v1.0.4 from v1.1.0.alpha.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.4/','/tidb-in-kubernetes/v1.3/release-1.0.4/','/tidb-in-kubernetes/v1.4/release-1.0.4/','/tidb-in-kubernetes/v1.5/release-1.0.4/','/tidb-in-kubernetes/v1.6/release-1.0.4/','/tidb-in-kubernetes/v2.0/release-1.0.4/']
 ---
 
 # TiDB Operator 1.0.4 Release Notes

--- a/en/releases/release-1.0.5.md
+++ b/en/releases/release-1.0.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.5 Release Notes
 summary: TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission in Kubernetes v1.16, and fixing e2e nil point dereference. No action is required for upgrading from v1.0.4.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.5/','/tidb-in-kubernetes/v1.3/release-1.0.5/','/tidb-in-kubernetes/v1.4/release-1.0.5/','/tidb-in-kubernetes/v1.5/release-1.0.5/','/tidb-in-kubernetes/v1.6/release-1.0.5/','/tidb-in-kubernetes/v2.0/release-1.0.5/']
 ---
 
 # TiDB Operator 1.0.5 Release Notes

--- a/en/releases/release-1.0.6.md
+++ b/en/releases/release-1.0.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.6 Release Notes
 summary: TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.6/','/tidb-in-kubernetes/v1.3/release-1.0.6/','/tidb-in-kubernetes/v1.4/release-1.0.6/','/tidb-in-kubernetes/v1.5/release-1.0.6/','/tidb-in-kubernetes/v1.6/release-1.0.6/','/tidb-in-kubernetes/v2.0/release-1.0.6/']
 ---
 
 # TiDB Operator 1.0.6 Release Notes

--- a/en/releases/release-1.0.7.md
+++ b/en/releases/release-1.0.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.7 Release Notes
 summary: TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
+aliases: ['/tidb-in-kubernetes/dev/release-1.0.7/','/tidb-in-kubernetes/v1.3/release-1.0.7/','/tidb-in-kubernetes/v1.4/release-1.0.7/','/tidb-in-kubernetes/v1.5/release-1.0.7/','/tidb-in-kubernetes/v1.6/release-1.0.7/','/tidb-in-kubernetes/v2.0/release-1.0.7/']
 ---
 
 # TiDB Operator 1.0.7 Release Notes

--- a/en/releases/release-1.1-ga.md
+++ b/en/releases/release-1.1-ga.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 GA Release Notes
 summary: Upgrade from v1.0.x, breaking changes, and other notable changes. Notable changes include support for preemption in tidb-scheduler, update BR to v4.0.0-rc.2, and support TiCDC in TidbCluster. The release also includes improvements in performance and updates to TiDB/TiKV/PD configuration to 4.0.0 GA version.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1-ga/','/tidb-in-kubernetes/v1.3/release-1.1-ga/','/tidb-in-kubernetes/v1.4/release-1.1-ga/','/tidb-in-kubernetes/v1.5/release-1.1-ga/','/tidb-in-kubernetes/v1.6/release-1.1-ga/','/tidb-in-kubernetes/v2.0/release-1.1-ga/']
 ---
 
 # TiDB Operator 1.1 GA Release Notes

--- a/en/releases/release-1.1.0-beta.1.md
+++ b/en/releases/release-1.1.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 Beta.1 Release Notes
 summary: The new version requires action to add timezone support for all charts. Other notable changes include support for backup to S3, scaling in/out with deleted slots feature, and managing Pump cluster. Additional changes involve refining configuration schema, setting default name of instance label key, and upgrading default backup image. The release also includes fixes and improvements for various components.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.1.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.1.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.1.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.1.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.1.0-beta.1/']
 ---
 
 # TiDB Operator 1.1 Beta.1 Release Notes

--- a/en/releases/release-1.1.0-beta.2.md
+++ b/en/releases/release-1.1.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 Beta.2 Release Notes
 summary: TiDB Operator 1.1 Beta.2 has been released on February 26, 2020. The default storage class now defaults to Kubernetes default storage class. Users need to set default storage class explicitly in their TiDB cluster helm or YAML files if different than Kubernetes default. Other changes include the ability to configure affinity and tolerations for Backup and Restore, support for TidbCluster Auto-scaling based on CPU average utilization load, and more. Additionally, several bug fixes and improvements have been made.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.0-beta.2/','/tidb-in-kubernetes/v1.3/release-1.1.0-beta.2/','/tidb-in-kubernetes/v1.4/release-1.1.0-beta.2/','/tidb-in-kubernetes/v1.5/release-1.1.0-beta.2/','/tidb-in-kubernetes/v1.6/release-1.1.0-beta.2/','/tidb-in-kubernetes/v2.0/release-1.1.0-beta.2/']
 ---
 
 # TiDB Operator 1.1 Beta.2 Release Notes

--- a/en/releases/release-1.1.0-rc.1.md
+++ b/en/releases/release-1.1.0-rc.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.1 Release Notes
 summary: The new release includes action required changes such as configuring `--advertise-address` for `tidb-server` and adding `tlsClient.tlsSecret` field in the backup and restore spec. Other notable changes include using `tidb-lightning` in `Restore`, adding `cert-allowed-cn` support to TiDB components, and fixing PD `location-labels` configuration. Additionally, there are several fixes and updates for TiDB clusters, including support for deploying clusters with TidbCluster and TidbMonitor CRs via Terraform. TLS support has been added for Pump, Drainer, and MySQL clients, and various bug fixes and improvements have been made.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.0-rc.1/','/tidb-in-kubernetes/v1.3/release-1.1.0-rc.1/','/tidb-in-kubernetes/v1.4/release-1.1.0-rc.1/','/tidb-in-kubernetes/v1.5/release-1.1.0-rc.1/','/tidb-in-kubernetes/v1.6/release-1.1.0-rc.1/','/tidb-in-kubernetes/v2.0/release-1.1.0-rc.1/']
 ---
 
 # TiDB Operator 1.1 RC.1 Release Notes

--- a/en/releases/release-1.1.0-rc.2.md
+++ b/en/releases/release-1.1.0-rc.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.2 Release Notes
 summary: TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.0-rc.2/','/tidb-in-kubernetes/v1.3/release-1.1.0-rc.2/','/tidb-in-kubernetes/v1.4/release-1.1.0-rc.2/','/tidb-in-kubernetes/v1.5/release-1.1.0-rc.2/','/tidb-in-kubernetes/v1.6/release-1.1.0-rc.2/','/tidb-in-kubernetes/v2.0/release-1.1.0-rc.2/']
 ---
 
 # TiDB Operator 1.1 RC.2 Release Notes

--- a/en/releases/release-1.1.0-rc.3.md
+++ b/en/releases/release-1.1.0-rc.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.3 Release Notes
 summary: TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.0-rc.3/','/tidb-in-kubernetes/v1.3/release-1.1.0-rc.3/','/tidb-in-kubernetes/v1.4/release-1.1.0-rc.3/','/tidb-in-kubernetes/v1.5/release-1.1.0-rc.3/','/tidb-in-kubernetes/v1.6/release-1.1.0-rc.3/','/tidb-in-kubernetes/v2.0/release-1.1.0-rc.3/']
 ---
 
 # TiDB Operator 1.1 RC.3 Release Notes

--- a/en/releases/release-1.1.0-rc.4.md
+++ b/en/releases/release-1.1.0-rc.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.4 Release Notes
 summary: TiDB Operator 1.1 RC.4 was released on May 15, 2020. The new version supports separate TiDB client certificates for each component and allows customization of backup path prefix for remote storage. It also fixes bugs related to service annotations and reconciling TiDB service. Other notable changes include support for TiCDC in TidbCluster CR, creating node pools for TiFlash and CDC on ACK and EKS, and backup and restore with GCS using BR. Additionally, it updates TiDBConfig and TiKVConfig to support the 4.0.0-rc version and adds external strategy ability for TidbClusterAutoScaler. PVReclaimPolicy for TidbMonitor when storage is enabled is also exposed.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.0-rc.4/','/tidb-in-kubernetes/v1.3/release-1.1.0-rc.4/','/tidb-in-kubernetes/v1.4/release-1.1.0-rc.4/','/tidb-in-kubernetes/v1.5/release-1.1.0-rc.4/','/tidb-in-kubernetes/v1.6/release-1.1.0-rc.4/','/tidb-in-kubernetes/v2.0/release-1.1.0-rc.4/']
 ---
 
 # TiDB Operator 1.1 RC.4 Release Notes

--- a/en/releases/release-1.1.1.md
+++ b/en/releases/release-1.1.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.1 Release Notes
 summary: TiDB Operator version 1.1.1 was released on June 19, 2020. Notable changes include support for adding sidecars to TiDB, TiKV, PD, etc. A cross check was added to ensure TiKV is not scaled or upgraded at the same time. Bugs related to TidbMonitor, alert rules, and pod scaling were fixed. Updates were made to TiDB Operator examples and configurations. Additional features include enabling direct visit to PD Dashboard, specifying subdirectory within the data volume, and support for LoadBalancerSourceRanges in ServiceSpec. The DM version was bumped to v2.0.0-beta.1, and support for scraping Pump and Drainer metrics in TidbMonitor was added.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.1/','/tidb-in-kubernetes/v1.3/release-1.1.1/','/tidb-in-kubernetes/v1.4/release-1.1.1/','/tidb-in-kubernetes/v1.5/release-1.1.1/','/tidb-in-kubernetes/v1.6/release-1.1.1/','/tidb-in-kubernetes/v2.0/release-1.1.1/']
 ---
 
 # TiDB Operator 1.1.1 Release Notes

--- a/en/releases/release-1.1.10.md
+++ b/en/releases/release-1.1.10.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.10 Release Notes
 summary: TiDB Operator 1.1.10 was released on January 28, 2021. The new version includes compatibility changes, rolling update changes, new features, improvements, and bug fixes. Some notable changes include the support for canary upgrade, `remotewrite` configuration for TidbMonitor, and customizing storage config for TiDB slow log. The update also fixes issues related to TLS-enabled backup and restore jobs, advanced StatefulSet, and recovery of TiKV component.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.10/','/tidb-in-kubernetes/v1.3/release-1.1.10/','/tidb-in-kubernetes/v1.4/release-1.1.10/','/tidb-in-kubernetes/v1.5/release-1.1.10/','/tidb-in-kubernetes/v1.6/release-1.1.10/','/tidb-in-kubernetes/v2.0/release-1.1.10/']
 ---
 
 # TiDB Operator 1.1.10 Release Notes

--- a/en/releases/release-1.1.11.md
+++ b/en/releases/release-1.1.11.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.11 Release Notes
 summary: TiDB Operator 1.1.11 was released on February 26, 2021. New features include support for configuring leader election durations and setting customized store labels. Improvements include TiFlash rolling upgrade logic, retrieving region leader count from TiKV Pod directly, and printing RocksDB and Raft logs to stdout for Grafana support.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.11/','/tidb-in-kubernetes/v1.3/release-1.1.11/','/tidb-in-kubernetes/v1.4/release-1.1.11/','/tidb-in-kubernetes/v1.5/release-1.1.11/','/tidb-in-kubernetes/v1.6/release-1.1.11/','/tidb-in-kubernetes/v2.0/release-1.1.11/']
 ---
 
 # TiDB Operator 1.1.11 Release Notes

--- a/en/releases/release-1.1.12.md
+++ b/en/releases/release-1.1.12.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.12 Release Notes
 summary: TiDB Operator 1.1.12 was released on April 15, 2021. New features include support for customized environment variables for backup and restore job containers, additional volume and volumeMount configurations for TidbMonitor, and the use of new service account resources in the tidb-operator chart. Improvements include DNS lookup failure exception retry, support for multiple PVCs for PD during scaling and failover, and optimization of the PodsAreChanged function. Bug fixes address issues with PVC size configuration, panic issue with TLS enabled TidbCluster CR, and wrong PVC status in UnjoinedMembers for PD and DM.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.12/','/tidb-in-kubernetes/v1.3/release-1.1.12/','/tidb-in-kubernetes/v1.4/release-1.1.12/','/tidb-in-kubernetes/v1.5/release-1.1.12/','/tidb-in-kubernetes/v1.6/release-1.1.12/','/tidb-in-kubernetes/v2.0/release-1.1.12/']
 ---
 
 # TiDB Operator 1.1.12 Release Notes

--- a/en/releases/release-1.1.13.md
+++ b/en/releases/release-1.1.13.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.13 Release Notes
 summary: TiDB Operator 1.1.13 was released on July 2, 2021. The release includes improvements such as support for configuring TLS certificates for TiCDC sinks, using TiKV version as the tag for BR `toolImage` if no tag is specified, handling PVC during scaling of TiDB, and masking the backup password in logging. Bug fixes include resolving issues with TiDB Operator panicking during the deployment of heterogeneous clusters and instances being kept in TiDB Dashboard after being scaled in.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.13/','/tidb-in-kubernetes/v1.3/release-1.1.13/','/tidb-in-kubernetes/v1.4/release-1.1.13/','/tidb-in-kubernetes/v1.5/release-1.1.13/','/tidb-in-kubernetes/v1.6/release-1.1.13/','/tidb-in-kubernetes/v2.0/release-1.1.13/']
 ---
 
 # TiDB Operator 1.1.13 Release Notes

--- a/en/releases/release-1.1.14.md
+++ b/en/releases/release-1.1.14.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.14 Release Notes
 summary: TiDB Operator 1.1.14 was released on October 21, 2021. This version includes bug fixes for security vulnerabilities in the `tidb-backup-manager` and `tidb-operator` images.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.14/','/tidb-in-kubernetes/v1.3/release-1.1.14/','/tidb-in-kubernetes/v1.4/release-1.1.14/','/tidb-in-kubernetes/v1.5/release-1.1.14/','/tidb-in-kubernetes/v1.6/release-1.1.14/','/tidb-in-kubernetes/v2.0/release-1.1.14/']
 ---
 
 # TiDB Operator 1.1.14 Release Notes

--- a/en/releases/release-1.1.15.md
+++ b/en/releases/release-1.1.15.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.15 Release Notes
 summary: TiDB Operator 1.1.15 was released on February 17, 2022. This version includes a bug fix for a potential goroutine leak when TiDB Operator checks the Region leader count of TiKV.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.15/','/tidb-in-kubernetes/v1.3/release-1.1.15/','/tidb-in-kubernetes/v1.4/release-1.1.15/','/tidb-in-kubernetes/v1.5/release-1.1.15/','/tidb-in-kubernetes/v1.6/release-1.1.15/','/tidb-in-kubernetes/v2.0/release-1.1.15/']
 ---
 
 # TiDB Operator 1.1.15 Release Notes

--- a/en/releases/release-1.1.2.md
+++ b/en/releases/release-1.1.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.2 Release Notes
 summary: TiDB Operator version 1.1.2 has been released on July 1, 2020. An issue with PD 4.0.2 has been fixed, requiring an upgrade before deploying TiDB 4.0.2 and later versions. Other changes include collecting metrics for TiCDC, TiDB Lightning, and TiKV Importer, updating PD/TiDB/TiKV config to v4.0.2, fixing a bug with `PD` Member, supporting Auto-Scaler Reference in `TidbCluster` Status, and configuring container lifecycle hooks and `terminationGracePeriodSeconds` in TiDB spec.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.2/','/tidb-in-kubernetes/v1.3/release-1.1.2/','/tidb-in-kubernetes/v1.4/release-1.1.2/','/tidb-in-kubernetes/v1.5/release-1.1.2/','/tidb-in-kubernetes/v1.6/release-1.1.2/','/tidb-in-kubernetes/v2.0/release-1.1.2/']
 ---
 
 # TiDB Operator 1.1.2 Release Notes

--- a/en/releases/release-1.1.3.md
+++ b/en/releases/release-1.1.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.3 Release Notes
 summary: TiDB Operator 1.1.3 was released on July 27, 2020. Action required includes adding a field `cleanPolicy` in `BackupSpec` and replacing `mydumper` with `dumpling` for backup. Other notable changes include updating tools in backup manager, adding TLS support for TiCDC, and support for auto-scaling by storage for TiKV in `TidbClusterAutoScaler`. Various bug fixes and updates were also made.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.3/','/tidb-in-kubernetes/v1.3/release-1.1.3/','/tidb-in-kubernetes/v1.4/release-1.1.3/','/tidb-in-kubernetes/v1.5/release-1.1.3/','/tidb-in-kubernetes/v1.6/release-1.1.3/','/tidb-in-kubernetes/v2.0/release-1.1.3/']
 ---
 
 # TiDB Operator 1.1.3 Release Notes

--- a/en/releases/release-1.1.4.md
+++ b/en/releases/release-1.1.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.4 Release Notes
 summary: TiDB Operator 1.1.4 was released on August 21, 2020. Notable changes include the addition of TableFilter to BackupSpec and RestoreSpec, support for customizing environment variables for the initializer container, patching PVCs when storage request is increased, TLS support for Backup & Restore with Dumpling & TiDB Lightning, and support for max-index-length TiDB config option. Other changes include fixes for goroutine and memory leaks, support for TLS for TiFlash, and configuration of TZ environment for admission webhook and advanced statefulset controller.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.4/','/tidb-in-kubernetes/v1.3/release-1.1.4/','/tidb-in-kubernetes/v1.4/release-1.1.4/','/tidb-in-kubernetes/v1.5/release-1.1.4/','/tidb-in-kubernetes/v1.6/release-1.1.4/','/tidb-in-kubernetes/v2.0/release-1.1.4/']
 ---
 
 # TiDB Operator 1.1.4 Release Notes

--- a/en/releases/release-1.1.5.md
+++ b/en/releases/release-1.1.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.5 Release Notes
 summary: TiDB Operator 1.1.5 was released on September 18, 2020. The new version includes compatibility changes, new features, improvements, and bug fixes. Some notable changes include support for configuring serviceAccount for TiDB/Pump/PD, labels configuration for TiDB, and recovery from failover for TiFlash and TiKV. Additionally, there are improvements in adapting configurations to v4.0.6, scaling taking precedence over upgrading, and bug fixes for the Grafana container in the TidbMonitor CR.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.5/','/tidb-in-kubernetes/v1.3/release-1.1.5/','/tidb-in-kubernetes/v1.4/release-1.1.5/','/tidb-in-kubernetes/v1.5/release-1.1.5/','/tidb-in-kubernetes/v1.6/release-1.1.5/','/tidb-in-kubernetes/v2.0/release-1.1.5/']
 ---
 
 # TiDB Operator 1.1.5 Release Notes

--- a/en/releases/release-1.1.6.md
+++ b/en/releases/release-1.1.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.6 Release Notes
 summary: TiDB Operator 1.1.6 was released on October 16, 2020. Compatibility changes include migration of `spec.pd.config` from YAML to TOML format, with some parameters requiring manual editing. New features include customizing arguments for BR, configurable TiKV evict leader timeout, and monitoring multiple TiDB clusters with one TidbMonitor CR. Improvements involve support for passing raw TOML config for various components and bug fixes address the problem of bootstrapping multiple PD clusters.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.6/','/tidb-in-kubernetes/v1.3/release-1.1.6/','/tidb-in-kubernetes/v1.4/release-1.1.6/','/tidb-in-kubernetes/v1.5/release-1.1.6/','/tidb-in-kubernetes/v1.6/release-1.1.6/','/tidb-in-kubernetes/v2.0/release-1.1.6/']
 ---
 
 # TiDB Operator 1.1.6 Release Notes

--- a/en/releases/release-1.1.7.md
+++ b/en/releases/release-1.1.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.7 Release Notes
 summary: TiDB Operator 1.1.7 was released on November 13, 2020. The new version includes compatibility changes, new features, improvements, and bug fixes. Some notable changes include the support for specifying the tool image for backup and restore, support for mounting multiple PVs for TiDB, TiKV, and PD, and the ability to support HA scheduling when failover happens. Additionally, the release includes improvements such as forbidding the scaling in of TiKV when the number of UP stores is equal to or less than 3, and bug fixes including fixing the issue that PD cannot scale into zero if there are other PD members outside of the TidbCluster.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.7/','/tidb-in-kubernetes/v1.3/release-1.1.7/','/tidb-in-kubernetes/v1.4/release-1.1.7/','/tidb-in-kubernetes/v1.5/release-1.1.7/','/tidb-in-kubernetes/v1.6/release-1.1.7/','/tidb-in-kubernetes/v2.0/release-1.1.7/']
 ---
 
 # TiDB Operator 1.1.7 Release Notes

--- a/en/releases/release-1.1.8.md
+++ b/en/releases/release-1.1.8.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.8 Release Notes
 summary: TiDB Operator 1.1.8 was released on December 21, 2020. New features include support for arbitrary Volume and VolumeMount for various components, enabling the use of NFS or other Kubernetes supported volume sources for backup/restore workflow. Improvements include support for cluster and client TLS, setting additional ports for TiDB service, and Prometheus to scrape metrics data from multiple TiDB clusters. Bug fixes address issues such as TiDB cluster deployment failure, non-ASCII character password error, misrecognition of TiFlash Pods, and crashing of tidb-controller-manager Pod.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.8/','/tidb-in-kubernetes/v1.3/release-1.1.8/','/tidb-in-kubernetes/v1.4/release-1.1.8/','/tidb-in-kubernetes/v1.5/release-1.1.8/','/tidb-in-kubernetes/v1.6/release-1.1.8/','/tidb-in-kubernetes/v2.0/release-1.1.8/']
 ---
 
 # TiDB Operator 1.1.8 Release Notes

--- a/en/releases/release-1.1.9.md
+++ b/en/releases/release-1.1.9.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.9 Release Notes
 summary: TiDB Operator 1.1.9 was released on December 28, 2020. The new version includes support for defining the image used for Backup and Restore operations, as well as bug fixes for issues with Prometheus metrics and compatibility with GCS for backup and restore operations.
+aliases: ['/tidb-in-kubernetes/dev/release-1.1.9/','/tidb-in-kubernetes/v1.3/release-1.1.9/','/tidb-in-kubernetes/v1.4/release-1.1.9/','/tidb-in-kubernetes/v1.5/release-1.1.9/','/tidb-in-kubernetes/v1.6/release-1.1.9/','/tidb-in-kubernetes/v2.0/release-1.1.9/']
 ---
 
 # TiDB Operator 1.1.9 Release Notes

--- a/en/releases/release-1.2.0-alpha.1.md
+++ b/en/releases/release-1.2.0-alpha.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-alpha.1 Release Notes
 summary: TiDB Operator 1.2.0-alpha.1 was released on January 15, 2021. The update includes the ability to deploy one TiDB cluster across multiple Kubernetes clusters, support for DM 2.0, auto-scaling with PD API, and canary upgrade of TiDB Operator. Improvements include local backend support for the TiDB Lightning chart, TLS support for the TiDB Lightning chart and TiKV Importer chart, persisting checkpoint for TiDB Lightning helm chart, support for Thanos sidecar for monitoring multiple clusters, and migration from Deployment to StatefulSet for TidbMonitor. Other notable changes include optimized rate limiter intervals and changes in the directory to save customized alert rules in TidbMonitor.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.0-alpha.1/','/tidb-in-kubernetes/v1.3/release-1.2.0-alpha.1/','/tidb-in-kubernetes/v1.4/release-1.2.0-alpha.1/','/tidb-in-kubernetes/v1.5/release-1.2.0-alpha.1/','/tidb-in-kubernetes/v1.6/release-1.2.0-alpha.1/','/tidb-in-kubernetes/v2.0/release-1.2.0-alpha.1/']
 ---
 
 # TiDB Operator 1.2.0-alpha.1 Release Notes

--- a/en/releases/release-1.2.0-beta.1.md
+++ b/en/releases/release-1.2.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-beta.1 Release Notes
 summary: TiDB Operator 1.2.0-beta.1 was released on April 7, 2021. The new version includes compatibility changes, rolling update changes, new features, improvements, and bug fixes. Some notable new features include support for setting customized environment variables for backup and restore job containers, additional volume and volumeMount configurations to TidbMonitor, and support for configuring durations for leader election. The release also includes various improvements and bug fixes to enhance the performance and stability of the TiDB Operator.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.2.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.2.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.2.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.2.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.2.0-beta.1/']
 ---
 
 # TiDB Operator 1.2.0-beta.1 Release Notes

--- a/en/releases/release-1.2.0-beta.2.md
+++ b/en/releases/release-1.2.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-beta.2 Release Notes
 summary: TiDB Operator 1.2.0-beta.2 was released on April 29, 2021. Upgrading the operator will recreate TidbMonitor and DM-master Pods. New features include support for monitoring multiple TidbClusters with TLS enabled, configuring podSecurityContext and topologySpreadConstraints for all TiDB components, deploying a DmCluster in a different namespace, and installing TiDB Operator with only namespace-scoped permissions. Improvements include adding a readiness probe for the TidbMonitor Pod, optimizing TidbMonitor for DmCluster with TLS enabled, and supporting not generating Prometheus alert rules. Bug fixes address issues with TiDB instances in TiDB Dashboard after scaling in and useless sync of TidbCluster CR caused by the update of `lastHeartbeatTime` in `status.tikv.stores`.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.0-beta.2/','/tidb-in-kubernetes/v1.3/release-1.2.0-beta.2/','/tidb-in-kubernetes/v1.4/release-1.2.0-beta.2/','/tidb-in-kubernetes/v1.5/release-1.2.0-beta.2/','/tidb-in-kubernetes/v1.6/release-1.2.0-beta.2/','/tidb-in-kubernetes/v2.0/release-1.2.0-beta.2/']
 ---
 
 # TiDB Operator 1.2.0-beta.2 Release Notes

--- a/en/releases/release-1.2.0-rc.1.md
+++ b/en/releases/release-1.2.0-rc.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-rc.1 Release Notes
 summary: TiDB Operator 1.2.0-rc.1 was released on May 28, 2021. The update includes changes to the Pump Pod, support for customized labels for TidbCluster Pods and services, full lifecycle management for Pump, and various improvements and bug fixes. Notable improvements include masking the backup password in logging, additional volumeMounts field for Grafana, and additional printout columns for TidbMonitor. Bug fixes address issues with TidbMonitor, PD member count, DM-master restart, rolling update, and backup using Dumpling.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.0-rc.1/','/tidb-in-kubernetes/v1.3/release-1.2.0-rc.1/','/tidb-in-kubernetes/v1.4/release-1.2.0-rc.1/','/tidb-in-kubernetes/v1.5/release-1.2.0-rc.1/','/tidb-in-kubernetes/v1.6/release-1.2.0-rc.1/','/tidb-in-kubernetes/v2.0/release-1.2.0-rc.1/']
 ---
 
 # TiDB Operator 1.2.0-rc.1 Release Notes

--- a/en/releases/release-1.2.0-rc.2.md
+++ b/en/releases/release-1.2.0-rc.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-rc.2 Release Notes
 summary: TiDB Operator 1.2.0-rc.2 was released on July 2, 2021. The new features include support for passing raw TOML config for TiCDC, setting StorageVolumes, AdditionalVolumes, and AdditionalVolumeMounts for TiCDC, and modifying Grafana dashboard. Improvements include using the TiKV version as the tag for BR toolImage, handling PVC during scaling of TiDB, and adding liveness and readiness probes for TiDB Operator. Bug fixes address issues with the deployment of heterogeneous clusters and the continuous update of TiDB service and TidbCluster status.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.0-rc.2/','/tidb-in-kubernetes/v1.3/release-1.2.0-rc.2/','/tidb-in-kubernetes/v1.4/release-1.2.0-rc.2/','/tidb-in-kubernetes/v1.5/release-1.2.0-rc.2/','/tidb-in-kubernetes/v1.6/release-1.2.0-rc.2/','/tidb-in-kubernetes/v2.0/release-1.2.0-rc.2/']
 ---
 
 # TiDB Operator 1.2.0-rc.2 Release Notes

--- a/en/releases/release-1.2.0.md
+++ b/en/releases/release-1.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0 Release Notes
 summary: TiDB Operator 1.2.0 was released on July 29, 2021. The update includes changes to the rolling update process, new features such as setting Prometheus retentionTime and priorityClassName, improvements to the default Region leader eviction timeout, and bug fixes related to URL parsing in TiDBMonitor.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.0/','/tidb-in-kubernetes/v1.3/release-1.2.0/','/tidb-in-kubernetes/v1.4/release-1.2.0/','/tidb-in-kubernetes/v1.5/release-1.2.0/','/tidb-in-kubernetes/v1.6/release-1.2.0/','/tidb-in-kubernetes/v2.0/release-1.2.0/']
 ---
 
 # TiDB Operator 1.2.0 Release Notes

--- a/en/releases/release-1.2.1.md
+++ b/en/releases/release-1.2.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.1 Release Notes
 summary: TiDB Operator 1.2.1 was released on August 18, 2021. The update includes changes to the rolling update process, which may cause the recreation of the TiCDC Pod if `hostNetwork` is enabled. Additionally, improvements have been made to support configuring `hostNetwork` for all components in TidbCluster, allowing all components to use the host network.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.1/','/tidb-in-kubernetes/v1.3/release-1.2.1/','/tidb-in-kubernetes/v1.4/release-1.2.1/','/tidb-in-kubernetes/v1.5/release-1.2.1/','/tidb-in-kubernetes/v1.6/release-1.2.1/','/tidb-in-kubernetes/v2.0/release-1.2.1/']
 ---
 
 # TiDB Operator 1.2.1 Release Notes

--- a/en/releases/release-1.2.2.md
+++ b/en/releases/release-1.2.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.2 Release Notes
 summary: TiDB Operator 1.2.2 was released on September 3, 2021. Upgrading the operator will recreate the TiDBMonitor and TiFlash Pods. The new feature includes support for dynamically reloading configurations in TiDBMonitor. Bug fixes address upgrade failures of TiCDC from an earlier version to v5.2.0.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.2/','/tidb-in-kubernetes/v1.3/release-1.2.2/','/tidb-in-kubernetes/v1.4/release-1.2.2/','/tidb-in-kubernetes/v1.5/release-1.2.2/','/tidb-in-kubernetes/v1.6/release-1.2.2/','/tidb-in-kubernetes/v2.0/release-1.2.2/']
 ---
 
 # TiDB Operator 1.2.2 Release Notes

--- a/en/releases/release-1.2.3.md
+++ b/en/releases/release-1.2.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.3 Release Notes
 summary: TiDB Operator 1.2.3 was released on September 7, 2021. This version fixed the TiFlash Pod rolling recreation issue that occurred after upgrading to v1.2.2.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.3/','/tidb-in-kubernetes/v1.3/release-1.2.3/','/tidb-in-kubernetes/v1.4/release-1.2.3/','/tidb-in-kubernetes/v1.5/release-1.2.3/','/tidb-in-kubernetes/v1.6/release-1.2.3/','/tidb-in-kubernetes/v2.0/release-1.2.3/']
 ---
 
 # TiDB Operator 1.2.3 Release Notes

--- a/en/releases/release-1.2.4.md
+++ b/en/releases/release-1.2.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.4 Release Notes
 summary: TiDB Operator 1.2.4 was released on October 21, 2021. The update includes changes to the rolling update process, new features such as customizing prometheus rules and reloading configurations, improvements to the TiFlash rolling upgrade process and support for deleting backup data in batches. Bug fixes were also made to address security vulnerabilities in the images and to resolve issues with retaining backup data when the Backup job is running.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.4/','/tidb-in-kubernetes/v1.3/release-1.2.4/','/tidb-in-kubernetes/v1.4/release-1.2.4/','/tidb-in-kubernetes/v1.5/release-1.2.4/','/tidb-in-kubernetes/v1.6/release-1.2.4/','/tidb-in-kubernetes/v2.0/release-1.2.4/']
 ---
 
 # TiDB Operator 1.2.4 Release Notes

--- a/en/releases/release-1.2.5.md
+++ b/en/releases/release-1.2.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.5 Release Notes
 summary: TiDB Operator 1.2.5 was released on December 27, 2021. The release includes improvements such as support for configuring all fields in `ComponentSpec` for DM, init container `resources` for TiFlash, and the `ssl-ca` parameter for TiDB. Bug fixes include issues with component roll update, TidbCluster spec update, goroutine leak, and high-level security issues.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.5/','/tidb-in-kubernetes/v1.3/release-1.2.5/','/tidb-in-kubernetes/v1.4/release-1.2.5/','/tidb-in-kubernetes/v1.5/release-1.2.5/','/tidb-in-kubernetes/v1.6/release-1.2.5/','/tidb-in-kubernetes/v2.0/release-1.2.5/']
 ---
 
 # TiDB Operator 1.2.5 Release Notes

--- a/en/releases/release-1.2.6.md
+++ b/en/releases/release-1.2.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.6 Release Notes
 summary: TiDB Operator 1.2.6 was released on January 4, 2022. The improvements include refining the retry logic when updating the status of the Backup and Restore CR.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.6/','/tidb-in-kubernetes/v1.3/release-1.2.6/','/tidb-in-kubernetes/v1.4/release-1.2.6/','/tidb-in-kubernetes/v1.5/release-1.2.6/','/tidb-in-kubernetes/v1.6/release-1.2.6/','/tidb-in-kubernetes/v2.0/release-1.2.6/']
 ---
 # TiDB Operator 1.2.6 Release Notes
 

--- a/en/releases/release-1.2.7.md
+++ b/en/releases/release-1.2.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.7 Release Notes
 summary: TiDB Operator 1.2.7 was released on February 17, 2022. The new feature includes the addition of a new field `spec.pd.startUpScriptVersion` to use the `dig` command instead of `nslookup` to lookup domain in the startup script of PD. An improvement was made to pre-check whether `VolumeMount` exists when the StatefulSet of components is deployed or updated to avoid failed rolling upgrade.
+aliases: ['/tidb-in-kubernetes/dev/release-1.2.7/','/tidb-in-kubernetes/v1.3/release-1.2.7/','/tidb-in-kubernetes/v1.4/release-1.2.7/','/tidb-in-kubernetes/v1.5/release-1.2.7/','/tidb-in-kubernetes/v1.6/release-1.2.7/','/tidb-in-kubernetes/v2.0/release-1.2.7/']
 ---
 # TiDB Operator 1.2.7 Release Notes
 

--- a/en/releases/release-1.3.0-beta.1.md
+++ b/en/releases/release-1.3.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.0-beta.1 Release Notes
 summary: TiDB Operator 1.3.0-beta.1 was released on January 12, 2022. The release includes compatibility changes, rolling update changes, new features, and improvements. Some changes may impact TiDB cluster management, such as the deletion of ValidatingWebhook and MutatingWebhook, and the need to upgrade TiDB Operator before deploying TiFlash. New features include support for configuring resource usage for the init container of TiFlash and enabling continuous profiling for the TiDB cluster. Improvements include optimizing the user experience of heterogeneous clusters and updating Grafana images for enhanced security.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.3.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.3.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.3.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.3.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.3.0-beta.1/']
 ---
 # TiDB Operator 1.3.0-beta.1 Release Notes
 

--- a/en/releases/release-1.3.0.md
+++ b/en/releases/release-1.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.0 Release Notes
 summary: TiDB Operator 1.3.0 has compatibility changes, new features, improvements, and bug fixes. Upgrading to v1.3.0 directly may cause failed rolling upgrade if a TiDB cluster is deployed across multiple Kubernetes clusters. It is recommended to upgrade TiDB Operator to v1.3.1 before upgrading TiFlash. New features include configuring DNS for Pods, setting random passwords for TiDB, and supporting one-time recover for TiKV/TiFlash/DM Worker. Improvements include pre-checking VolumeMount existence and enhancing the feature of deploying a TiDB cluster across Kubernetes clusters. Bug fixes include fixing the issue that tidb scheduler cannot be deployed on Kubernetes v1.23 or later versions.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.0/','/tidb-in-kubernetes/v1.3/release-1.3.0/','/tidb-in-kubernetes/v1.4/release-1.3.0/','/tidb-in-kubernetes/v1.5/release-1.3.0/','/tidb-in-kubernetes/v1.6/release-1.3.0/','/tidb-in-kubernetes/v2.0/release-1.3.0/']
 ---
 
 # TiDB Operator 1.3.0 Release Notes

--- a/en/releases/release-1.3.1.md
+++ b/en/releases/release-1.3.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.1 Release Notes
 summary: TiDB Operator version 1.3.1 was released on February 24, 2022. The release includes compatibility changes, new features, improvements, and bug fixes. Users must upgrade TiDB Operator to avoid TiFlash losing metadata. A new field `spec.dnsPolicy` was added to support configuring `DNSPolicy` for Pods. The `tidb-lightning` Helm chart now uses `local` backend as the default backend. Bug fixes include issues with TiFlash losing metadata and not working if certain fields are not set in TiFlash's config, as well as TiDB cluster's PD components failing to start due to discovery service errors.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.1/','/tidb-in-kubernetes/v1.3/release-1.3.1/','/tidb-in-kubernetes/v1.4/release-1.3.1/','/tidb-in-kubernetes/v1.5/release-1.3.1/','/tidb-in-kubernetes/v1.6/release-1.3.1/','/tidb-in-kubernetes/v2.0/release-1.3.1/']
 ---
 
 # TiDB Operator 1.3.1 Release Notes

--- a/en/releases/release-1.3.10.md
+++ b/en/releases/release-1.3.10.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.10 Release Notes
 summary: TiDB Operator 1.3.10 was released on February 24, 2023. The new version includes an improvement to bump the Go version to 1.19 in order to fix security vulnerabilities.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.10/','/tidb-in-kubernetes/v1.3/release-1.3.10/','/tidb-in-kubernetes/v1.4/release-1.3.10/','/tidb-in-kubernetes/v1.5/release-1.3.10/','/tidb-in-kubernetes/v1.6/release-1.3.10/','/tidb-in-kubernetes/v2.0/release-1.3.10/']
 ---
 
 # TiDB Operator 1.3.10 Release Notes

--- a/en/releases/release-1.3.2.md
+++ b/en/releases/release-1.3.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.2 Release Notes
 summary: TiDB Operator 1.3.2 was released on March 18, 2022. The improvements include support for TiDB to run on Istio-enabled Kubernetes clusters and support for multi-arch docker image.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.2/','/tidb-in-kubernetes/v1.3/release-1.3.2/','/tidb-in-kubernetes/v1.4/release-1.3.2/','/tidb-in-kubernetes/v1.5/release-1.3.2/','/tidb-in-kubernetes/v1.6/release-1.3.2/','/tidb-in-kubernetes/v2.0/release-1.3.2/']
 ---
 
 # TiDB Operator 1.3.2 Release Notes

--- a/en/releases/release-1.3.3.md
+++ b/en/releases/release-1.3.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.3 Release Notes
 summary: TiDB Operator 1.3.3 was released on May 17, 2022. The new feature includes adding a new field to customize the tidb service port. Several bug fixes were made, including fixing issues with leader scheduler leakage, incompatibility with ARM architecture, panic when tidb Service has no Endpoints, and loss of Labels and Annotations after TiDB Operator fails to access the Kubernetes server.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.3/','/tidb-in-kubernetes/v1.3/release-1.3.3/','/tidb-in-kubernetes/v1.4/release-1.3.3/','/tidb-in-kubernetes/v1.5/release-1.3.3/','/tidb-in-kubernetes/v1.6/release-1.3.3/','/tidb-in-kubernetes/v2.0/release-1.3.3/']
 ---
 
 # TiDB Operator 1.3.3 Release Notes

--- a/en/releases/release-1.3.4.md
+++ b/en/releases/release-1.3.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.4 Release Notes
 summary: TiDB Operator 1.3.4 was released on June 22, 2022. The improvement in this version includes adding the 'volumes' field in the status information of each component to display the volume status.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.4/','/tidb-in-kubernetes/v1.3/release-1.3.4/','/tidb-in-kubernetes/v1.4/release-1.3.4/','/tidb-in-kubernetes/v1.5/release-1.3.4/','/tidb-in-kubernetes/v1.6/release-1.3.4/','/tidb-in-kubernetes/v2.0/release-1.3.4/']
 ---
 
 # TiDB Operator 1.3.4 Release Notes

--- a/en/releases/release-1.3.5.md
+++ b/en/releases/release-1.3.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.5 Release Notes
 summary: TiDB Operator 1.3.5 was released on June 29, 2022. The new feature includes support for backing up and restoring data from Azure Blob Storage.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.5/','/tidb-in-kubernetes/v1.3/release-1.3.5/','/tidb-in-kubernetes/v1.4/release-1.3.5/','/tidb-in-kubernetes/v1.5/release-1.3.5/','/tidb-in-kubernetes/v1.6/release-1.3.5/','/tidb-in-kubernetes/v2.0/release-1.3.5/']
 ---
 
 # TiDB Operator 1.3.5 Release Notes

--- a/en/releases/release-1.3.6.md
+++ b/en/releases/release-1.3.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.6 Release Notes
 summary: TiDB Operator 1.3.6 was released on July 5, 2022. The improvement in this version includes reducing the impact of PVC scale-up on cluster performance by scaling up PVCs pod by pod and evicting TiKV leader before resizing PVCs of TiKV.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.6/','/tidb-in-kubernetes/v1.3/release-1.3.6/','/tidb-in-kubernetes/v1.4/release-1.3.6/','/tidb-in-kubernetes/v1.5/release-1.3.6/','/tidb-in-kubernetes/v1.6/release-1.3.6/','/tidb-in-kubernetes/v2.0/release-1.3.6/']
 ---
 
 # TiDB Operator 1.3.6 Release Notes

--- a/en/releases/release-1.3.7.md
+++ b/en/releases/release-1.3.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.7 Release Notes
 summary: TiDB Operator 1.3.7 was released on August 1, 2022. The new features include the addition of the `suspendAction` field to suspend any component. Improvements include recreating the `StatefulSet` of a component after PVCs are scaled up and continuing scale-up if a leader eviction times out. Bug fixes address issues with TiKV upgrades when using local storage and potential backup file leaks after cleanup.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.7/','/tidb-in-kubernetes/v1.3/release-1.3.7/','/tidb-in-kubernetes/v1.4/release-1.3.7/','/tidb-in-kubernetes/v1.5/release-1.3.7/','/tidb-in-kubernetes/v1.6/release-1.3.7/','/tidb-in-kubernetes/v2.0/release-1.3.7/']
 ---
 
 # TiDB Operator 1.3.7 Release Notes

--- a/en/releases/release-1.3.8.md
+++ b/en/releases/release-1.3.8.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.8 Release Notes
 summary: TiDB Operator 1.3.8 was released on September 13, 2022. The new feature includes special annotations for TidbCluster to configure the minimum ready duration for TiDB, TiKV, and TiFlash. The minimum ready duration specifies the minimum number of seconds that a newly created Pod takes to be ready during a rolling upgrade. An improvement is the support for graceful upgrade of a TiCDC Pod if the Pod version is v6.3.0 or later versions.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.8/','/tidb-in-kubernetes/v1.3/release-1.3.8/','/tidb-in-kubernetes/v1.4/release-1.3.8/','/tidb-in-kubernetes/v1.5/release-1.3.8/','/tidb-in-kubernetes/v1.6/release-1.3.8/','/tidb-in-kubernetes/v2.0/release-1.3.8/']
 ---
 
 # TiDB Operator 1.3.8 Release Notes

--- a/en/releases/release-1.3.9.md
+++ b/en/releases/release-1.3.9.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.9 Release Notes
 summary: TiDB Operator 1.3.9 was released on October 10, 2022. This version includes a bug fix for the issue that PD upgrade would get stuck if the `acrossK8s` field is set but the `clusterDomain` field is not set.
+aliases: ['/tidb-in-kubernetes/dev/release-1.3.9/','/tidb-in-kubernetes/v1.3/release-1.3.9/','/tidb-in-kubernetes/v1.4/release-1.3.9/','/tidb-in-kubernetes/v1.5/release-1.3.9/','/tidb-in-kubernetes/v1.6/release-1.3.9/','/tidb-in-kubernetes/v2.0/release-1.3.9/']
 ---
 
 # TiDB Operator 1.3.9 Release Notes

--- a/en/releases/release-1.4.0-alpha.1.md
+++ b/en/releases/release-1.4.0-alpha.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-alpha.1 Release Notes
 summary: TiDB Operator 1.4.0-alpha.1 was released on September 26, 2022. Changes include disabling volume modification by default, rolling update changes for TiCDC, and new features such as setting location labels for tidb-server and scaling multiple TiFlash and TiKV Pods simultaneously. Improvements include optimizing prometheus remoteWrite configuration for TidbMonitor and adding metrics port for TiFlash Service. Bug fixes address issues with cluster sync getting stuck and TiDB Operator panicking if PD spec is nil.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.0-alpha.1/','/tidb-in-kubernetes/v1.3/release-1.4.0-alpha.1/','/tidb-in-kubernetes/v1.4/release-1.4.0-alpha.1/','/tidb-in-kubernetes/v1.5/release-1.4.0-alpha.1/','/tidb-in-kubernetes/v1.6/release-1.4.0-alpha.1/','/tidb-in-kubernetes/v2.0/release-1.4.0-alpha.1/']
 ---
 
 # TiDB Operator 1.4.0-alpha.1 Release Notes

--- a/en/releases/release-1.4.0-beta.1.md
+++ b/en/releases/release-1.4.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-beta.1 Release Notes
 summary: TiDB Operator 1.4.0-beta.1 was released on October 27, 2022. The new feature includes support for snapshot backup and restore based on Amazon EBS, with benefits such as reducing the impact of backup on QPS to less than 5% and shortening the backup and restore time. Bug fixes include updating the log backup checkpoint ts after TiDB Operator restarts and when TLS is enabled for the TiDB cluster.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.4.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.4.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.4.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.4.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.4.0-beta.1/']
 ---
 
 # TiDB Operator 1.4.0-beta.1 Release Notes

--- a/en/releases/release-1.4.0-beta.2.md
+++ b/en/releases/release-1.4.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-beta.2 Release Notes
 summary: TiDB Operator 1.4.0-beta.2 was released on November 11, 2022. Bug fixes include an issue with `BackupSchedule` not setting a prefix when using Azure Blob Storage and an upgrade of AWS SDK to v1.44.72 to support the Asia Pacific (Jakarta) region.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.0-beta.2/','/tidb-in-kubernetes/v1.3/release-1.4.0-beta.2/','/tidb-in-kubernetes/v1.4/release-1.4.0-beta.2/','/tidb-in-kubernetes/v1.5/release-1.4.0-beta.2/','/tidb-in-kubernetes/v1.6/release-1.4.0-beta.2/','/tidb-in-kubernetes/v2.0/release-1.4.0-beta.2/']
 ---
 
 # TiDB Operator 1.4.0-beta.2 Release Notes

--- a/en/releases/release-1.4.0-beta.3.md
+++ b/en/releases/release-1.4.0-beta.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-beta.3 Release Notes
 summary: TiDB Operator 1.4.0-beta.3 was released on December 2, 2022. The new features include experimental support for TiProxy and GA for snapshot backup and restore based on Amazon EBS. The release also includes bug fixes for error messages, volume-snapshot backup cleanup failure, and backup failure with massive TiKV nodes.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.0-beta.3/','/tidb-in-kubernetes/v1.3/release-1.4.0-beta.3/','/tidb-in-kubernetes/v1.4/release-1.4.0-beta.3/','/tidb-in-kubernetes/v1.5/release-1.4.0-beta.3/','/tidb-in-kubernetes/v1.6/release-1.4.0-beta.3/','/tidb-in-kubernetes/v2.0/release-1.4.0-beta.3/']
 ---
 
 # TiDB Operator 1.4.0-beta.3 Release Notes

--- a/en/releases/release-1.4.0.md
+++ b/en/releases/release-1.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0 Release Notes
 summary: TiDB Operator 1.4.0 was released on December 29, 2022. New features include support for managing TiDB Dashboard in a separate CRD, configuring Readiness Probe for TiKV and PD, and backup and restore based on Amazon EBS volume-snapshot. Bug fixes address issues with backup based on EBS snapshot and log backup stopping in the Complete state.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.0/','/tidb-in-kubernetes/v1.3/release-1.4.0/','/tidb-in-kubernetes/v1.4/release-1.4.0/','/tidb-in-kubernetes/v1.5/release-1.4.0/','/tidb-in-kubernetes/v1.6/release-1.4.0/','/tidb-in-kubernetes/v2.0/release-1.4.0/']
 ---
 
 # TiDB Operator 1.4.0 Release Notes

--- a/en/releases/release-1.4.1.md
+++ b/en/releases/release-1.4.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.1 Release Notes
 summary: TiDB Operator 1.4.1 was released on January 13, 2023. New features include support for cleaning up failed instances of PD, TiKV, and TiFlash components. Improvements include support for configuring QPS and Burst for the Kubernetes client. Bug fixes address the issue of TiDB Controller Manager panicking without PV permission.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.1/','/tidb-in-kubernetes/v1.3/release-1.4.1/','/tidb-in-kubernetes/v1.4/release-1.4.1/','/tidb-in-kubernetes/v1.5/release-1.4.1/','/tidb-in-kubernetes/v1.6/release-1.4.1/','/tidb-in-kubernetes/v2.0/release-1.4.1/']
 ---
 
 # TiDB Operator 1.4.1 Release Notes

--- a/en/releases/release-1.4.2.md
+++ b/en/releases/release-1.4.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.2 Release Notes
 summary: TiDB Operator 1.4.2 was released on February 3, 2023. This version fixed the issue where TiFlash does not listen on IPv6 addresses when the `preferIPv6` configuration is enabled.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.2/','/tidb-in-kubernetes/v1.3/release-1.4.2/','/tidb-in-kubernetes/v1.4/release-1.4.2/','/tidb-in-kubernetes/v1.5/release-1.4.2/','/tidb-in-kubernetes/v1.6/release-1.4.2/','/tidb-in-kubernetes/v2.0/release-1.4.2/']
 ---
 
 # TiDB Operator 1.4.2 Release Notes

--- a/en/releases/release-1.4.3.md
+++ b/en/releases/release-1.4.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.3 Release Notes
 summary: TiDB Operator version 1.4.3 was released on February 24, 2023. Bug fixes include resolving the TiFlash metric server not listening on correct IPv6 addresses when the `preferIPv6` configuration is enabled, and fixing the issue of TiDB Operator continuously modifying EBS disks in AWS when the feature gate `VolumeModifying` is enabled and EBS parameters are missing in `StorageClass`.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.3/','/tidb-in-kubernetes/v1.3/release-1.4.3/','/tidb-in-kubernetes/v1.4/release-1.4.3/','/tidb-in-kubernetes/v1.5/release-1.4.3/','/tidb-in-kubernetes/v1.6/release-1.4.3/','/tidb-in-kubernetes/v2.0/release-1.4.3/']
 ---
 
 # TiDB Operator 1.4.3 Release Notes

--- a/en/releases/release-1.4.4.md
+++ b/en/releases/release-1.4.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.4 Release Notes
 summary: TiDB Operator 1.4.4 released on March 13, 2023. New features include support for volume-snapshot backup and restore on TiDB cluster with TiFlash, accurate backup size display, retries for snapshot backups, and integrated management of log and snapshot backups. Bug fixes address sync failure with custom TiDB builds, volume-snapshot backup data restoration, panic during snapshot backup, and potential failure during restore.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.4/','/tidb-in-kubernetes/v1.3/release-1.4.4/','/tidb-in-kubernetes/v1.4/release-1.4.4/','/tidb-in-kubernetes/v1.5/release-1.4.4/','/tidb-in-kubernetes/v1.6/release-1.4.4/','/tidb-in-kubernetes/v2.0/release-1.4.4/']
 ---
 
 # TiDB Operator 1.4.4 Release Notes

--- a/en/releases/release-1.4.5.md
+++ b/en/releases/release-1.4.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.5 Release Notes
 summary: TiDB Operator 1.4.5 was released on June 26, 2023. The improvements include adding metrics for TidbCluster reconcile errors, reconciler and worker queue observability, introducing `startUpScriptVersion` field for DM master, and support for rolling restart and scaling-in of TiCDC clusters. Bug fixes include suppressing GC for newly created scheduled backups, making `backupTemplate` optional in backup CR, and fixing issues related to Kubernetes cluster-level permission and `AdditionalVolumeMounts` for TidbCluster.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.5/','/tidb-in-kubernetes/v1.3/release-1.4.5/','/tidb-in-kubernetes/v1.4/release-1.4.5/','/tidb-in-kubernetes/v1.5/release-1.4.5/','/tidb-in-kubernetes/v1.6/release-1.4.5/','/tidb-in-kubernetes/v2.0/release-1.4.5/']
 ---
 
 # TiDB Operator 1.4.5 Release Notes

--- a/en/releases/release-1.4.6.md
+++ b/en/releases/release-1.4.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.6 Release Notes
 summary: TiDB Operator 1.4.6 was released on July 19, 2023. The improvements include enabling volume resizing by default. Bug fixes address issues with executing backup and restore with BR >=v6.6.0 and the graceful drain for TiCDC when a non-SemVer image tag is used.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.6/','/tidb-in-kubernetes/v1.3/release-1.4.6/','/tidb-in-kubernetes/v1.4/release-1.4.6/','/tidb-in-kubernetes/v1.5/release-1.4.6/','/tidb-in-kubernetes/v1.6/release-1.4.6/','/tidb-in-kubernetes/v2.0/release-1.4.6/']
 ---
 
 # TiDB Operator 1.4.6 Release Notes

--- a/en/releases/release-1.4.7.md
+++ b/en/releases/release-1.4.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.7 Release Notes
 summary: TiDB Operator 1.4.7 was released on July 26, 2023. This version includes bug fixes, such as making `logBackupTemplate` optional in BackupSchedule CR.
+aliases: ['/tidb-in-kubernetes/dev/release-1.4.7/','/tidb-in-kubernetes/v1.3/release-1.4.7/','/tidb-in-kubernetes/v1.4/release-1.4.7/','/tidb-in-kubernetes/v1.5/release-1.4.7/','/tidb-in-kubernetes/v1.6/release-1.4.7/','/tidb-in-kubernetes/v2.0/release-1.4.7/']
 ---
 
 # TiDB Operator 1.4.7 Release Notes

--- a/en/releases/release-1.5.0-beta.1.md
+++ b/en/releases/release-1.5.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.0-beta.1 Release Notes
 summary: TiDB Operator 1.5.0-beta.1 was released on April 11, 2023. The new features include support for graceful restart of PD and TiDB Pods, managing TiCDC and TiProxy with Advanced StatefulSet, and defining a strategy to restart failed backup jobs. Improvements include upgrading Kubernetes dependencies, adding metrics for observability, and customizing Prometheus scraping settings. Bug fixes address the issue of unreachable pprof endpoint due to route conflicts with the metrics endpoint.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.5.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.5.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.5.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.5.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.5.0-beta.1/']
 ---
 
 # TiDB Operator 1.5.0-beta.1 Release Notes

--- a/en/releases/release-1.5.0.md
+++ b/en/releases/release-1.5.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.0 Release Notes
 summary: Learn about new features, improvements, and bug fixes in TiDB Operator 1.5.0.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.0/','/tidb-in-kubernetes/v1.3/release-1.5.0/','/tidb-in-kubernetes/v1.4/release-1.5.0/','/tidb-in-kubernetes/v1.5/release-1.5.0/','/tidb-in-kubernetes/v1.6/release-1.5.0/','/tidb-in-kubernetes/v2.0/release-1.5.0/']
 ---
 
 # TiDB Operator 1.5.0 Release Notes

--- a/en/releases/release-1.5.1.md
+++ b/en/releases/release-1.5.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.1 Release Notes
 summary: TiDB Operator 1.5.1 was released on October 20, 2023. The new feature includes support for replacing volumes for PD, TiKV, and TiDB. Bug fixes include resolving errors from PVC modifier during manual TiKV eviction, fixing deadlock issues caused by TiKV eviction during volume replacement, addressing TidbCluster rollback during the upgrade process, and resolving the issue with the `MaxReservedTime` option for scheduled backup.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.1/','/tidb-in-kubernetes/v1.3/release-1.5.1/','/tidb-in-kubernetes/v1.4/release-1.5.1/','/tidb-in-kubernetes/v1.5/release-1.5.1/','/tidb-in-kubernetes/v1.6/release-1.5.1/','/tidb-in-kubernetes/v2.0/release-1.5.1/']
 ---
 
 # TiDB Operator 1.5.1 Release Notes

--- a/en/releases/release-1.5.2.md
+++ b/en/releases/release-1.5.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.2 Release Notes
 summary: TiDB Operator 1.5.2 released on January 19, 2024. New features include support for backing up and restoring data of a TiDB cluster across multiple AWS Kubernetes clusters to AWS storage using EBS volume snapshots. Improvements include better support for scenarios such as Stale Read and explicitly specifying PD addresses. Bug fixes address issues with changing meta information and PD member labels.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.2/','/tidb-in-kubernetes/v1.3/release-1.5.2/','/tidb-in-kubernetes/v1.4/release-1.5.2/','/tidb-in-kubernetes/v1.5/release-1.5.2/','/tidb-in-kubernetes/v1.6/release-1.5.2/','/tidb-in-kubernetes/v2.0/release-1.5.2/']
 ---
 
 # TiDB Operator 1.5.2 Release Notes

--- a/en/releases/release-1.5.3.md
+++ b/en/releases/release-1.5.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.3 Release Notes
 summary: Learn about new features and bug fixes in TiDB Operator 1.5.3.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.3/','/tidb-in-kubernetes/v1.3/release-1.5.3/','/tidb-in-kubernetes/v1.4/release-1.5.3/','/tidb-in-kubernetes/v1.5/release-1.5.3/','/tidb-in-kubernetes/v1.6/release-1.5.3/','/tidb-in-kubernetes/v2.0/release-1.5.3/']
 ---
 
 # TiDB Operator 1.5.3 Release Notes

--- a/en/releases/release-1.5.4.md
+++ b/en/releases/release-1.5.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.4 Release Notes
 summary: Learn about improvements and bug fixes in TiDB Operator 1.5.4.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.4/','/tidb-in-kubernetes/v1.3/release-1.5.4/','/tidb-in-kubernetes/v1.4/release-1.5.4/','/tidb-in-kubernetes/v1.5/release-1.5.4/','/tidb-in-kubernetes/v1.6/release-1.5.4/','/tidb-in-kubernetes/v2.0/release-1.5.4/']
 ---
 
 # TiDB Operator 1.5.4 Release Notes

--- a/en/releases/release-1.5.5.md
+++ b/en/releases/release-1.5.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.5 Release Notes
 summary: Learn about new features and improvements in TiDB Operator 1.5.5.
+aliases: ['/tidb-in-kubernetes/dev/release-1.5.5/','/tidb-in-kubernetes/v1.3/release-1.5.5/','/tidb-in-kubernetes/v1.4/release-1.5.5/','/tidb-in-kubernetes/v1.5/release-1.5.5/','/tidb-in-kubernetes/v1.6/release-1.5.5/','/tidb-in-kubernetes/v2.0/release-1.5.5/']
 ---
 
 # TiDB Operator 1.5.5 Release Notes

--- a/en/releases/release-1.6.0-beta.1.md
+++ b/en/releases/release-1.6.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.0-beta.1 Release Notes
 summary: Learn about new features, improvements, and bug fixes in TiDB Operator 1.6.0-beta.1.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.0-beta.1/','/tidb-in-kubernetes/v1.3/release-1.6.0-beta.1/','/tidb-in-kubernetes/v1.4/release-1.6.0-beta.1/','/tidb-in-kubernetes/v1.5/release-1.6.0-beta.1/','/tidb-in-kubernetes/v1.6/release-1.6.0-beta.1/','/tidb-in-kubernetes/v2.0/release-1.6.0-beta.1/']
 ---
 
 # TiDB Operator 1.6.0-beta.1 Release Notes

--- a/en/releases/release-1.6.0.md
+++ b/en/releases/release-1.6.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.0 Release Notes
 summary: Learn about new features, improvements, and bug fixes in TiDB Operator 1.6.0.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.0/','/tidb-in-kubernetes/v1.3/release-1.6.0/','/tidb-in-kubernetes/v1.4/release-1.6.0/','/tidb-in-kubernetes/v1.5/release-1.6.0/','/tidb-in-kubernetes/v1.6/release-1.6.0/','/tidb-in-kubernetes/v2.0/release-1.6.0/']
 ---
 
 # TiDB Operator 1.6.0 Release Notes

--- a/en/releases/release-1.6.1.md
+++ b/en/releases/release-1.6.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.1 Release Notes
 summary: Learn about new features, improvements, and bug fixes in TiDB Operator 1.6.1.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.1/','/tidb-in-kubernetes/v1.3/release-1.6.1/','/tidb-in-kubernetes/v1.4/release-1.6.1/','/tidb-in-kubernetes/v1.5/release-1.6.1/','/tidb-in-kubernetes/v1.6/release-1.6.1/','/tidb-in-kubernetes/v2.0/release-1.6.1/']
 ---
 
 # TiDB Operator 1.6.1 Release Notes

--- a/en/releases/release-1.6.2.md
+++ b/en/releases/release-1.6.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.2 Release Notes
 summary: Learn about new features, improvements, and bug fixes in TiDB Operator 1.6.2.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.2/','/tidb-in-kubernetes/v1.3/release-1.6.2/','/tidb-in-kubernetes/v1.4/release-1.6.2/','/tidb-in-kubernetes/v1.5/release-1.6.2/','/tidb-in-kubernetes/v1.6/release-1.6.2/','/tidb-in-kubernetes/v2.0/release-1.6.2/']
 ---
 
 # TiDB Operator 1.6.2 Release Notes

--- a/en/releases/release-1.6.3.md
+++ b/en/releases/release-1.6.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.3 Release Notes
 summary: Learn about bug fixes in TiDB Operator 1.6.3.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.3/','/tidb-in-kubernetes/v1.3/release-1.6.3/','/tidb-in-kubernetes/v1.4/release-1.6.3/','/tidb-in-kubernetes/v1.5/release-1.6.3/','/tidb-in-kubernetes/v1.6/release-1.6.3/','/tidb-in-kubernetes/v2.0/release-1.6.3/']
 ---
 
 # TiDB Operator 1.6.3 Release Notes

--- a/en/releases/release-1.6.4.md
+++ b/en/releases/release-1.6.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.4 Release Notes
 summary: Learn about new features in TiDB Operator 1.6.4.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.4/','/tidb-in-kubernetes/v1.3/release-1.6.4/','/tidb-in-kubernetes/v1.4/release-1.6.4/','/tidb-in-kubernetes/v1.5/release-1.6.4/','/tidb-in-kubernetes/v1.6/release-1.6.4/','/tidb-in-kubernetes/v2.0/release-1.6.4/']
 ---
 
 # TiDB Operator 1.6.4 Release Notes

--- a/en/releases/release-1.6.5.md
+++ b/en/releases/release-1.6.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.5 Release Notes
 summary: Learn about new features, improvements, and bug fixes in TiDB Operator 1.6.5.
+aliases: ['/tidb-in-kubernetes/dev/release-1.6.5/','/tidb-in-kubernetes/v1.3/release-1.6.5/','/tidb-in-kubernetes/v1.4/release-1.6.5/','/tidb-in-kubernetes/v1.5/release-1.6.5/','/tidb-in-kubernetes/v1.6/release-1.6.5/','/tidb-in-kubernetes/v2.0/release-1.6.5/']
 ---
 
 # TiDB Operator 1.6.5 Release Notes

--- a/en/releases/release-2.0.0-beta.0.md
+++ b/en/releases/release-2.0.0-beta.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 2.0.0-beta.0 Release Notes
 summary: TiDB Operator 2.0.0-beta.0 is released. The v2 version introduces major refactoring from v1, with key changes including splitting the `TidbCluster` CRD into multiple CRDs, removing the dependency on StatefulSet, and introducing the Overlay feature for more flexible custom configurations.
+aliases: ['/tidb-in-kubernetes/dev/release-2.0.0-beta.0/','/tidb-in-kubernetes/v1.3/release-2.0.0-beta.0/','/tidb-in-kubernetes/v1.4/release-2.0.0-beta.0/','/tidb-in-kubernetes/v1.5/release-2.0.0-beta.0/','/tidb-in-kubernetes/v1.6/release-2.0.0-beta.0/','/tidb-in-kubernetes/v2.0/release-2.0.0-beta.0/']
 ---
 
 # TiDB Operator 2.0.0-beta.0 Release Notes

--- a/en/releases/release-2.0.0.md
+++ b/en/releases/release-2.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 2.0.0 Release Notes
 summary: TiDB Operator 2.0.0 is released. The v2 version introduces major refactoring from v1, with key changes including splitting the `TidbCluster` CRD into multiple CRDs, removing the dependency on StatefulSet, and introducing the Overlay feature for more flexible custom configurations.
+aliases: ['/tidb-in-kubernetes/dev/release-2.0.0/','/tidb-in-kubernetes/v1.3/release-2.0.0/','/tidb-in-kubernetes/v1.4/release-2.0.0/','/tidb-in-kubernetes/v1.5/release-2.0.0/','/tidb-in-kubernetes/v1.6/release-2.0.0/','/tidb-in-kubernetes/v2.0/release-2.0.0/']
 ---
 
 # TiDB Operator 2.0.0 Release Notes

--- a/zh/releases/release-0.1.0.md
+++ b/zh/releases/release-0.1.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.1.0 Release Notes
 summary: TiDB Operator 0.1.0 was released on August 22, 2018. Notable changes include the ability to bootstrap multiple TiDB clusters, support for monitoring deployment and Helm charts, basic Network PV/Local PV support, safe scaling of the TiDB cluster, orderly cluster upgrades, and stopping the TiDB process without terminating the Pod. Additionally, cluster meta info can be synchronized to POD/PV/PVC labels, and basic unit tests & E2E tests are available. Tutorials for GKE and local DinD are also provided.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-0.1.0/','/zh/tidb-in-kubernetes/v1.3/release-0.1.0/','/zh/tidb-in-kubernetes/v1.4/release-0.1.0/','/zh/tidb-in-kubernetes/v1.5/release-0.1.0/','/zh/tidb-in-kubernetes/v1.6/release-0.1.0/','/zh/tidb-in-kubernetes/v2.0/release-0.1.0/']
 ---
 
 # TiDB Operator 0.1.0 Release Notes

--- a/zh/releases/release-0.2.0.md
+++ b/zh/releases/release-0.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.2.0 Release Notes
 summary: TiDB Operator 0.2.0 was released on September 11, 2018. Notable changes include experimental support for auto-failover, unification of Tiller and TiDB Operator managed resources labels, managing TiDB service via Tiller, adding toleration for TiDB cluster components, and refactoring upgrade functions as interface. Additionally, a script for easy setup of DinD environment was added, and code was linted and formatted in CI.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-0.2.0/','/zh/tidb-in-kubernetes/v1.3/release-0.2.0/','/zh/tidb-in-kubernetes/v1.4/release-0.2.0/','/zh/tidb-in-kubernetes/v1.5/release-0.2.0/','/zh/tidb-in-kubernetes/v1.6/release-0.2.0/','/zh/tidb-in-kubernetes/v2.0/release-0.2.0/']
 ---
 
 # TiDB Operator 0.2.0 Release Notes

--- a/zh/releases/release-0.2.1.md
+++ b/zh/releases/release-0.2.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.2.1 Release Notes
 summary: TiDB Operator 0.2.1 was released on September 20, 2018. This version includes bug fixes for retry on conflict logic, TiDB timezone configuration, failover, and repeated updating of pod and pd/tidb StatefulSet.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-0.2.1/','/zh/tidb-in-kubernetes/v1.3/release-0.2.1/','/zh/tidb-in-kubernetes/v1.4/release-0.2.1/','/zh/tidb-in-kubernetes/v1.5/release-0.2.1/','/zh/tidb-in-kubernetes/v1.6/release-0.2.1/','/zh/tidb-in-kubernetes/v2.0/release-0.2.1/']
 ---
 
 # TiDB Operator 0.2.1 Release Notes

--- a/zh/releases/release-0.3.0.md
+++ b/zh/releases/release-0.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.3.0 Release Notes
 summary: TiDB Operator 0.3.0 was released on October 12, 2018. Notable changes include the addition of full backup support, TiDB Binlog support, graceful upgrade feature, and the ability to persist monitor data.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-0.3.0/','/zh/tidb-in-kubernetes/v1.3/release-0.3.0/','/zh/tidb-in-kubernetes/v1.4/release-0.3.0/','/zh/tidb-in-kubernetes/v1.5/release-0.3.0/','/zh/tidb-in-kubernetes/v1.6/release-0.3.0/','/zh/tidb-in-kubernetes/v2.0/release-0.3.0/']
 ---
 
 # TiDB Operator 0.3.0 Release Notes

--- a/zh/releases/release-0.3.1.md
+++ b/zh/releases/release-0.3.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.3.1 Release Notes
 summary: TiDB Operator 0.3.1 was released on October 31, 2018. The release includes minor changes such as parameterizing the serviceAccount, bumping TiDB to v2.0.7, and allowing user-specified config files. Bug fixes include addressing issues with parallel upgrades, wrong parameters, and recovery after a failed upgrade.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-0.3.1/','/zh/tidb-in-kubernetes/v1.3/release-0.3.1/','/zh/tidb-in-kubernetes/v1.4/release-0.3.1/','/zh/tidb-in-kubernetes/v1.5/release-0.3.1/','/zh/tidb-in-kubernetes/v1.6/release-0.3.1/','/zh/tidb-in-kubernetes/v2.0/release-0.3.1/']
 ---
 
 # TiDB Operator 0.3.1 Release Notes

--- a/zh/releases/release-0.4.0.md
+++ b/zh/releases/release-0.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 0.4 Release Notes
 summary: TiDB Operator 0.4.0 was released on November 9, 2018. Notable changes include extending Kubernetes scheduler for TiDB data awareness, restoring backup data from GCS bucket, and setting password for TiDB when first deployed. Minor changes and bug fixes include updating roadmap, adding unit tests, E2E tests, adding TiDB failover limit, synchronizing PV reclaim policy early, using helm release name as instance label, and fixing local PV setup script.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-0.4.0/','/zh/tidb-in-kubernetes/v1.3/release-0.4.0/','/zh/tidb-in-kubernetes/v1.4/release-0.4.0/','/zh/tidb-in-kubernetes/v1.5/release-0.4.0/','/zh/tidb-in-kubernetes/v1.6/release-0.4.0/','/zh/tidb-in-kubernetes/v2.0/release-0.4.0/']
 ---
 
 # TiDB Operator 0.4 Release Notes

--- a/zh/releases/release-1.0-ga.md
+++ b/zh/releases/release-1.0-ga.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 GA Release Notes
 summary: TiDB Operator 1.0.0 has been released on July 30, 2019. The new version requires action to be taken for configuration changes in `values.yaml`. Stability test cases have been added, along with improvements such as GKE SSD setup simplification and AWS Terraform script modularization. Bug fixes include sysbench installation and TiKV metrics monitoring. Detailed bug fixes and changes include upgrading TiDB monitor, specifying TiKV status address, and enabling nlb cross zone load balancing by default. Multiple TiDB clusters management is now supported in Alibaba Cloud. The default TiDB version has been upgraded to v3.0.1. The release also includes various other bug fixes and improvements.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0-ga/','/zh/tidb-in-kubernetes/v1.3/release-1.0-ga/','/zh/tidb-in-kubernetes/v1.4/release-1.0-ga/','/zh/tidb-in-kubernetes/v1.5/release-1.0-ga/','/zh/tidb-in-kubernetes/v1.6/release-1.0-ga/','/zh/tidb-in-kubernetes/v2.0/release-1.0-ga/']
 ---
 
 # TiDB Operator 1.0 GA Release Notes

--- a/zh/releases/release-1.0.0-beta.0.md
+++ b/zh/releases/release-1.0.0-beta.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.0 Release Notes
 summary: TiDB Operator 1.0 Beta.0 was released on November 26, 2018. Notable changes include the introduction of basic chaos testing, improved unit test coverage, default log-level values for PD/TiKV/TiDB, and various bug fixes and enhancements. The release also includes a user guide and migration to Go 1.11 module.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-beta.0/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-beta.0/']
 ---
 
 # TiDB Operator 1.0 Beta.0 Release Notes

--- a/zh/releases/release-1.0.0-beta.1-p1.md
+++ b/zh/releases/release-1.0.0-beta.1-p1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.1 P1 Release Notes
 summary: TiDB Operator 1.0 Beta.1 P1 was released on January 7, 2019. The bug fixes include resolving scheduler policy issues for Kubernetes v1.10, v1.11, and v1.12. The documentation updates include a proposal to add multiple statefulsets support to TiDB Operator and an updated roadmap.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-beta.1-p1/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-beta.1-p1/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-beta.1-p1/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-beta.1-p1/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-beta.1-p1/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-beta.1-p1/']
 ---
 
 # TiDB Operator 1.0 Beta.1 P1 Release Notes

--- a/zh/releases/release-1.0.0-beta.1-p2.md
+++ b/zh/releases/release-1.0.0-beta.1-p2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.1 P2 Release Notes
 summary: TiDB Operator 1.0 Beta.1 P2 was released on February 21, 2019. Notable changes include a new algorithm for scheduler HA predicate, addition of TiDB discovery service, serial scheduling, change in tolerations type to an array, direct start when there is a join file, addition of code coverage icon, omission of just the empty leaves in `values.yml`, backup to ceph object storage in charts, and addition of `ClusterIDLabelKey` label to TidbCluster.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-beta.1-p2/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-beta.1-p2/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-beta.1-p2/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-beta.1-p2/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-beta.1-p2/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-beta.1-p2/']
 ---
 
 # TiDB Operator 1.0 Beta.1 P2 Release Notes

--- a/zh/releases/release-1.0.0-beta.1.md
+++ b/zh/releases/release-1.0.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.1 Release Notes
 summary: TiDB Operator 1.0 Beta.1 was released on December 27, 2018. The release includes bug fixes such as pd_control bug, orphan pod cleaner, scheduler configuration fix, Grafana configuration fix, and more. Minor improvements include adding Kubernetes 1.12 local DinD scripts, bumping default TiDB to v2.1.0, releasing tidb-operator/tidb-cluster charts, and adding connection timeout for TiDB password setter job. Other improvements involve separating ad-hoc backup and restore to another chart, adding compiler version info to tidb-operator binary, allowing specifying TiDB service LoadBalancer IP, and exposing TiKV cpu/memory related configuration to values.yaml.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-beta.1/']
 ---
 
 # TiDB Operator 1.0 Beta.1 Release Notes

--- a/zh/releases/release-1.0.0-beta.2.md
+++ b/zh/releases/release-1.0.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.2 Release Notes
 summary: TiDB Operator 1.0 Beta.2 has been released on May 10, 2019. The new version includes enhanced stability, improved ease of use, bug fixes, and other improvements. Some of the key changes include refactored e2e test, one-command deployment for AWS and Aliyun, and support for slow log of TiDB. Numerous bug fixes and detailed changes have also been made to improve the overall performance and user experience.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-beta.2/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-beta.2/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-beta.2/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-beta.2/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-beta.2/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-beta.2/']
 ---
 
 # TiDB Operator 1.0 Beta.2 Release Notes

--- a/zh/releases/release-1.0.0-beta.3.md
+++ b/zh/releases/release-1.0.0-beta.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 Beta.3 Release Notes
 summary: TiDB Operator 1.0 Beta.3 was released on June 6, 2019. The new version includes the removal of `nodeSelectorRequired` from values.yaml and the addition of stability cases, new features, documentation improvements, and bug fixes. Some notable new features include ConfigMap rollout management, stable scheduling for pods, and support for adding additional pod annotations. The default TiDB version has been upgraded to v3.0.0-rc.1, and various bug fixes and changes have been implemented.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-beta.3/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-beta.3/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-beta.3/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-beta.3/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-beta.3/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-beta.3/']
 ---
 
 # TiDB Operator 1.0 Beta.3 Release Notes

--- a/zh/releases/release-1.0.0-rc.1.md
+++ b/zh/releases/release-1.0.0-rc.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0 RC.1 Release Notes
 summary: TiDB Operator 1.0 RC.1 was released on July 12, 2019. The new version includes stability test cases, improvements such as increasing TiKV GC life time, and bug fixes like fixing unbound variables in the backup script and scheduled backup bugs. It also supports force upgrade when PD cluster is unavailable and adds Amazon S3 support for backup/restore features. Multiple clusters management in EKS and local SSD provision for COS on GKE are also included. The release notes contain detailed bug fixes and changes, including various pull requests for bug fixes and improvements.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.0-rc.1/','/zh/tidb-in-kubernetes/v1.3/release-1.0.0-rc.1/','/zh/tidb-in-kubernetes/v1.4/release-1.0.0-rc.1/','/zh/tidb-in-kubernetes/v1.5/release-1.0.0-rc.1/','/zh/tidb-in-kubernetes/v1.6/release-1.0.0-rc.1/','/zh/tidb-in-kubernetes/v2.0/release-1.0.0-rc.1/']
 ---
 
 # TiDB Operator 1.0 RC.1 Release Notes

--- a/zh/releases/release-1.0.1.md
+++ b/zh/releases/release-1.0.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.1 Release Notes
 summary: TiDB Operator version 1.0.1 was released on September 17, 2019. The release includes important bug fixes and improvements. Users of version 1.0.0 or prior must upgrade to avoid potential service outage. The backup tool image has been updated to fix a serious bug. Other improvements include modularizing GCP Terraform, adding support for various configurations, and reducing e2e run time. Bug fixes address issues such as TiKV scale-in failure, orphan pods cleaner bugs, and incorrect condition judgment. The release also includes detailed bug fixes and changes.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.1/','/zh/tidb-in-kubernetes/v1.3/release-1.0.1/','/zh/tidb-in-kubernetes/v1.4/release-1.0.1/','/zh/tidb-in-kubernetes/v1.5/release-1.0.1/','/zh/tidb-in-kubernetes/v1.6/release-1.0.1/','/zh/tidb-in-kubernetes/v2.0/release-1.0.1/']
 ---
 
 # TiDB Operator 1.0.1 Release Notes

--- a/zh/releases/release-1.0.2.md
+++ b/zh/releases/release-1.0.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.2 Release Notes
 summary: TiDB Operator version 1.0.2 was released on November 1, 2019. The new version includes improvements such as suspending the ReplaceUnhealthy process for AWS TiKV auto-scaling-group, adding a new VM manager 'qm' in stability test, and setting default externalTrafficPolicy to 'Local' for TiDB service in AWS/GCP/Aliyun. Bug fixes include issues with tkctl version, create_tidb_cluster_release variable in AWS Terraform script, and compatibility issues with Kubernetes 1.16 and above versions. Other fixes and changes are also included in this release.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.2/','/zh/tidb-in-kubernetes/v1.3/release-1.0.2/','/zh/tidb-in-kubernetes/v1.4/release-1.0.2/','/zh/tidb-in-kubernetes/v1.5/release-1.0.2/','/zh/tidb-in-kubernetes/v1.6/release-1.0.2/','/zh/tidb-in-kubernetes/v2.0/release-1.0.2/']
 ---
 
 # TiDB Operator 1.0.2 Release Notes

--- a/zh/releases/release-1.0.3.md
+++ b/zh/releases/release-1.0.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.3 Release Notes
 summary: TiDB Operator version 1.0.3 was released on November 13, 2019. The new version requires an upgrade to TiDB v3.0.5 and adds timezone support for all charts. Existing TiDB clusters with customized timezones will trigger a rolling update. Improvements include timezone support and configuring resource requests and limits for all containers of the TiDB cluster. Bug fixes include upgrading default TiDB version to v3.0.5 and adding timezone support for all containers of the TiDB cluster.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.3/','/zh/tidb-in-kubernetes/v1.3/release-1.0.3/','/zh/tidb-in-kubernetes/v1.4/release-1.0.3/','/zh/tidb-in-kubernetes/v1.5/release-1.0.3/','/zh/tidb-in-kubernetes/v1.6/release-1.0.3/','/zh/tidb-in-kubernetes/v2.0/release-1.0.3/']
 ---
 
 # TiDB Operator 1.0.3 Release Notes

--- a/zh/releases/release-1.0.4.md
+++ b/zh/releases/release-1.0.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.4 Release Notes
 summary: TiDB Operator version 1.0.4 was released on November 23, 2019. The new version introduces HostNetwork support for better performance, podSecurityContext support, and new Helm charts for TiDB Lightning and TiDB Binlog. It also includes bug fixes and changes. Users of the v1.1.0.alpha branch are advised to upgrade to v1.0.4, as it includes all fixes from the alpha branch and introduces additional improvements.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.4/','/zh/tidb-in-kubernetes/v1.3/release-1.0.4/','/zh/tidb-in-kubernetes/v1.4/release-1.0.4/','/zh/tidb-in-kubernetes/v1.5/release-1.0.4/','/zh/tidb-in-kubernetes/v1.6/release-1.0.4/','/zh/tidb-in-kubernetes/v2.0/release-1.0.4/']
 ---
 
 # TiDB Operator 1.0.4 Release Notes

--- a/zh/releases/release-1.0.5.md
+++ b/zh/releases/release-1.0.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.5 Release Notes
 summary: TiDB Operator version 1.0.5 was released on December 11, 2019. The new features include fixing backup failure issue, recommending deployment of TiDB and Pump on the same node, fixing RBAC permission, and resolving e2e nil point dereference. No action is required for upgrading from v1.0.4.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.5/','/zh/tidb-in-kubernetes/v1.3/release-1.0.5/','/zh/tidb-in-kubernetes/v1.4/release-1.0.5/','/zh/tidb-in-kubernetes/v1.5/release-1.0.5/','/zh/tidb-in-kubernetes/v1.6/release-1.0.5/','/zh/tidb-in-kubernetes/v2.0/release-1.0.5/']
 ---
 
 # TiDB Operator 1.0.5 Release Notes

--- a/zh/releases/release-1.0.6.md
+++ b/zh/releases/release-1.0.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.6 Release Notes
 summary: TiDB Operator 1.0.6 was released on December 27, 2019. Users need to migrate configs from the old `values.yaml` to the new one to avoid monitor pod failures. The new release includes improvements in monitor, TiDB Scheduler, compatibility, TiKV Importer, E2E, and CI. Notable changes include enabling alert rule persistence, adding node & pod info in TiDB Grafana, refining scheduler error messages, fixing compatibility issues in Kubernetes v1.17, and adjusting the release CI script.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.6/','/zh/tidb-in-kubernetes/v1.3/release-1.0.6/','/zh/tidb-in-kubernetes/v1.4/release-1.0.6/','/zh/tidb-in-kubernetes/v1.5/release-1.0.6/','/zh/tidb-in-kubernetes/v1.6/release-1.0.6/','/zh/tidb-in-kubernetes/v2.0/release-1.0.6/']
 ---
 
 # TiDB Operator 1.0.6 Release Notes

--- a/zh/releases/release-1.0.7.md
+++ b/zh/releases/release-1.0.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.0.7 Release Notes
 summary: TiDB Operator 1.0.7 was released on June 16, 2020. Notable changes include fixing alert rules lost after rolling upgrade, upgrading local volume provisioner to 2.3.4, fixing operator failover config invalid, removing unnecessary duplicated docs, updating doc links and image in readme, emitting events when PD failover, fixing some broken urls, and removing some not very useful update events.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.0.7/','/zh/tidb-in-kubernetes/v1.3/release-1.0.7/','/zh/tidb-in-kubernetes/v1.4/release-1.0.7/','/zh/tidb-in-kubernetes/v1.5/release-1.0.7/','/zh/tidb-in-kubernetes/v1.6/release-1.0.7/','/zh/tidb-in-kubernetes/v2.0/release-1.0.7/']
 ---
 
 # TiDB Operator 1.0.7 Release Notes

--- a/zh/releases/release-1.1-ga.md
+++ b/zh/releases/release-1.1-ga.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 GA Release Notes
 summary: TiDB Operator 1.1 GA 发布日期 2020 年 5 月 28 日。将 TiDB Pod 的 readiness 探针从 HTTPGet 更改为 TCPSocket 4000 端口。这将触发 tidb-server 组件滚动升级。你可以在升级 TiDB Operator 之前将 spec.paused 设置为 true 以避免滚动升级，并在准备升级 tidb-server 时将其重新设置为 false。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1-ga/','/zh/tidb-in-kubernetes/v1.3/release-1.1-ga/','/zh/tidb-in-kubernetes/v1.4/release-1.1-ga/','/zh/tidb-in-kubernetes/v1.5/release-1.1-ga/','/zh/tidb-in-kubernetes/v1.6/release-1.1-ga/','/zh/tidb-in-kubernetes/v2.0/release-1.1-ga/']
 ---
 
 # TiDB Operator 1.1 GA Release Notes

--- a/zh/releases/release-1.1.0-beta.1.md
+++ b/zh/releases/release-1.1.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 Beta.1 Release Notes
 summary: 支持配置时区，备份到 S3，基础默认设置，增强型 StatefulSet 扩缩容，自定义资源初始化 TiDB 集群，优化配置结构，支持临时存储，发布 Terraform Aliyun ACK 版本，优化报错信息，支持 TLS 加密连接，支持动态扩展云存储 PV，支持自动生成证书，支持暂停备份计划，升级 TiDB 版本。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.1.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.1.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.1.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.1.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.1.0-beta.1/']
 ---
 
 # TiDB Operator 1.1 Beta.1 Release Notes

--- a/zh/releases/release-1.1.0-beta.2.md
+++ b/zh/releases/release-1.1.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 Beta.2 Release Notes
 summary: 默认存储类和备份存储类已废弃，现在使用 Kubernetes 默认存储类。用户可设置备份和恢复的亲和性和容忍度。解决了 AdvancedStatefulSet 和 Admission Webhook 一起使用的问题。支持基于 CPU 平均负载的集群自动扩容。支持用户自定义证书。修复了一些问题并优化了日志。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.0-beta.2/','/zh/tidb-in-kubernetes/v1.3/release-1.1.0-beta.2/','/zh/tidb-in-kubernetes/v1.4/release-1.1.0-beta.2/','/zh/tidb-in-kubernetes/v1.5/release-1.1.0-beta.2/','/zh/tidb-in-kubernetes/v1.6/release-1.1.0-beta.2/','/zh/tidb-in-kubernetes/v2.0/release-1.1.0-beta.2/']
 ---
 
 # TiDB Operator 1.1 Beta.2 Release Notes

--- a/zh/releases/release-1.1.0-rc.1.md
+++ b/zh/releases/release-1.1.0-rc.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.1 Release Notes
 summary: 此版本包括对 tidb-server 的配置选项的更新，备份和恢复规范的修改，以及对 TiDB 组件的一些修复和改进。还支持通过 Terraform 在 AWS 和 ACK 上部署 TiDB 集群，并添加了一些新的功能和文档。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.0-rc.1/','/zh/tidb-in-kubernetes/v1.3/release-1.1.0-rc.1/','/zh/tidb-in-kubernetes/v1.4/release-1.1.0-rc.1/','/zh/tidb-in-kubernetes/v1.5/release-1.1.0-rc.1/','/zh/tidb-in-kubernetes/v1.6/release-1.1.0-rc.1/','/zh/tidb-in-kubernetes/v2.0/release-1.1.0-rc.1/']
 ---
 
 # TiDB Operator 1.1 RC.1 Release Notes

--- a/zh/releases/release-1.1.0-rc.2.md
+++ b/zh/releases/release-1.1.0-rc.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.2 Release Notes
 summary: TiDB Operator 1.1 RC.2 was released on April 15, 2020. Action required includes changing TiDB pod readiness probe and setting spec.paused to true before upgrading. Notable changes include adding status field for TidbAutoScaler CR, emitting more events for TidbCluster and TidbClusterAutoScaler, and adding TLS support for TiKV metrics API. Other changes involve adding a switch to skip PD Dashboard TLS configuration, supporting TiFlash in TidbCluster CR, and fixing errors related to alertmanager in TidbMonitor.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.0-rc.2/','/zh/tidb-in-kubernetes/v1.3/release-1.1.0-rc.2/','/zh/tidb-in-kubernetes/v1.4/release-1.1.0-rc.2/','/zh/tidb-in-kubernetes/v1.5/release-1.1.0-rc.2/','/zh/tidb-in-kubernetes/v1.6/release-1.1.0-rc.2/','/zh/tidb-in-kubernetes/v2.0/release-1.1.0-rc.2/']
 ---
 
 # TiDB Operator 1.1 RC.2 Release Notes

--- a/zh/releases/release-1.1.0-rc.3.md
+++ b/zh/releases/release-1.1.0-rc.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.3 Release Notes
 summary: TiDB Operator 1.1 RC.3 was released on April 30, 2020. Notable changes include support for TiFlash metrics in TidbMonitor, fixing bugs related to failover pods and statefulsets, and adding new features like configuring Ingress in TidbMonitor and supporting failover for TiFlash. Other changes include updates to terraform scripts and adding new fields in TiKVConfig.
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.0-rc.3/','/zh/tidb-in-kubernetes/v1.3/release-1.1.0-rc.3/','/zh/tidb-in-kubernetes/v1.4/release-1.1.0-rc.3/','/zh/tidb-in-kubernetes/v1.5/release-1.1.0-rc.3/','/zh/tidb-in-kubernetes/v1.6/release-1.1.0-rc.3/','/zh/tidb-in-kubernetes/v2.0/release-1.1.0-rc.3/']
 ---
 
 # TiDB Operator 1.1 RC.3 Release Notes

--- a/zh/releases/release-1.1.0-rc.4.md
+++ b/zh/releases/release-1.1.0-rc.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1 RC.4 Release Notes
 summary: TiDB Operator 1.1 RC.4 发布于 2020 年 5 月 15 日。每个组件可以使用单独的 TiDB 客户端证书。用户应该将 `Backup` 和 `Restore` CR 中的旧的 TLS 配置迁移到新的配置。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.0-rc.4/','/zh/tidb-in-kubernetes/v1.3/release-1.1.0-rc.4/','/zh/tidb-in-kubernetes/v1.4/release-1.1.0-rc.4/','/zh/tidb-in-kubernetes/v1.5/release-1.1.0-rc.4/','/zh/tidb-in-kubernetes/v1.6/release-1.1.0-rc.4/','/zh/tidb-in-kubernetes/v2.0/release-1.1.0-rc.4/']
 ---
 
 # TiDB Operator 1.1 RC.4 Release Notes

--- a/zh/releases/release-1.1.1.md
+++ b/zh/releases/release-1.1.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.1 Release Notes
 summary: TiDB Operator 1.1.1 版本发布，重大变化包括添加 `additionalContainers` 和 `additionalVolumes` 字段，修复了多个问题，并更新了配置版本到 v4.0.1。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.1/','/zh/tidb-in-kubernetes/v1.3/release-1.1.1/','/zh/tidb-in-kubernetes/v1.4/release-1.1.1/','/zh/tidb-in-kubernetes/v1.5/release-1.1.1/','/zh/tidb-in-kubernetes/v1.6/release-1.1.1/','/zh/tidb-in-kubernetes/v2.0/release-1.1.1/']
 ---
 
 # TiDB Operator 1.1.1 Release Notes

--- a/zh/releases/release-1.1.10.md
+++ b/zh/releases/release-1.1.10.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.10 Release Notes
 summary: TiDB Operator 1.1.10 版本发布，包含兼容性改动、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性改动包括 `apiVersion` 更改，滚动升级改动导致 TidbMonitor Pod 删除重建。新功能包括灰度升级、TidbMonitor 支持 `remotewrite`、配置 init containers 等。优化提升包括自定义存储、增加 label 支持多集群监控等。Bug 修复包括备份或者恢复失败、Pod 在升级过程中不会进行迁移 leader 等问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.10/','/zh/tidb-in-kubernetes/v1.3/release-1.1.10/','/zh/tidb-in-kubernetes/v1.4/release-1.1.10/','/zh/tidb-in-kubernetes/v1.5/release-1.1.10/','/zh/tidb-in-kubernetes/v1.6/release-1.1.10/','/zh/tidb-in-kubernetes/v2.0/release-1.1.10/']
 ---
 
 # TiDB Operator 1.1.10 Release Notes

--- a/zh/releases/release-1.1.11.md
+++ b/zh/releases/release-1.1.11.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.11 Release Notes
 summary: TiDB Operator 1.1.11 版本发布，新增优化 LeaderElection 和自定义 Store 标签功能。优化 TiFlash 滚动更新机制，改进获取 region leader 数量方式。支持打印 RocksDB 和 Raft 日志到 stdout。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.11/','/zh/tidb-in-kubernetes/v1.3/release-1.1.11/','/zh/tidb-in-kubernetes/v1.4/release-1.1.11/','/zh/tidb-in-kubernetes/v1.5/release-1.1.11/','/zh/tidb-in-kubernetes/v1.6/release-1.1.11/','/zh/tidb-in-kubernetes/v2.0/release-1.1.11/']
 ---
 
 # TiDB Operator 1.1.11 Release Notes

--- a/zh/releases/release-1.1.12.md
+++ b/zh/releases/release-1.1.12.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.12 Release Notes
 summary: TiDB Operator 1.1.12 版本发布日期为 2021 年 4 月 15 日。新功能包括支持为备份和恢复 Job 设置自定义环境变量，支持备份恢复 CR 设置 affinity 和 tolerations，以及支持 tidb-operator chart 使用新的 service account。优化提升包括 TiDBInitializer 中增加重试机制，增加多 PVC 支持，以及优化 `PodsAreChanged` 函数。Bug 修复包括修复挂载多 PVC 时容量设置错误的问题，修复创建 `.spec.tidb` 为空并开启 TLS 的 TidbCluster 导致 tidb-controller-manager panic 的问题，以及修复 `UnjoinedMembers` 中 PVC 状态异常的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.12/','/zh/tidb-in-kubernetes/v1.3/release-1.1.12/','/zh/tidb-in-kubernetes/v1.4/release-1.1.12/','/zh/tidb-in-kubernetes/v1.5/release-1.1.12/','/zh/tidb-in-kubernetes/v1.6/release-1.1.12/','/zh/tidb-in-kubernetes/v2.0/release-1.1.12/']
 ---
 
 # TiDB Operator 1.1.12 Release Notes

--- a/zh/releases/release-1.1.13.md
+++ b/zh/releases/release-1.1.13.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.13 Release Notes
 summary: TiDB Operator 1.1.13 版本发布，优化了 TiCDC 配置 TLS 证书、BR 工具镜像 tag、扩缩容 TiDB 过程中协调 PVC、备份日志中隐藏数据库密码。修复了部署异构集群时可能 panic 的问题和 TiDB 实例缩容后在 TiDB Dashboard 中仍然存在的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.13/','/zh/tidb-in-kubernetes/v1.3/release-1.1.13/','/zh/tidb-in-kubernetes/v1.4/release-1.1.13/','/zh/tidb-in-kubernetes/v1.5/release-1.1.13/','/zh/tidb-in-kubernetes/v1.6/release-1.1.13/','/zh/tidb-in-kubernetes/v2.0/release-1.1.13/']
 ---
 
 # TiDB Operator 1.1.13 Release Notes

--- a/zh/releases/release-1.1.14.md
+++ b/zh/releases/release-1.1.14.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.14 Release Notes
 summary: TiDB Operator 1.1.14 版本发布日期为 2021 年 10 月 21 日。此版本修复了 `tidb-backup-manager` 和 `tidb-operator` 镜像中的安全漏洞。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.14/','/zh/tidb-in-kubernetes/v1.3/release-1.1.14/','/zh/tidb-in-kubernetes/v1.4/release-1.1.14/','/zh/tidb-in-kubernetes/v1.5/release-1.1.14/','/zh/tidb-in-kubernetes/v1.6/release-1.1.14/','/zh/tidb-in-kubernetes/v2.0/release-1.1.14/']
 ---
 
 # TiDB Operator 1.1.14 Release Notes

--- a/zh/releases/release-1.1.15.md
+++ b/zh/releases/release-1.1.15.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.15 Release Notes
 summary: TiDB Operator 1.1.15 发布日期为 2022 年 2 月 17 日。此版本修复了 TiDB Operator 计算 TiKV Region leader 数量时可能会造成 goroutine 泄露的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.15/','/zh/tidb-in-kubernetes/v1.3/release-1.1.15/','/zh/tidb-in-kubernetes/v1.4/release-1.1.15/','/zh/tidb-in-kubernetes/v1.5/release-1.1.15/','/zh/tidb-in-kubernetes/v1.6/release-1.1.15/','/zh/tidb-in-kubernetes/v2.0/release-1.1.15/']
 ---
 
 # TiDB Operator 1.1.15 Release Notes

--- a/zh/releases/release-1.1.2.md
+++ b/zh/releases/release-1.1.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.2 Release Notes
 summary: TiDB Operator 1.1.2 版本修复了与 PD 4.0.2 不兼容的问题。需要将 TiDB Operator 升级到 v1.1.2 后再部署 TiDB 4.0.2 及更高版本。其他变更包括抓取监控指标和更新配置为 v4.0.2，修复缩容后 PD 成员可能仍然存在的错误，同步信息到 `TidbCluster` `Status` 字段，以及支持在 TiDB 参数中配置容器生命周期 hook 和 `terminationGracePeriodSeconds`。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.2/','/zh/tidb-in-kubernetes/v1.3/release-1.1.2/','/zh/tidb-in-kubernetes/v1.4/release-1.1.2/','/zh/tidb-in-kubernetes/v1.5/release-1.1.2/','/zh/tidb-in-kubernetes/v1.6/release-1.1.2/','/zh/tidb-in-kubernetes/v2.0/release-1.1.2/']
 ---
 
 # TiDB Operator 1.1.2 Release Notes

--- a/zh/releases/release-1.1.3.md
+++ b/zh/releases/release-1.1.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.3 Release Notes
 summary: TiDB Operator 1.1.3 版本发布，需要采取的行动包括在 `BackupSpec` 中添加 `cleanPolicy` 字段，将 `mydumper` 替换为 `dumpling` 进行备份。其他变更包括更新 backup manager 工具、为 TiCDC 添加 TLS 支持、在 Drainer 和下游数据库服务器之间添加 TLS 支持等。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.3/','/zh/tidb-in-kubernetes/v1.3/release-1.1.3/','/zh/tidb-in-kubernetes/v1.4/release-1.1.3/','/zh/tidb-in-kubernetes/v1.5/release-1.1.3/','/zh/tidb-in-kubernetes/v1.6/release-1.1.3/','/zh/tidb-in-kubernetes/v2.0/release-1.1.3/']
 ---
 
 # TiDB Operator 1.1.3 Release Notes

--- a/zh/releases/release-1.1.4.md
+++ b/zh/releases/release-1.1.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.4 Release Notes
 summary: TiDB Operator 1.1.4 版本发布，重大变化包括添加 TableFilter 到 BackupSpec 和 RestoreSpec，更新 TiDB 和配套工具版本为 v4.0.4，支持自定义环境变量，增加存储请求，为备份恢复添加 TLS 支持，支持 TiFlash 中的 cert-allowed-cn 配置项，修复了启用 TLS 时的内存泄漏问题，为 TiFlash 添加 TLS 支持，配置 TZ 环境。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.4/','/zh/tidb-in-kubernetes/v1.3/release-1.1.4/','/zh/tidb-in-kubernetes/v1.4/release-1.1.4/','/zh/tidb-in-kubernetes/v1.5/release-1.1.4/','/zh/tidb-in-kubernetes/v1.6/release-1.1.4/','/zh/tidb-in-kubernetes/v2.0/release-1.1.4/']
 ---
 
 # TiDB Operator 1.1.4 Release Notes

--- a/zh/releases/release-1.1.5.md
+++ b/zh/releases/release-1.1.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.5 Release Notes
 summary: TiDB Operator 1.1.5 版本发布日期为 2020 年 9 月 18 日。此版本兼容性变化需要注意 TiFlash 版本低于 `v4.0.5` 的设置。新功能包括支持为 TiDB/Pump/PD 配置 `serviceAccount`，以及配置 `spec.tikv.config.log-format` 和 `spec.tikv.config.server.max-grpc-send-msg-len`。优化提升方面支持 TiDB/PD/TiKV 的 v4.0.6 配置，挂载集群客户端证书到 PD Pod，以及对于 TiFlash/PD/TiDB 的伸缩实例优先于升级。同时修复了 TidbMonitor CR 中的 Grafana container 忽略 `Env` 配置的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.5/','/zh/tidb-in-kubernetes/v1.3/release-1.1.5/','/zh/tidb-in-kubernetes/v1.4/release-1.1.5/','/zh/tidb-in-kubernetes/v1.5/release-1.1.5/','/zh/tidb-in-kubernetes/v1.6/release-1.1.5/','/zh/tidb-in-kubernetes/v2.0/release-1.1.5/']
 ---
 
 # TiDB Operator 1.1.5 Release Notes

--- a/zh/releases/release-1.1.6.md
+++ b/zh/releases/release-1.1.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.6 Release Notes
 summary: TiDB Operator 1.1.6 版本发布日期为 2020 年 10 月 16 日。此版本包含兼容性变化、滚动升级改动、新功能、优化提升和 Bug 修复。兼容性变化包括 `spec.pd.config` 参数的自动转换和需要手动编辑 TidbCluster CR 的配置。滚动升级改动包括 TiDB 或 TiKV 集群的滚动升级以及 TiFlash 集群的滚动升级。新功能包括支持 Backup 和 Restore CR 自定义 BR 命令行参数、配置 TiKV evict leader 超时时间等。优化提升包括透传 TiFlash/TiKV/PD/Pump 的 TOML 格式配置、定时备份到 GCS 时目录名称添加备份时间等。Bug 修复包括修复 Discovery 可能导致启动多个 PD 集群的错误。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.6/','/zh/tidb-in-kubernetes/v1.3/release-1.1.6/','/zh/tidb-in-kubernetes/v1.4/release-1.1.6/','/zh/tidb-in-kubernetes/v1.5/release-1.1.6/','/zh/tidb-in-kubernetes/v1.6/release-1.1.6/','/zh/tidb-in-kubernetes/v2.0/release-1.1.6/']
 ---
 
 # TiDB Operator 1.1.6 Release Notes

--- a/zh/releases/release-1.1.7.md
+++ b/zh/releases/release-1.1.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.7 Release Notes
 summary: TiDB Operator 1.1.7 版本发布日期为 2020 年 11 月 13 日。此版本中兼容性变化包括配置项 `prometheus.spec.config.commandOptions` 的行为变化。新增功能包括对 `Backup` 和 `Restore` CR 的配置项 `spec.toolImage` 的新增，以及对 `spec.pd.storageVolumes`、`spec.tidb.storageVolumes` 和 `spec.tikv.storageVolumes` 的支持。优化提升方面包括禁止缩容 TiKV 实例和新增 `BackupStatus` 和 `RestoreStatus` 中的 `phase` 状态。此外还修复了当前 `TidbCluster` 之外存在 PD member 时无法把 PD scale 到 0 的 bug。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.7/','/zh/tidb-in-kubernetes/v1.3/release-1.1.7/','/zh/tidb-in-kubernetes/v1.4/release-1.1.7/','/zh/tidb-in-kubernetes/v1.5/release-1.1.7/','/zh/tidb-in-kubernetes/v1.6/release-1.1.7/','/zh/tidb-in-kubernetes/v2.0/release-1.1.7/']
 ---
 
 # TiDB Operator 1.1.7 Release Notes

--- a/zh/releases/release-1.1.8.md
+++ b/zh/releases/release-1.1.8.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.8 Release Notes
 summary: TiDB Operator 1.1.8 版本新增了对备份和恢复任务的支持，用户可以利用该功能实现基于 NFS 或者任意 Kubernetes 支持的 Volume 类型的任务。此外，还优化了 TiDB 组件和客户端开启 TLS 的功能，支持为 TiDB service 指定额外的端口，以及在连接 TiDB server 时不使用 TLS。修复了一系列 Bug，包括部署 TiDB 集群问题、编码错误问题、Pods 误认为问题等。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.8/','/zh/tidb-in-kubernetes/v1.3/release-1.1.8/','/zh/tidb-in-kubernetes/v1.4/release-1.1.8/','/zh/tidb-in-kubernetes/v1.5/release-1.1.8/','/zh/tidb-in-kubernetes/v1.6/release-1.1.8/','/zh/tidb-in-kubernetes/v2.0/release-1.1.8/']
 ---
 
 # TiDB Operator 1.1.8 Release Notes

--- a/zh/releases/release-1.1.9.md
+++ b/zh/releases/release-1.1.9.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.1.9 Release Notes
 summary: TiDB Operator 1.1.9 版本发布日期为 2020 年 12 月 28 日。此版本优化了支持使用 `spec.toolImage` 来为 `Backup` 和 `Restore` 指定 Dumpling/TiDB Lightning 的二进制可执行文件。同时修复了 Prometheus 不能拉取 TiKV Importer 的 metrics 以及用 BR 和 GCS 进行备份与恢复时的兼容性问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.1.9/','/zh/tidb-in-kubernetes/v1.3/release-1.1.9/','/zh/tidb-in-kubernetes/v1.4/release-1.1.9/','/zh/tidb-in-kubernetes/v1.5/release-1.1.9/','/zh/tidb-in-kubernetes/v1.6/release-1.1.9/','/zh/tidb-in-kubernetes/v2.0/release-1.1.9/']
 ---
 
 # TiDB Operator 1.1.9 Release Notes

--- a/zh/releases/release-1.2.0-alpha.1.md
+++ b/zh/releases/release-1.2.0-alpha.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-alpha.1 Release Notes
 summary: TiDB Operator 1.2.0-alpha.1 版本发布。滚动升级改动包括 TidbMonitor Pod 重建。新增功能包括跨多个 Kubernetes 集群部署 TiDB 集群、管理 DM 2.0、PD API 弹性伸缩、灰度升级 TiDB Operator。优化提升包括 TiDB Lightning chart 支持 local backend、TLS、持久化 checkpoint，TidbMonitor 支持配置 Thanos sidecar，管理资源从 Deployment 变为 StatefulSet。其他改进包括优化队列 rate limiter 间隔，修改 TidbMonitor 自定义告警规则存储目录。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.0-alpha.1/','/zh/tidb-in-kubernetes/v1.3/release-1.2.0-alpha.1/','/zh/tidb-in-kubernetes/v1.4/release-1.2.0-alpha.1/','/zh/tidb-in-kubernetes/v1.5/release-1.2.0-alpha.1/','/zh/tidb-in-kubernetes/v1.6/release-1.2.0-alpha.1/','/zh/tidb-in-kubernetes/v2.0/release-1.2.0-alpha.1/']
 ---
 
 # TiDB Operator 1.2.0-alpha.1 Release Notes

--- a/zh/releases/release-1.2.0-beta.1.md
+++ b/zh/releases/release-1.2.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-beta.1 Release Notes
 summary: TiDB Operator 1.2.0-beta.1 发布日期为 2021 年 4 月 7 日。此版本包含兼容性改动和滚动升级改动。新增功能包括为备份和恢复 Job 设置自定义环境变量，支持配置额外的 volume 和 volumeMount，以及支持设置自定义 Store 标签。优化提升方面包括增加重试机制解决 DNS 查询异常处理问题，优化 Thanos 的 example yaml，以及在 PD 的扩缩容和容灾过程中增加多 PVC 支持。Bug 修复方面包括修复挂载多 PVC 时容量设置错误的问题，修复 TidbMonitor 外部标签包含无法识别的环境变量的问题，以及修复备份或恢复 Pod 状态没有正常更新为 Failed 的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.2.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.2.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.2.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.2.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.2.0-beta.1/']
 ---
 
 # TiDB Operator 1.2.0-beta.1 Release Notes

--- a/zh/releases/release-1.2.0-beta.2.md
+++ b/zh/releases/release-1.2.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-beta.2 Release Notes
 summary: TiDB Operator 1.2.0-beta.2 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。新功能包括 TidbMonitor 支持监控多个启用了 TLS 的 TidbCluster，以及为所有 TiDB 组件设置安全上下文和拓扑约束。优化提升包括为 TidbMonitor Pod 增加 readiness 探测器和支持不生成 Prometheus 的告警规则。 Bug 修复包括修复 TiDB 实例缩容后仍在 TiDB Dashboard 中展示的问题和解决 TidbCluster CR 同步问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.0-beta.2/','/zh/tidb-in-kubernetes/v1.3/release-1.2.0-beta.2/','/zh/tidb-in-kubernetes/v1.4/release-1.2.0-beta.2/','/zh/tidb-in-kubernetes/v1.5/release-1.2.0-beta.2/','/zh/tidb-in-kubernetes/v1.6/release-1.2.0-beta.2/','/zh/tidb-in-kubernetes/v2.0/release-1.2.0-beta.2/']
 ---
 
 # TiDB Operator 1.2.0-beta.2 Release Notes

--- a/zh/releases/release-1.2.0-rc.1.md
+++ b/zh/releases/release-1.2.0-rc.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-rc.1 Release Notes
 summary: TiDB Operator 1.2.0-rc.1 发布，滚动升级改动会导致 Pump Pod 删除重建。新增支持为 TidbCluster 中的 Pod 与 service 设置自定义的 label，以及对 Pump 的完整生命周期管理。优化提升包括隐藏数据库密码的展示、支持为 Grafana 配置额外的 volumeMount、为 TidbMonitor 增加额外的信息展示列，以及 TidbMonitor 支持将配置信息直接写入到 PD 的 etcd 中。Bug 修复包括对启用了 TLS 的 DmCluster 进行监控的问题、PD 在扩容过程中 member 数量统计不正确的问题、DM-master 可能无法成功重启的问题、`configUpdateStrategy` 从 `InPlace` 修改为 `RollingUpdate` 后可能造成的 TidbCluster 组件滚动更新的问题，以及使用 Dumpling 备份数据时可能失败的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.0-rc.1/','/zh/tidb-in-kubernetes/v1.3/release-1.2.0-rc.1/','/zh/tidb-in-kubernetes/v1.4/release-1.2.0-rc.1/','/zh/tidb-in-kubernetes/v1.5/release-1.2.0-rc.1/','/zh/tidb-in-kubernetes/v1.6/release-1.2.0-rc.1/','/zh/tidb-in-kubernetes/v2.0/release-1.2.0-rc.1/']
 ---
 
 # TiDB Operator 1.2.0-rc.1 Release Notes

--- a/zh/releases/release-1.2.0-rc.2.md
+++ b/zh/releases/release-1.2.0-rc.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0-rc.2 Release Notes
 summary: TiDB Operator 1.2.0-rc.2 发布，新增支持透传 TiCDC 的 TOML 格式配置、为 TiCDC 设置存储卷和挂载、自定义 Discovery、TidbMonitor 和 TidbInitializer 的标签和注释、修改 Grafana 仪表盘。优化支持未指定 BR toolImage tag 时将 TiKV 版本作为 tag、扩缩容 TiDB 过程中协调 PVC、增加 liveness 与 readiness 探测器。修复部署异构集群时可能 panic 的问题、TidbCluster spec 未更改时 TiDB service 与 TidbCluster 状态持续更新的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.0-rc.2/','/zh/tidb-in-kubernetes/v1.3/release-1.2.0-rc.2/','/zh/tidb-in-kubernetes/v1.4/release-1.2.0-rc.2/','/zh/tidb-in-kubernetes/v1.5/release-1.2.0-rc.2/','/zh/tidb-in-kubernetes/v1.6/release-1.2.0-rc.2/','/zh/tidb-in-kubernetes/v2.0/release-1.2.0-rc.2/']
 ---
 
 # TiDB Operator 1.2.0-rc.2 Release Notes

--- a/zh/releases/release-1.2.0.md
+++ b/zh/releases/release-1.2.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.0 Release Notes
 summary: TiDB Operator 1.2.0 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级改动包括升级 TiDB Operator 会导致 TidbMonitor Pod 删除重建。新功能包括支持为 `TiDBMonitor` 的 `Prometheus` 设置更细粒度的 `retentionTime` 和通过 `priorityClassName` 设置备份 Job 优先级。优化提升包括调整升级过程中驱逐 TiKV 的 Region Leader 超时的默认值。Bug 修复包括修复解析 `TiDBMonitor` 定义中 `Prometheus.RemoteWrite` 的 URL 可能失败的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.0/','/zh/tidb-in-kubernetes/v1.3/release-1.2.0/','/zh/tidb-in-kubernetes/v1.4/release-1.2.0/','/zh/tidb-in-kubernetes/v1.5/release-1.2.0/','/zh/tidb-in-kubernetes/v1.6/release-1.2.0/','/zh/tidb-in-kubernetes/v2.0/release-1.2.0/']
 ---
 
 # TiDB Operator 1.2.0 Release Notes

--- a/zh/releases/release-1.2.1.md
+++ b/zh/releases/release-1.2.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.1 Release Notes
 summary: TiDB Operator 1.2.1 版本发布日期为 2021 年 8 月 18 日。滚动升级改动，如果部署 TiCDC 时配置了 hostNetwork 为 true，升级 TiDB Operator 后会导致 TiCDC Pod 删除重建。优化提升包括支持为 TidbCluster 的所有组件配置 hostNetwork，使所有组件都可以使用宿主机网络。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.1/','/zh/tidb-in-kubernetes/v1.3/release-1.2.1/','/zh/tidb-in-kubernetes/v1.4/release-1.2.1/','/zh/tidb-in-kubernetes/v1.5/release-1.2.1/','/zh/tidb-in-kubernetes/v1.6/release-1.2.1/','/zh/tidb-in-kubernetes/v2.0/release-1.2.1/']
 ---
 
 # TiDB Operator 1.2.1 Release Notes

--- a/zh/releases/release-1.2.2.md
+++ b/zh/releases/release-1.2.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.2 Release Notes
 summary: TiDB Operator 1.2.2 版本发布日期为 2021 年 9 月 3 日。滚动升级改动包括升级 TiDB Operator 会导致 TiDBMonitor Pod 和 TiFlash Pod 删除重建。新功能包括 TiDBMonitor 支持动态重新加载配置。Bug 修复包括修复 TiCDC 无法从低版本升级到 v5.2.0 的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.2/','/zh/tidb-in-kubernetes/v1.3/release-1.2.2/','/zh/tidb-in-kubernetes/v1.4/release-1.2.2/','/zh/tidb-in-kubernetes/v1.5/release-1.2.2/','/zh/tidb-in-kubernetes/v1.6/release-1.2.2/','/zh/tidb-in-kubernetes/v2.0/release-1.2.2/']
 ---
 
 # TiDB Operator 1.2.2 Release Notes

--- a/zh/releases/release-1.2.3.md
+++ b/zh/releases/release-1.2.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.3 Release Notes
 summary: TiDB Operator 1.2.3 版本发布日期为 2021 年 9 月 7 日。此版本修复了升级到 TiDB Operator v1.2.2 时导致 TiFlash Pod 滚动重启的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.3/','/zh/tidb-in-kubernetes/v1.3/release-1.2.3/','/zh/tidb-in-kubernetes/v1.4/release-1.2.3/','/zh/tidb-in-kubernetes/v1.5/release-1.2.3/','/zh/tidb-in-kubernetes/v1.6/release-1.2.3/','/zh/tidb-in-kubernetes/v2.0/release-1.2.3/']
 ---
 
 # TiDB Operator 1.2.3 Release Notes

--- a/zh/releases/release-1.2.4.md
+++ b/zh/releases/release-1.2.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.4 Release Notes
 summary: TiDB Operator 1.2.4 版本发布，包括滚动升级改动、新功能、优化提升和 Bug 修复。滚动升级会导致 TidbMonitor Pod 删除重建。新增 TidbMonitor 支持用户自定义 Prometheus 告警规则和动态重新加载告警规则，以及支持批量删除备份数据。优化了 TiFlash 滚动升级流程，修复了镜像中的安全漏洞和备份数据残留的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.4/','/zh/tidb-in-kubernetes/v1.3/release-1.2.4/','/zh/tidb-in-kubernetes/v1.4/release-1.2.4/','/zh/tidb-in-kubernetes/v1.5/release-1.2.4/','/zh/tidb-in-kubernetes/v1.6/release-1.2.4/','/zh/tidb-in-kubernetes/v2.0/release-1.2.4/']
 ---
 
 # TiDB Operator 1.2.4 Release Notes

--- a/zh/releases/release-1.2.5.md
+++ b/zh/releases/release-1.2.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.5 Release Notes
 summary: TiDB Operator 1.2.5 版本发布，优化了 DM 配置、TiFlash init container 资源配置和 TiDB TLS 客户端认证参数配置。修复了组件启动脚本更新后的滚动更新问题、启用 TLS 后 TidbCluster spec 自动更新问题、TiKV Region leader 数量计算可能导致 goroutine 泄露的问题和一些高级别的安全问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.5/','/zh/tidb-in-kubernetes/v1.3/release-1.2.5/','/zh/tidb-in-kubernetes/v1.4/release-1.2.5/','/zh/tidb-in-kubernetes/v1.5/release-1.2.5/','/zh/tidb-in-kubernetes/v1.6/release-1.2.5/','/zh/tidb-in-kubernetes/v2.0/release-1.2.5/']
 ---
 
 # TiDB Operator 1.2.5 Release Notes

--- a/zh/releases/release-1.2.6.md
+++ b/zh/releases/release-1.2.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.6 Release Notes
 summary: TiDB Operator 1.2.6 发布日期 2022 年 1 月 4 日。优化更新 Restore 和 Backup 状态时的重试逻辑。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.6/','/zh/tidb-in-kubernetes/v1.3/release-1.2.6/','/zh/tidb-in-kubernetes/v1.4/release-1.2.6/','/zh/tidb-in-kubernetes/v1.5/release-1.2.6/','/zh/tidb-in-kubernetes/v1.6/release-1.2.6/','/zh/tidb-in-kubernetes/v2.0/release-1.2.6/']
 ---
 # TiDB Operator 1.2.6 Release Notes
 

--- a/zh/releases/release-1.2.7.md
+++ b/zh/releases/release-1.2.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.2.7 Release Notes
 summary: TiDB Operator 1.2.7 发布，新增 `spec.pd.startUpScriptVersion` 字段，支持在 PD 启动脚本中使用 `dig` 命令解析域名。优化部署或更新组件的 StatefulSet，预先检查配置的 VolumeMount 是否存在，防止集群进行失败的滚动更新。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.2.7/','/zh/tidb-in-kubernetes/v1.3/release-1.2.7/','/zh/tidb-in-kubernetes/v1.4/release-1.2.7/','/zh/tidb-in-kubernetes/v1.5/release-1.2.7/','/zh/tidb-in-kubernetes/v1.6/release-1.2.7/','/zh/tidb-in-kubernetes/v2.0/release-1.2.7/']
 ---
 # TiDB Operator 1.2.7 Release Notes
 

--- a/zh/releases/release-1.3.0-beta.1.md
+++ b/zh/releases/release-1.3.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.0-beta.1 Release Notes
 summary: TiDB Operator 1.3.0-beta.1 发布日期为 2022 年 1 月 12 日。此版本的兼容性改动包括删除 Pod `ValidatingWebhook` 和 `MutatingWebhook`，升级后不会影响 TiDB 集群管理。升级到 1.3.0-beta.1 版本后，需要按照操作来升级 TiDB Operator。此版本还支持新功能和优化提升，包括支持 TiFlash 的 init container 配置资源使用量，支持持续性能分析，以及优化 TidbMonitor 部署示例等。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.3.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.3.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.3.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.3.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.3.0-beta.1/']
 ---
 
 # TiDB Operator 1.3.0-beta.1 Release Notes

--- a/zh/releases/release-1.3.0.md
+++ b/zh/releases/release-1.3.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.0 Release Notes
 summary: TiDB Operator 1.3.0 版本发布，包括兼容性改动、新功能、优化提升和 Bug 修复。兼容性改动包括跨集群部署 TiDB 集群升级操作，TiFlash 升级操作需注意。新增功能包括支持内部组件访问 TiDB 时跳过服务端证书验证、设置所有组件 Pod 的 DNS 配置等。优化提升包括部署或更新组件的 StatefulSet 预先检查配置的 VolumeMount 是否存在，跨集群部署 TiDB 集群功能增强。Bug 修复包括修复 Kubernetes v1.23 及之后版本无法部署 tidb scheduler 的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.0/','/zh/tidb-in-kubernetes/v1.3/release-1.3.0/','/zh/tidb-in-kubernetes/v1.4/release-1.3.0/','/zh/tidb-in-kubernetes/v1.5/release-1.3.0/','/zh/tidb-in-kubernetes/v1.6/release-1.3.0/','/zh/tidb-in-kubernetes/v2.0/release-1.3.0/']
 ---
 
 # TiDB Operator 1.3.0 Release Notes

--- a/zh/releases/release-1.3.1.md
+++ b/zh/releases/release-1.3.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.1 Release Notes
 summary: TiDB Operator 1.3.1 版本发布日期为 2022 年 2 月 24 日。此版本修复了 TiFlash 丢失元数据的问题，并添加了新的 `spec.dnsPolicy` 字段以支持配置 Pod 的 DNSPolicy。另外，`tidb-lightning` Helm chart 默认后端改为使用 `local`。还修复了 TiFlash 配置中缺少 `tmp_path` 字段时无法使用 TiFlash v5.4.0 及以后版本的问题，以及 Discovery 服务错误导致 TiDB 集群 PD 组件启动失败的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.1/','/zh/tidb-in-kubernetes/v1.3/release-1.3.1/','/zh/tidb-in-kubernetes/v1.4/release-1.3.1/','/zh/tidb-in-kubernetes/v1.5/release-1.3.1/','/zh/tidb-in-kubernetes/v1.6/release-1.3.1/','/zh/tidb-in-kubernetes/v2.0/release-1.3.1/']
 ---
 
 # TiDB Operator 1.3.1 Release Notes

--- a/zh/releases/release-1.3.10.md
+++ b/zh/releases/release-1.3.10.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.10 Release Notes
 summary: TiDB Operator 1.3.10 发布，优化提升包括升级 Golang 版本到 1.19 以修复安全漏洞。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.10/','/zh/tidb-in-kubernetes/v1.3/release-1.3.10/','/zh/tidb-in-kubernetes/v1.4/release-1.3.10/','/zh/tidb-in-kubernetes/v1.5/release-1.3.10/','/zh/tidb-in-kubernetes/v1.6/release-1.3.10/','/zh/tidb-in-kubernetes/v2.0/release-1.3.10/']
 ---
 
 # TiDB Operator 1.3.10 Release Notes

--- a/zh/releases/release-1.3.2.md
+++ b/zh/releases/release-1.3.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.2 Release Notes
 summary: TiDB Operator 1.3.2 版本发布，优化支持在启用 Istio 的 Kubernetes 集群上部署与运行 TiDB，支持多架构 Docker 镜像包括 ARM 系统。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.2/','/zh/tidb-in-kubernetes/v1.3/release-1.3.2/','/zh/tidb-in-kubernetes/v1.4/release-1.3.2/','/zh/tidb-in-kubernetes/v1.5/release-1.3.2/','/zh/tidb-in-kubernetes/v1.6/release-1.3.2/','/zh/tidb-in-kubernetes/v2.0/release-1.3.2/']
 ---
 
 # TiDB Operator 1.3.2 Release Notes

--- a/zh/releases/release-1.3.3.md
+++ b/zh/releases/release-1.3.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.3 Release Notes
 summary: TiDB Operator 1.3.3 发布，新增了 `spec.tidb.service.port` 字段，修复了集群升级过程中可能泄漏的问题，更新了 `tidb-backup-manager` 镜像的基础镜像，修复了不兼容 ARM 架构的问题，修复了当 tidb Service 没有 Endpoint 时可能会 panic 的问题，修复了 Kubernetes 集群访问失败并重试后组件 Pod 的 Labels 和 Annotations 可能丢失的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.3/','/zh/tidb-in-kubernetes/v1.3/release-1.3.3/','/zh/tidb-in-kubernetes/v1.4/release-1.3.3/','/zh/tidb-in-kubernetes/v1.5/release-1.3.3/','/zh/tidb-in-kubernetes/v1.6/release-1.3.3/','/zh/tidb-in-kubernetes/v2.0/release-1.3.3/']
 ---
 
 # TiDB Operator 1.3.3 Release Notes

--- a/zh/releases/release-1.3.4.md
+++ b/zh/releases/release-1.3.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.4 Release Notes
 summary: TiDB Operator 1.3.4 发布，优化提升包括在各个组件的状态信息中添加了 `volumes` 字段，以展示存储卷状态。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.4/','/zh/tidb-in-kubernetes/v1.3/release-1.3.4/','/zh/tidb-in-kubernetes/v1.4/release-1.3.4/','/zh/tidb-in-kubernetes/v1.5/release-1.3.4/','/zh/tidb-in-kubernetes/v1.6/release-1.3.4/','/zh/tidb-in-kubernetes/v2.0/release-1.3.4/']
 ---
 
 # TiDB Operator 1.3.4 Release Notes

--- a/zh/releases/release-1.3.5.md
+++ b/zh/releases/release-1.3.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.5 Release Notes
 summary: TiDB Operator 1.3.5 发布，新增功能支持使用 Azure Blob Storage 备份与恢复 TiDB 集群数据。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.5/','/zh/tidb-in-kubernetes/v1.3/release-1.3.5/','/zh/tidb-in-kubernetes/v1.4/release-1.3.5/','/zh/tidb-in-kubernetes/v1.5/release-1.3.5/','/zh/tidb-in-kubernetes/v1.6/release-1.3.5/','/zh/tidb-in-kubernetes/v2.0/release-1.3.5/']
 ---
 
 # TiDB Operator 1.3.5 Release Notes

--- a/zh/releases/release-1.3.6.md
+++ b/zh/releases/release-1.3.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.6 Release Notes
 summary: TiDB Operator 1.3.6 版本发布日期为 2022 年 7 月 5 日。此版本优化了扩容 PVC 对集群性能的影响，现在扩容 PVC 时按照 Pod 一个个扩容，并且在扩容 TiKV 的 PVC 前会先驱逐该 TiKV 上的 leader。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.6/','/zh/tidb-in-kubernetes/v1.3/release-1.3.6/','/zh/tidb-in-kubernetes/v1.4/release-1.3.6/','/zh/tidb-in-kubernetes/v1.5/release-1.3.6/','/zh/tidb-in-kubernetes/v1.6/release-1.3.6/','/zh/tidb-in-kubernetes/v2.0/release-1.3.6/']
 ---
 
 # TiDB Operator 1.3.6 Release Notes

--- a/zh/releases/release-1.3.7.md
+++ b/zh/releases/release-1.3.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.7 Release Notes
 summary: TiDB Operator 1.3.7 版本发布，新增了暂停组件功能，优化了扩容完成后重建 StatefulSet 的流程，修复了本地存储升级 TiKV 和清理备份文件后残留的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.7/','/zh/tidb-in-kubernetes/v1.3/release-1.3.7/','/zh/tidb-in-kubernetes/v1.4/release-1.3.7/','/zh/tidb-in-kubernetes/v1.5/release-1.3.7/','/zh/tidb-in-kubernetes/v1.6/release-1.3.7/','/zh/tidb-in-kubernetes/v2.0/release-1.3.7/']
 ---
 
 # TiDB Operator 1.3.7 Release Notes

--- a/zh/releases/release-1.3.8.md
+++ b/zh/releases/release-1.3.8.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.8 Release Notes
 summary: TiDB Operator 1.3.8 版本发布，新增了为 `TidbCluster` 添加特殊 Annotation 的功能，支持配置 TiDB、TiKV 和 TiFlash 的 Pod 的最小等待时间。此外，还优化了支持优雅升级版本大于或等于 6.3.0 的 TiCDC pod。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.8/','/zh/tidb-in-kubernetes/v1.3/release-1.3.8/','/zh/tidb-in-kubernetes/v1.4/release-1.3.8/','/zh/tidb-in-kubernetes/v1.5/release-1.3.8/','/zh/tidb-in-kubernetes/v1.6/release-1.3.8/','/zh/tidb-in-kubernetes/v2.0/release-1.3.8/']
 ---
 
 # TiDB Operator 1.3.8 Release Notes

--- a/zh/releases/release-1.3.9.md
+++ b/zh/releases/release-1.3.9.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.3.9 Release Notes
 summary: TiDB Operator 1.3.9 发布，修复了在已设置 `acrossK8s` 字段但未设置 `clusterDomain` 的情况下，PD 升级流程会卡住的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.3.9/','/zh/tidb-in-kubernetes/v1.3/release-1.3.9/','/zh/tidb-in-kubernetes/v1.4/release-1.3.9/','/zh/tidb-in-kubernetes/v1.5/release-1.3.9/','/zh/tidb-in-kubernetes/v1.6/release-1.3.9/','/zh/tidb-in-kubernetes/v2.0/release-1.3.9/']
 ---
 
 # TiDB Operator 1.3.9 Release Notes

--- a/zh/releases/release-1.4.0-alpha.1.md
+++ b/zh/releases/release-1.4.0-alpha.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-alpha.1 Release Notes
 summary: TiDB Operator 1.4.0-alpha.1 发布，包含兼容性改动、滚动升级改动、新功能、优化提升和错误修复。新增自动设置 TiDB 的 location labels、新字段 `spec.tikv.scalePolicy` 与 `spec.tiflash.scalePolicy`、`startScriptVersion` 字段、BR 恢复集群到备份时间点、feature gate `VolumeModifying`、修改存储参数、配置 BR 的 `--check-requirements` 参数、使用字段 `additionalContainers` 自定义 Pod 容器配置。优化了 `TidbMonitor` 使用的 Prometheus 的 remoteWrite 配置和 TiFlash `Service` 添加 metric 端口。修复了集群扩缩容时的问题和 PD spec 为空导致 TiDB Operator 崩溃的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.0-alpha.1/','/zh/tidb-in-kubernetes/v1.3/release-1.4.0-alpha.1/','/zh/tidb-in-kubernetes/v1.4/release-1.4.0-alpha.1/','/zh/tidb-in-kubernetes/v1.5/release-1.4.0-alpha.1/','/zh/tidb-in-kubernetes/v1.6/release-1.4.0-alpha.1/','/zh/tidb-in-kubernetes/v2.0/release-1.4.0-alpha.1/']
 ---
 
 # TiDB Operator 1.4.0-alpha.1 Release Notes

--- a/zh/releases/release-1.4.0-beta.1.md
+++ b/zh/releases/release-1.4.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-beta.1 Release Notes
 summary: TiDB Operator 1.4.0-beta.1 发布，新增支持基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复（实验特性），修复了日志备份的 checkpoint ts 无法更新的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.4.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.4.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.4.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.4.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.4.0-beta.1/']
 ---
 
 # TiDB Operator 1.4.0-beta.1 Release Notes

--- a/zh/releases/release-1.4.0-beta.2.md
+++ b/zh/releases/release-1.4.0-beta.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-beta.2 Release Notes
 summary: TiDB Operator 1.4.0-beta.2 发布日期为 2022 年 11 月 11 日。此版本修复了使用 Azure Blob Storage 时未设置前缀的问题，并升级了 AWS SDK 到 v1.44.72 以支持使用 AWS 的 Asia Pacific (Jakarta) 区域 (`ap-southeast-3`)。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.0-beta.2/','/zh/tidb-in-kubernetes/v1.3/release-1.4.0-beta.2/','/zh/tidb-in-kubernetes/v1.4/release-1.4.0-beta.2/','/zh/tidb-in-kubernetes/v1.5/release-1.4.0-beta.2/','/zh/tidb-in-kubernetes/v1.6/release-1.4.0-beta.2/','/zh/tidb-in-kubernetes/v2.0/release-1.4.0-beta.2/']
 ---
 
 # TiDB Operator 1.4.0-beta.2 Release Notes

--- a/zh/releases/release-1.4.0-beta.3.md
+++ b/zh/releases/release-1.4.0-beta.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0-beta.3 Release Notes
 summary: TiDB Operator 1.4.0-beta.3 发布，新增 TiProxy 实验性支持和基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复 GA。修复了拼写错误和清理卷快照备份失败的问题，以及大规模 TiKV 节点下备份 TiDB 集群失败的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.0-beta.3/','/zh/tidb-in-kubernetes/v1.3/release-1.4.0-beta.3/','/zh/tidb-in-kubernetes/v1.4/release-1.4.0-beta.3/','/zh/tidb-in-kubernetes/v1.5/release-1.4.0-beta.3/','/zh/tidb-in-kubernetes/v1.6/release-1.4.0-beta.3/','/zh/tidb-in-kubernetes/v2.0/release-1.4.0-beta.3/']
 ---
 
 # TiDB Operator 1.4.0-beta.3 Release Notes

--- a/zh/releases/release-1.4.0.md
+++ b/zh/releases/release-1.4.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.0 Release Notes
 summary: TiDB Operator 1.4.0 版本发布，新增支持独立管理 TiDB Dashboard，配置 TiKV 和 PD 的 Readiness Probe，以及基于 Amazon EBS 的 TiDB 集群 volume-snapshot 备份和恢复。优化支持 IPv6 网络环境，修复了基于 EBS 快照备份无法恢复到不同 namespace 的问题和日志备份停止占用 Complete 状态的 bug。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.0/','/zh/tidb-in-kubernetes/v1.3/release-1.4.0/','/zh/tidb-in-kubernetes/v1.4/release-1.4.0/','/zh/tidb-in-kubernetes/v1.5/release-1.4.0/','/zh/tidb-in-kubernetes/v1.6/release-1.4.0/','/zh/tidb-in-kubernetes/v2.0/release-1.4.0/']
 ---
 
 # TiDB Operator 1.4.0 Release Notes

--- a/zh/releases/release-1.4.1.md
+++ b/zh/releases/release-1.4.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.1 Release Notes
 summary: TiDB Operator 1.4.1 版本发布，新增故障自动转移功能，优化了 TiDB Controller Manager 中 Kubernetes 客户端的配置，修复了未配置 PV 权限时 TiDB Controller Manager panic 的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.1/','/zh/tidb-in-kubernetes/v1.3/release-1.4.1/','/zh/tidb-in-kubernetes/v1.4/release-1.4.1/','/zh/tidb-in-kubernetes/v1.5/release-1.4.1/','/zh/tidb-in-kubernetes/v1.6/release-1.4.1/','/zh/tidb-in-kubernetes/v2.0/release-1.4.1/']
 ---
 
 # TiDB Operator 1.4.1 Release Notes

--- a/zh/releases/release-1.4.2.md
+++ b/zh/releases/release-1.4.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.2 Release Notes
 summary: TiDB Operator 1.4.2 发布，修复了开启 `preferIPv6` 时 TiFlash 没有监听 IPv6 地址的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.2/','/zh/tidb-in-kubernetes/v1.3/release-1.4.2/','/zh/tidb-in-kubernetes/v1.4/release-1.4.2/','/zh/tidb-in-kubernetes/v1.5/release-1.4.2/','/zh/tidb-in-kubernetes/v1.6/release-1.4.2/','/zh/tidb-in-kubernetes/v2.0/release-1.4.2/']
 ---
 
 # TiDB Operator 1.4.2 Release Notes

--- a/zh/releases/release-1.4.3.md
+++ b/zh/releases/release-1.4.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.3 Release Notes
 summary: TiDB Operator 1.4.3 发布，修复了开启 `preferIPv6` 时 TiFlash 的 metric server 未监听正确 IPv6 地址的问题，以及在 AWS 环境中打开了 feature gate `VolumeModifying` 且 `StorageClass` 缺少 EBS 相关参数时 TiDB Operator 会一直尝试修改 EBS 参数的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.3/','/zh/tidb-in-kubernetes/v1.3/release-1.4.3/','/zh/tidb-in-kubernetes/v1.4/release-1.4.3/','/zh/tidb-in-kubernetes/v1.5/release-1.4.3/','/zh/tidb-in-kubernetes/v1.6/release-1.4.3/','/zh/tidb-in-kubernetes/v2.0/release-1.4.3/']
 ---
 
 # TiDB Operator 1.4.3 Release Notes

--- a/zh/releases/release-1.4.4.md
+++ b/zh/releases/release-1.4.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.4 Release Notes
 summary: TiDB Operator 1.4.4 发布，新增支持在已部署 TiFlash 的集群上使用卷快照备份和恢复，准确显示备份大小，支持重试快照备份，集成管理日志备份和快照备份。修复了使用非语义版本格式的 TiDB 镜像同步失败的问题，使用卷快照备份一个已缩容的集群后无法恢复数据的问题，卷快照备份可能崩溃的问题，卷快照恢复可能在最后阶段失败的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.4/','/zh/tidb-in-kubernetes/v1.3/release-1.4.4/','/zh/tidb-in-kubernetes/v1.4/release-1.4.4/','/zh/tidb-in-kubernetes/v1.5/release-1.4.4/','/zh/tidb-in-kubernetes/v1.6/release-1.4.4/','/zh/tidb-in-kubernetes/v2.0/release-1.4.4/']
 ---
 
 # TiDB Operator 1.4.4 Release Notes

--- a/zh/releases/release-1.4.5.md
+++ b/zh/releases/release-1.4.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.5 Release Notes
 summary: TiDB Operator 1.4.5 版本发布，优化了 TidbCluster 的错误处理相关 metrics 和 worker 队列相关 metrics，增加了 DM master 组件的 `startUpScriptVersion` 字段，以及跨 Kubernetes 集群滚动重启或缩容 TiCDC 集群的能力。同时修复了定时备份中取消 GC、Backup CR 字段可选值、TiDB Operator 未配置权限时的 panic 问题，以及 TidbCluster 中设置 `AdditionalVolumeMounts` 时可能的 panic 问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.5/','/zh/tidb-in-kubernetes/v1.3/release-1.4.5/','/zh/tidb-in-kubernetes/v1.4/release-1.4.5/','/zh/tidb-in-kubernetes/v1.5/release-1.4.5/','/zh/tidb-in-kubernetes/v1.6/release-1.4.5/','/zh/tidb-in-kubernetes/v2.0/release-1.4.5/']
 ---
 
 # TiDB Operator 1.4.5 Release Notes

--- a/zh/releases/release-1.4.6.md
+++ b/zh/releases/release-1.4.6.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4.6 Release Notes
 summary: TiDB Operator 1.4.6 发布，优化默认启用 volume resize 支持，修复备份恢复时报错问题，修复 TiCDC image tag 不符合语义化版本时无法 Graceful Drain TiCDC 的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.6/','/zh/tidb-in-kubernetes/v1.3/release-1.4.6/','/zh/tidb-in-kubernetes/v1.4/release-1.4.6/','/zh/tidb-in-kubernetes/v1.5/release-1.4.6/','/zh/tidb-in-kubernetes/v1.6/release-1.4.6/','/zh/tidb-in-kubernetes/v2.0/release-1.4.6/']
 ---
 
 # TiDB Operator 1.4.6 Release Notes

--- a/zh/releases/release-1.4.7.md
+++ b/zh/releases/release-1.4.7.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.4. Release Notes
 summary: TiDB Operator 1.4.7 发布，修复了 BackupSchedule CR 字段中的 `logBackupTemplate` 字段变成可选值的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.4.7/','/zh/tidb-in-kubernetes/v1.3/release-1.4.7/','/zh/tidb-in-kubernetes/v1.4/release-1.4.7/','/zh/tidb-in-kubernetes/v1.5/release-1.4.7/','/zh/tidb-in-kubernetes/v1.6/release-1.4.7/','/zh/tidb-in-kubernetes/v2.0/release-1.4.7/']
 ---
 
 # TiDB Operator 1.4.7 Release Notes

--- a/zh/releases/release-1.5.0-beta.1.md
+++ b/zh/releases/release-1.5.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.0-beta.1 Release Notes
 summary: TiDB Operator 1.5.0-beta.1 发布，新增支持优雅重启 PD 和 TiDB Pod，使用 Advanced StatefulSet 管理 TiCDC 和 TiProxy，新增 TiDB Spec 字段，允许用户定义策略重启失败备份任务，升级 Kubernetes 依赖库至 v1.20 版本，添加与 reconciler 和 worker queue 相关的 Metric，优化滚动升级 TiKV 节点性能，允许用户自定义 Prometheus Scraping 相关配置，TiProxy 支持共享部分 TiDB 证书，配置 `spec.preferIPv6` 为 `true` 时，Service 的 `ipFamilyPolicy` 将配置为 `PreferDualStack`，添加统计协调流程失败计数的 Metric，修复了因为 metric 接口冲突而导致 pprof 接口无法访问的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.5.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.5.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.5.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.5.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.5.0-beta.1/']
 ---
 
 # TiDB Operator 1.5.0-beta.1 Release Notes

--- a/zh/releases/release-1.5.0.md
+++ b/zh/releases/release-1.5.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.0 Release Notes
 summary: 了解 TiDB Operator 1.5.0 版本的新功能、优化提升，以及 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.0/','/zh/tidb-in-kubernetes/v1.3/release-1.5.0/','/zh/tidb-in-kubernetes/v1.4/release-1.5.0/','/zh/tidb-in-kubernetes/v1.5/release-1.5.0/','/zh/tidb-in-kubernetes/v1.6/release-1.5.0/','/zh/tidb-in-kubernetes/v2.0/release-1.5.0/']
 ---
 
 # TiDB Operator 1.5.0 Release Notes

--- a/zh/releases/release-1.5.1.md
+++ b/zh/releases/release-1.5.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.1 Release Notes
 summary: TiDB Operator 1.5.1 发布，新增支持替换 PD、TiKV 和 TiDB 所使用的 volume。修复了多个 Bug，包括手动触发 TiKV eviction 时 PVC Modifier 报错的问题，替换 TiKV volume 过程中再触发 TiKV eviction 时可能造成 TiDB Operator reconcile 死锁的问题，TidbCluster 在 Upgrade 过程中可能无法回滚的问题，以及 MaxReservedTime 选项没有被 backup schedule gc 使用的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.1/','/zh/tidb-in-kubernetes/v1.3/release-1.5.1/','/zh/tidb-in-kubernetes/v1.4/release-1.5.1/','/zh/tidb-in-kubernetes/v1.5/release-1.5.1/','/zh/tidb-in-kubernetes/v1.6/release-1.5.1/','/zh/tidb-in-kubernetes/v2.0/release-1.5.1/']
 ---
 
 # TiDB Operator 1.5.1 Release Notes

--- a/zh/releases/release-1.5.2.md
+++ b/zh/releases/release-1.5.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.2 Release Notes
 summary: TiDB Operator 1.5.2 版本新增了对 AWS EBS 快照的备份能力的跨多个 K8S 集群的支持。优化了重启 PD、TiKV 时的启动流程，修复了替换 volume 时可能出现的问题。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.2/','/zh/tidb-in-kubernetes/v1.3/release-1.5.2/','/zh/tidb-in-kubernetes/v1.4/release-1.5.2/','/zh/tidb-in-kubernetes/v1.5/release-1.5.2/','/zh/tidb-in-kubernetes/v1.6/release-1.5.2/','/zh/tidb-in-kubernetes/v2.0/release-1.5.2/']
 ---
 
 # TiDB Operator 1.5.2 Release Notes

--- a/zh/releases/release-1.5.3.md
+++ b/zh/releases/release-1.5.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.3 Release Notes
 summary: 了解 TiDB Operator 1.5.3 版本的新功能和 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.3/','/zh/tidb-in-kubernetes/v1.3/release-1.5.3/','/zh/tidb-in-kubernetes/v1.4/release-1.5.3/','/zh/tidb-in-kubernetes/v1.5/release-1.5.3/','/zh/tidb-in-kubernetes/v1.6/release-1.5.3/','/zh/tidb-in-kubernetes/v2.0/release-1.5.3/']
 ---
 
 # TiDB Operator 1.5.3 Release Notes

--- a/zh/releases/release-1.5.4.md
+++ b/zh/releases/release-1.5.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.4 Release Notes
 summary: 了解 TiDB Operator 1.5.4 版本的优化提升和 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.4/','/zh/tidb-in-kubernetes/v1.3/release-1.5.4/','/zh/tidb-in-kubernetes/v1.4/release-1.5.4/','/zh/tidb-in-kubernetes/v1.5/release-1.5.4/','/zh/tidb-in-kubernetes/v1.6/release-1.5.4/','/zh/tidb-in-kubernetes/v2.0/release-1.5.4/']
 ---
 
 # TiDB Operator 1.5.4 Release Notes

--- a/zh/releases/release-1.5.5.md
+++ b/zh/releases/release-1.5.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.5.5 Release Notes
 summary: 了解 TiDB Operator 1.5.5 版本的新功能和优化提升。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.5.5/','/zh/tidb-in-kubernetes/v1.3/release-1.5.5/','/zh/tidb-in-kubernetes/v1.4/release-1.5.5/','/zh/tidb-in-kubernetes/v1.5/release-1.5.5/','/zh/tidb-in-kubernetes/v1.6/release-1.5.5/','/zh/tidb-in-kubernetes/v2.0/release-1.5.5/']
 ---
 
 # TiDB Operator 1.5.5 Release Notes

--- a/zh/releases/release-1.6.0-beta.1.md
+++ b/zh/releases/release-1.6.0-beta.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.0-beta.1 Release Notes
 summary: 了解 TiDB Operator 1.6.0-beta.1 版本的新功能、优化提升，以及 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.0-beta.1/','/zh/tidb-in-kubernetes/v1.3/release-1.6.0-beta.1/','/zh/tidb-in-kubernetes/v1.4/release-1.6.0-beta.1/','/zh/tidb-in-kubernetes/v1.5/release-1.6.0-beta.1/','/zh/tidb-in-kubernetes/v1.6/release-1.6.0-beta.1/','/zh/tidb-in-kubernetes/v2.0/release-1.6.0-beta.1/']
 ---
 
 # TiDB Operator 1.6.0-beta.1 Release Notes

--- a/zh/releases/release-1.6.0.md
+++ b/zh/releases/release-1.6.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.0 Release Notes
 summary: 了解 TiDB Operator 1.6.0 版本的新功能、优化提升，以及 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.0/','/zh/tidb-in-kubernetes/v1.3/release-1.6.0/','/zh/tidb-in-kubernetes/v1.4/release-1.6.0/','/zh/tidb-in-kubernetes/v1.5/release-1.6.0/','/zh/tidb-in-kubernetes/v1.6/release-1.6.0/','/zh/tidb-in-kubernetes/v2.0/release-1.6.0/']
 ---
 
 # TiDB Operator 1.6.0 Release Notes

--- a/zh/releases/release-1.6.1.md
+++ b/zh/releases/release-1.6.1.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.1 Release Notes
 summary: 了解 TiDB Operator 1.6.1 版本的新功能、优化提升，以及 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.1/','/zh/tidb-in-kubernetes/v1.3/release-1.6.1/','/zh/tidb-in-kubernetes/v1.4/release-1.6.1/','/zh/tidb-in-kubernetes/v1.5/release-1.6.1/','/zh/tidb-in-kubernetes/v1.6/release-1.6.1/','/zh/tidb-in-kubernetes/v2.0/release-1.6.1/']
 ---
 
 # TiDB Operator 1.6.1 Release Notes

--- a/zh/releases/release-1.6.2.md
+++ b/zh/releases/release-1.6.2.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.2 Release Notes
 summary: 了解 TiDB Operator 1.6.2 版本的新功能、优化提升，以及 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.2/','/zh/tidb-in-kubernetes/v1.3/release-1.6.2/','/zh/tidb-in-kubernetes/v1.4/release-1.6.2/','/zh/tidb-in-kubernetes/v1.5/release-1.6.2/','/zh/tidb-in-kubernetes/v1.6/release-1.6.2/','/zh/tidb-in-kubernetes/v2.0/release-1.6.2/']
 ---
 
 # TiDB Operator 1.6.2 Release Notes

--- a/zh/releases/release-1.6.3.md
+++ b/zh/releases/release-1.6.3.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.3 Release Notes
 summary: 了解 TiDB Operator 1.6.3 版本的 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.3/','/zh/tidb-in-kubernetes/v1.3/release-1.6.3/','/zh/tidb-in-kubernetes/v1.4/release-1.6.3/','/zh/tidb-in-kubernetes/v1.5/release-1.6.3/','/zh/tidb-in-kubernetes/v1.6/release-1.6.3/','/zh/tidb-in-kubernetes/v2.0/release-1.6.3/']
 ---
 
 # TiDB Operator 1.6.3 Release Notes

--- a/zh/releases/release-1.6.4.md
+++ b/zh/releases/release-1.6.4.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.4 Release Notes
 summary: 了解 TiDB Operator 1.6.4 版本的新功能。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.4/','/zh/tidb-in-kubernetes/v1.3/release-1.6.4/','/zh/tidb-in-kubernetes/v1.4/release-1.6.4/','/zh/tidb-in-kubernetes/v1.5/release-1.6.4/','/zh/tidb-in-kubernetes/v1.6/release-1.6.4/','/zh/tidb-in-kubernetes/v2.0/release-1.6.4/']
 ---
 
 # TiDB Operator 1.6.4 Release Notes

--- a/zh/releases/release-1.6.5.md
+++ b/zh/releases/release-1.6.5.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 1.6.5 Release Notes
 summary: 了解 TiDB Operator 1.6.5 版本的新功能、优化提升，以及 Bug 修复。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-1.6.5/','/zh/tidb-in-kubernetes/v1.3/release-1.6.5/','/zh/tidb-in-kubernetes/v1.4/release-1.6.5/','/zh/tidb-in-kubernetes/v1.5/release-1.6.5/','/zh/tidb-in-kubernetes/v1.6/release-1.6.5/','/zh/tidb-in-kubernetes/v2.0/release-1.6.5/']
 ---
 
 # TiDB Operator 1.6.5 Release Notes

--- a/zh/releases/release-2.0.0-beta.0.md
+++ b/zh/releases/release-2.0.0-beta.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 2.0.0-beta.0 Release Notes
 summary: TiDB Operator 2.0.0-beta.0 版本发布。v2 版本对 v1 版本进行了大幅重构，主要改动包括将 `TidbCluster` 拆分为多个 CRD、移除对 StatefulSet 的依赖，并引入 Overlay 功能以实现更灵活的自定义配置。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-2.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.3/release-2.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.4/release-2.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.5/release-2.0.0-beta.0/','/zh/tidb-in-kubernetes/v1.6/release-2.0.0-beta.0/','/zh/tidb-in-kubernetes/v2.0/release-2.0.0-beta.0/']
 ---
 
 # TiDB Operator 2.0.0-beta.0 Release Notes

--- a/zh/releases/release-2.0.0.md
+++ b/zh/releases/release-2.0.0.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Operator 2.0.0 Release Notes
 summary: TiDB Operator 2.0.0 版本发布。v2 版本对 v1 版本进行了大幅重构，主要改动包括将 `TidbCluster` 拆分为多个 CRD、移除对 StatefulSet 的依赖，并引入 Overlay 功能以实现更灵活的自定义配置。
+aliases: ['/zh/tidb-in-kubernetes/dev/release-2.0.0/','/zh/tidb-in-kubernetes/v1.3/release-2.0.0/','/zh/tidb-in-kubernetes/v1.4/release-2.0.0/','/zh/tidb-in-kubernetes/v1.5/release-2.0.0/','/zh/tidb-in-kubernetes/v1.6/release-2.0.0/','/zh/tidb-in-kubernetes/v2.0/release-2.0.0/']
 ---
 
 # TiDB Operator 2.0.0 Release Notes


### PR DESCRIPTION
### What is changed, added, or deleted? (Required)

Add legacy URL aliases to all English and Chinese TiDB Operator release notes. The aliases cover the dev, v1.3, v1.4, v1.5, v1.6, and v2.0 documentation paths so existing release-note links continue to resolve.

### Which TiDB Operator version(s) do your changes apply to? (Required)

- [x] main (the latest development version for v2.x)
- [ ] v2.0 (TiDB Operator 2.0 versions)
- [ ] release-1.x (the latest development version for v1.x)
- [ ] v1.6 (TiDB Operator 1.6 versions)
- [ ] v1.5 (TiDB Operator 1.5 versions)
- [ ] v1.4 (TiDB Operator 1.4 versions)
- [ ] v1.3 (TiDB Operator 1.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): N/A